### PR TITLE
Expand information on the "Tasks" plugin

### DIFF
--- a/02 - Community Expansions/02.05 All Community Expansions/Plugins/obsidian-tasks-plugin.md
+++ b/02 - Community Expansions/02.05 All Community Expansions/Plugins/obsidian-tasks-plugin.md
@@ -16,8 +16,7 @@ publish: true
 
 %% ----- Badges ----- %%
 
-%% Does the repository or author have any sponsoring links? Uncomment the next line and add them below. If they don't, please delete the placeholder tag. %%
-%% Sponsor this work: #placeholder/author %%
+%% The repository or author does not have any sponsoring links. %%
 
 %% ----- Do not edit this section ----- %%
 
@@ -30,3 +29,33 @@ Mobile compatible: [[Mobile-compatible plugins|Yes]]
 Task management for Obsidian
 
 %% ----- Do not edit anything above this line ----- %% 
+
+For complete information, see the **[official documentation](https://schemar.github.io/obsidian-tasks/)**.
+
+---
+
+## Summary
+
+Track checklist items/tasks across your entire vault. Query them and mark them as done wherever you want. Supports due dates, recurring tasks (repetition), done dates, sub-set of checklist items, and filtering.
+
+Tasks tracks your checklist items from your vault. The simplest way to create a new task is to create a new checklist item. The markdown syntax for checklist items is a list item that starts with spaced brackets: `- [ ] take out the trash`. Now Tasks tracks that you need to take out the trash!
+
+A more convenient way to create a task is by using the `Tasks: Create or edit` command from the command palette. You can also bind a hotkey to the command. The command will parse what's on the current line in your editor and pre-populate a modal. In the modal, you can change the task's description, its due date, and a recurrence rule to have a repeating task.
+
+---
+
+## Screenshots
+
+*All screenshots assume the global filter `#task` which is not set by default (see also "Getting Started").*
+
+![ACME Tasks](https://github.com/schemar/obsidian-tasks/raw/main/resources/screenshots/acme.png)
+The `ACME` note has some tasks.
+
+![Important Project Tasks](https://github.com/schemar/obsidian-tasks/raw/main/resources/screenshots/important_project.png)
+The `Important Project` note also has some tasks.
+
+![Tasks Queries](https://github.com/schemar/obsidian-tasks/raw/main/resources/screenshots/tasks_queries.png)
+The `Tasks` note gathers all tasks from the vault and displays them using queries.
+
+![Create or Edit Modal](https://github.com/schemar/obsidian-tasks/raw/main/resources/screenshots/modal.png)
+The `Tasks: Create or edit` command helps you when editing a task.


### PR DESCRIPTION
I added a link to the docs, a summary, and screenshots to the Tasks
plugin's page to make it easier for people to see what it is about when
they browse the community hub's plugins.

I tried not to add too much information so that this page won't need
updating with future releases of Tasks.

## Checklist

- [x] I have renamed all attached images with descriptive file names (or I did not include any images)
- [x] Before creating a new note, I searched the vault (or I only edited existing notes)
