### PR TITLE
Add Relative Line Numbers to Vim-related Plugins category

### DIFF
--- a/02 - Community Expansions/02.01 Plugins by Category/Vim-related Plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Vim-related Plugins.md
@@ -16,6 +16,7 @@ Plugins related to [[Vim]] mode
 - [[obsidian-vimrc-support|Vimrc Support]]
 - [[mrj-add-codemirror-matchbrackets|Add Codemirror's matchbrackets.js]]
 - [[obsidian-vim-im-switch-plugin|Vim Input Method Switch]]
+- [[obsidian-relative-line-numbers|Relative Line Numbers]]
 
 ## Related categories
 


### PR DESCRIPTION
- Edited Vim-related Plugins to include Relative line numbers plugin as it is a feature inspired by Vim

## Checklist

- [x] I have renamed all attached images with descriptive file names (or I did not include any images)
- [x] Before creating a new note, I searched the vault (or I only edited existing notes)
