### PR TITLE
Make heading numbers match section names

### DIFF
--- a/04 - Guides, Workflows, & Courses/🗂️ 04 - Guides, Workflows, & Courses.md
+++ b/04 - Guides, Workflows, & Courses/🗂️ 04 - Guides, Workflows, & Courses.md
@@ -6,7 +6,7 @@ tags:
 publish: true
 ---
 
-# 🗂️ 05 - Guides, Workflows, & Courses
+# 🗂️ 04 - Guides, Workflows, & Courses
 
 Here you can find [[🗂️ Guides|various guides, written or in video form]] how to accomplish various tasks. There are guides every interest
 - [[for Beginners]]

--- a/05 - Concepts/🗂️ 05 - Concepts.md
+++ b/05 - Concepts/🗂️ 05 - Concepts.md
@@ -6,7 +6,7 @@ tags:
 publish: true
 ---
 
-# 🗂️ 06 - Concepts
+# 🗂️ 05 - Concepts
 
 Confused by all the technical lingo like [[YAML frontmatter|YAML]], [[Markdown|Markdown]], [[SCSS]], or [[LaTeX|LaTeX]]? Or feel overwhelmed by all the different "schools" and techniques of Personal Knowledge Management like [[Spaced repetition]], [[PARA]], or [[Digital garden]]?
 

--- a/06 - Inbox/🗂️ 06 - Inbox.md
+++ b/06 - Inbox/🗂️ 06 - Inbox.md
@@ -6,7 +6,7 @@ tags:
 publish: true
 ---
 
-# 🗂️ 07 - Inbox
+# 🗂️ 06 - Inbox
 
 In this folder are all new things which haven't been properly sorted into the Obsidian Hub yet.
 


### PR DESCRIPTION
<!-- Add a small description here of the changes you added -->

- Fixed 3  H1s that were off-by-one with their section name

## Checklist

- [x] I have renamed all attached images with descriptive file names (or I did not include any images)
- [x] Before creating a new note, I searched the vault (or I only edited existing notes)
