### PR TITLE
Links to obsidian october

### DIFF
--- a/00 - Meta/Tag glossary.md
+++ b/00 - Meta/Tag glossary.md
@@ -21,4 +21,4 @@ We also have a #placeholder tag we use to signal the type of information that is
 - #placeholder/screenshot 
 - #placeholder/tool - Similar to the author tag, any information about a tool
 
-Other than that, we use the #MOC tag for [[Maps of Content (MOC)]].
+Other than that, we use the `#MOC` tag for [[Maps of Content (MOC)]].

--- a/00 - Start here.md
+++ b/00 - Start here.md
@@ -11,6 +11,7 @@ tags:
 
 We think of this vault as a [[Digital garden]]. This means that the content in our vault is very much a work in progress. Since we're at a very early stage, there's a lot of space to grow! You can check out a few sample notes were we already have some content:
 
+- [[Obsidian October 2021]]
 - [[02.02 - Categories|Plugin categories]].
 - [[How to Style Obsidian]]
 - [[YT - How to use QuickAdd|How to use QuickAdd]]

--- a/11 - Events/Obsidian October 2021.md
+++ b/11 - Events/Obsidian October 2021.md
@@ -48,12 +48,12 @@ We're honored to have invited some veteran developers in the community to be on 
 
 - [[Liam Cain]], author of the 3 plugins including the popular [[calendar|Calendar]] plugin
 - [[Matthew Meyers]], author of 8 plugins including the [[obsidian-kanban|Kanban]] plugin and the [[California Coast]] theme
-- [[Argentina Ortega Sáinz|Argentina Ortega Sáinz (argentum)]], author of the [[nldates-obsidian|Natural Language Dates]] and [[hotkeysplus-obsidian|Hotkeys++]]
+- [[Argentina Ortega Sáinz|Argentina Ortega Sáinz (argentum)]], author of the [[nldates-obsidian|Natural Language Dates]] and [[hotkeysplus-obsidian|Hotkeys++]] plugins
 
 ### Theme judges
 
-- [[Stephan Ango|Stephan Ango (kepano)]], author of [[Minimal|Minimal]] theme and 4 plugins
-- [[Chetachi Ezikeuzor|Chetachi Ezikeuzor (Chetachi)]], author of [[Yin and Yang|Yin and Yang]] and [[cmenu-plugin|cMenu]]
+- [[Stephan Ango|Stephan Ango (kepano)]], author of the [[Minimal]] theme and 4 plugins
+- [[Chetachi Ezikeuzor|Chetachi Ezikeuzor (Chetachi)]], author of the [[Yin and Yang]] theme and [[cmenu-plugin|cMenu]] plugin
 - [[SlRvb]], author of the [[ITS Theme]]
 
 [^1]: Obsidian credit can be used towards any Obsidian license or service. It is non-transferable.

--- a/11 - Events/Obsidian October 2021.md
+++ b/11 - Events/Obsidian October 2021.md
@@ -46,14 +46,14 @@ We're honored to have invited some veteran developers in the community to be on 
 
 ### Plugin judges
 
-- [[Liam Cain]], author of the 3 plugins including **Calendar**
-- [[Matthew Meyers]], author of 8 plugins including **Kanban** and the **California Coast** theme
-- [[Argentina Ortega Sáinz|Argentina Ortega Sáinz (argentum)]], author of **Natural Language Dates** and **Hotkey++**
+- [[Liam Cain]], author of the 3 plugins including the popular [[calendar|Calendar]] plugin
+- [[Matthew Meyers]], author of 8 plugins including the [[obsidian-kanban|Kanban]] plugin and the [[California Coast]] theme
+- [[Argentina Ortega Sáinz|Argentina Ortega Sáinz (argentum)]], author of the [[nldates-obsidian|Natural Language Dates]] and [[hotkeysplus-obsidian|Hotkeys++]]
 
 ### Theme judges
 
-- [[Stephan Ango|Stephan Ango (kepano)]], author of **Minimal** and 4 plugins
-- [[Chetachi Ezikeuzor|Chetachi Ezikeuzor (Chetachi)]], author of **Yin and Yang** and **cMenu**
-- [[SlRvb]], author of **ITS**
+- [[Stephan Ango|Stephan Ango (kepano)]], author of [[Minimal|Minimal]] theme and 4 plugins
+- [[Chetachi Ezikeuzor|Chetachi Ezikeuzor (Chetachi)]], author of [[Yin and Yang|Yin and Yang]] and [[cmenu-plugin|cMenu]]
+- [[SlRvb]], author of the [[ITS Theme]]
 
 [^1]: Obsidian credit can be used towards any Obsidian license or service. It is non-transferable.


### PR DESCRIPTION
<!-- Add a small description here of the changes you added -->

- Added links to the obsidian october note from the 00 - Start here, and links to plugins/themes mentioned in the obsidian october note
- Removed the `#MOC` tag from the tag glossary for the graph filters.

## Checklist

- [x] I have renamed all attached images with descriptive file names (or I did not include any images)
- [x] Before creating a new note, I searched the vault (or I only edited existing notes)
