### PR TITLE
Split "Plugins to export and import markdown files" category

### DIFF
--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins to convert content into markdown.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins to convert content into markdown.md
@@ -1,32 +1,27 @@
 ---
 aliases:
-- 
-tags: 
-- seedling 
+-
+tags:
+- seedling
 publish: true
 ---
 
 
-# Plugins to export and import into Markdown
+# Plugins to convert content into Markdown
 
-Plugins to convert from/to [[Markdown]].
+Plugins to convert to [[Markdown]].
 
 ## Plugins in this category
 
 - [[convert-url-to-iframe|Convert url to preview (iframe)]]
 - [[wikilinks-to-mdlinks-obsidian|Wikilinks to MDLinks (Markdown Links)]]
-- [[obsidian-export-to-tex|Export To TeX]]
 - [[pdf-to-markdown-plugin|PDF to Markdown]]
 - [[obsidian-extract-pdf-highlights|PDF Highlights]]
 - [[obsidian-file-path-to-uri|File path to URI]]
-- [[obsidian-jsonifier|JSONifier]]
 - [[better-pdf-plugin|Better PDF Plugin]]
 - [[extract-url|Extract url content]]
-- [[obsidian-static-file-server|Static File Server]]
 - [[obsidian-csv-table|CSV Table]]
 - [[obsidian-pluck|Pluck]]
-- [[obsidian-pandoc|Obsidian Pandoc]]
-- [[mochi-cards-exporter|Mochi Cards Exporter]]
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins to export markdown content.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins to export markdown content.md
@@ -1,0 +1,26 @@
+---
+aliases:
+-
+tags:
+- seedling
+publish: true
+---
+
+
+# Plugins to export Markdown content
+
+Plugins to convert from [[Markdown]].
+
+## Plugins in this category
+
+- [[obsidian-export-to-tex|Export To TeX]]
+- [[obsidian-jsonifier|JSONifier]]
+- [[obsidian-static-file-server|Static File Server]]
+- [[obsidian-pandoc|Obsidian Pandoc]]
+- [[mochi-cards-exporter|Mochi Cards Exporter]]
+
+## Related categories
+
+%% Add links to other 02.02 - Category notes %%
+
+#placeholder/notes


### PR DESCRIPTION
- Add Plugins to convert content into markdown.md
- Rename Plugins to export and import markdown files.md to Plugins to export markdown content.md
- Move appropriate plugins from combined file to new file

#62

Changes as requested in Issue #62 and described above.

- Added/Edited note ...

## Checklist

- [x] I have renamed all attached images with descriptive file names (or I did not include any images)
- [x] Before creating a new note, I searched the vault (or I only edited existing notes)
