### PR TITLE
feat: core plugins by default

### DIFF
--- a/.obsidian/core-plugins.json
+++ b/.obsidian/core-plugins.json
@@ -1,0 +1,15 @@
+[
+  "file-explorer",
+  "global-search",
+  "switcher",
+  "graph",
+  "backlink",
+  "page-preview",
+  "templates",
+  "note-composer",
+  "command-palette",
+  "markdown-importer",
+  "word-count",
+  "open-with-default-app",
+  "file-recovery"
+]

--- a/.obsidian/templates.json
+++ b/.obsidian/templates.json
@@ -1,0 +1,3 @@
+{
+  "folder": "00 - Meta/00.01 - Meta OCV templates"
+}


### PR DESCRIPTION
<!-- Add a small description here of the changes you added -->

- Adds core plugins that are enabled by **default** + **Templates**. It should be set like so as default, as the contributor will probably use some of templates list.
- Set **00 - Meta/00.01 - Meta OCV templates** as a default template folder.

## Checklist

- [x] I have renamed all attached images with descriptive file names (or I did not include any images)
- [x] Before creating a new note, I searched the vault (or I only edited existing notes)
