### PR TITLE
Feat/theme download count

### DIFF
--- a/.github/scripts/templates/theme.md.jinja
+++ b/.github/scripts/templates/theme.md.jinja
@@ -8,6 +8,7 @@ publish: true
 
 %% ----- Badges ----- %%
 
+![Downloads](https://img.shields.io/badge/downloads-{{download_count}}-573E7A?style=for-the-badge&logo=)
 ![GitHub last commit](https://img.shields.io/github/last-commit/{{repo}}?color=573E7A&label=last%20update&logo=github&style=for-the-badge)
 ![GitHub issues by-label](https://img.shields.io/github/issues/{{repo}}/help%20wanted?color=573E7A&logo=github&style=for-the-badge) 
 ![GitHub Repo stars](https://img.shields.io/github/stars/{{repo}}?color=573E7A&logo=github&style=for-the-badge)

--- a/.github/scripts/update-releases.py
+++ b/.github/scripts/update-releases.py
@@ -16,6 +16,7 @@ from utils import (
     write_file,
     get_json_from_github,
     get_plugin_manifest,
+    get_theme_download_count,
 )
 from utils import PLUGINS_JSON_FILE, THEMES_JSON_FILE, OUTPUT_DIR
 
@@ -74,6 +75,9 @@ def process_released_themes(overwrite=False, verbose=False):
     print_progress_bar(
         0, len(theme_list),
     )
+
+    theme_downloads: dict = requests.get('https://releases.obsidian.md/stats/theme').json()
+
     for theme in theme_list:
         repo = theme.get("repo")
         user = repo.split("/")[0]
@@ -86,12 +90,17 @@ def process_released_themes(overwrite=False, verbose=False):
         css_file = get_theme_css(THEME_CSS_FILE.format(repo, branch))
         settings = get_theme_settings(css_file)
         plugin_support = get_theme_plugin_support(css_file)
+
+        current_name = theme.get("name")
+        download_count = theme_downloads[current_name]["download"]
+
         theme.update(
             user=user,
             modes=modes,
             branch=branch,
             settings=settings,
             plugins=plugin_support,
+            download_count= download_count,
         )
         group = write_file(
             template, theme.get("name"), overwrite=overwrite, verbose=verbose, **theme

--- a/.github/scripts/update-releases.py
+++ b/.github/scripts/update-releases.py
@@ -4,6 +4,7 @@ import sys
 import argparse
 import glob
 from themes import get_theme_plugin_support, get_theme_settings
+import requests
 
 from utils import (
     THEME_CSS_FILE,
@@ -16,7 +17,6 @@ from utils import (
     write_file,
     get_json_from_github,
     get_plugin_manifest,
-    get_theme_download_count,
 )
 from utils import PLUGINS_JSON_FILE, THEMES_JSON_FILE, OUTPUT_DIR
 

--- a/.github/scripts/utils.py
+++ b/.github/scripts/utils.py
@@ -159,6 +159,3 @@ def print_progress_bar(
     # Print New Line on Complete
     if iteration == total:
         print()
-
-def get_theme_download_count(name: string):
-    pass

--- a/.github/scripts/utils.py
+++ b/.github/scripts/utils.py
@@ -159,3 +159,6 @@ def print_progress_bar(
     # Print New Line on Complete
     if iteration == total:
         print()
+
+def get_theme_download_count(name: string):
+    pass


### PR DESCRIPTION
<!-- Add a small description here of the changes you added -->

- I updated the script to include theme download count.
Currently, I have omitted the logo because the data is not fetched from Github. I still included the option because without it, the height would be smaller than the other banners.

## Checklist

- [x] I have renamed all attached images with descriptive file names (or I did not include any images)
- [x] Before creating a new note, I searched the vault (or I only edited existing notes)
