### PR TITLE
Feat/theme download count

### DIFF
--- a/.github/scripts/templates/theme.md.jinja
+++ b/.github/scripts/templates/theme.md.jinja
@@ -8,6 +8,7 @@ publish: true
 
 %% ----- Badges ----- %%
 
+![Downloads](https://img.shields.io/badge/downloads-{{download_count}}-573E7A?style=for-the-badge&logo=)
 ![GitHub last commit](https://img.shields.io/github/last-commit/{{repo}}?color=573E7A&label=last%20update&logo=github&style=for-the-badge)
 ![GitHub issues by-label](https://img.shields.io/github/issues/{{repo}}/help%20wanted?color=573E7A&logo=github&style=for-the-badge) 
 ![GitHub Repo stars](https://img.shields.io/github/stars/{{repo}}?color=573E7A&logo=github&style=for-the-badge)

--- a/.github/scripts/update-releases.py
+++ b/.github/scripts/update-releases.py
@@ -4,6 +4,7 @@ import sys
 import argparse
 import glob
 from themes import get_theme_plugin_support, get_theme_settings
+import requests
 
 from utils import (
     THEME_CSS_FILE,
@@ -74,6 +75,9 @@ def process_released_themes(overwrite=False, verbose=False):
     print_progress_bar(
         0, len(theme_list),
     )
+
+    theme_downloads: dict = requests.get('https://releases.obsidian.md/stats/theme').json()
+
     for theme in theme_list:
         repo = theme.get("repo")
         user = repo.split("/")[0]
@@ -86,12 +90,17 @@ def process_released_themes(overwrite=False, verbose=False):
         css_file = get_theme_css(THEME_CSS_FILE.format(repo, branch))
         settings = get_theme_settings(css_file)
         plugin_support = get_theme_plugin_support(css_file)
+
+        current_name = theme.get("name")
+        download_count = theme_downloads[current_name]["download"]
+
         theme.update(
             user=user,
             modes=modes,
             branch=branch,
             settings=settings,
             plugins=plugin_support,
+            download_count= download_count,
         )
         group = write_file(
             template, theme.get("name"), overwrite=overwrite, verbose=verbose, **theme


### PR DESCRIPTION
<!-- Add a small description here of the changes you added -->

- I added the theme download count in the first commit to the script. In the second commit, I ran it with the arguments `--themes` and `--overwrite` to show that it works.
I left out the GitHub logo because the download count doesn't come from GitHub. Nevertheless, I added the logo parameter and left it empty because the height would be too small otherwise.

## Checklist

- [x] I have renamed all attached images with descriptive file names (or I did not include any images)
- [x] Before creating a new note, I searched the vault (or I only edited existing notes)
