### PR TITLE
Fix some broken/dangling links

### DIFF
--- a/02 - Community Expansions/02.01 Plugins by Category/🗂️ 02.01 Plugins by Category.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/🗂️ 02.01 Plugins by Category.md
@@ -41,7 +41,8 @@ tags:
 
 - [[Plugins to manage files and attachments]]
 - [[Plugins for Video and Audio files]]
-- [[Plugins to export and import markdown files]]
+- [[Plugins to convert content into Markdown]]
+- [[Plugins to export Markdown content]]
 
 ### Note contents
 
@@ -67,7 +68,8 @@ tags:
 - [[Third-Party Integration Plugins]]
 - [[Automation plugins]]
 - [[Backup plugins]]
-- [[Plugins to export and import markdown files]]
+- [[Plugins to convert content into Markdown]]
+- [[Plugins to export Markdown content]]
 - [[Date and calendar plugins]]
 - [[Plugins for Security and Privacy]]
 - [[Task management plugins]]

--- a/04 - Guides, Workflows, & Courses/Guides/Effective Remote Work.md
+++ b/04 - Guides, Workflows, & Courses/Guides/Effective Remote Work.md
@@ -11,9 +11,9 @@ publish: true
 %% Match the title with the channel's title %% 
 
 %% Add the link (replacing #placeholder/link below) and then remove this comment%%
-Link: [YouTube](placeholder/link)
+Link: [YouTube](https://www.youtube.com/channel/UCkzyo69rqBoBJUyQ9jo53Bw)
 
-Hosted by #placeholder/author.
+Hosted by [[Justin DiRose]].
 
 %% Add a few sentences of what sort of videos they produce, feel free to link to other notes (e.g. after creating a note for a YouTube video you liked) %% 
 #placeholder/description 

--- a/06 - Inbox/Productivity Guru.md
+++ b/06 - Inbox/Productivity Guru.md
@@ -11,7 +11,7 @@ publish: true
 %% Match the title with the channel's title %% 
 
 %% Add the link (replacing #placeholder/link below) and then remove this comment%%
-Link: [YouTube](placeholder/link)
+Link: [YouTube](https://www.youtube.com/c/ProductivityGuru)
 
 Hosted by #placeholder/author.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ Each note represents exactly one tool, which (in the future) should also serve a
 #### [[🗂️ 03 - Showcases & Templates]]
 All Showcases, Examples, and Templates belong into this folder. This includes special-purpose or pre-prepared Vaults ("Starter Kits"). Note examples are pretty much the equivalent of the `#snip-a-note` channel on Discord.
 
-In this folder, you can add new notes with the [[T - Showcases|Template for Showcases]], the [[T - Vault showcase|Template for Vaults]], and the [[T - Templates|Template for Templates]] (Yeah, this is getting meta.)
+In this folder, you can add new notes with the [[T - Note showcase|Template for Showcases]], the [[T - Vault showcase|Template for Vaults]], and the [[T - Templates|Template for Templates]] (Yeah, this is getting meta.)
 
 #### [[🗂️ 04 - Guides, Workflows, & Courses]]
 This is where all guides, instructions, explainers, and workflows should be placed. Courses, basically being more comprehensive paid guides, are also located here. To make it easier for everyone to find guides relevant to them, the guides should be linked to from the "for Group X" notes (which are basically MoCs) .


### PR DESCRIPTION
<!-- Add a small description here of the changes you added -->

- Fix two dangling links in plugin categories
- Fix broken link "Template for Showcases". By a process of elimination, it looks like this should link to "T - Note showcase.md"
- Add YouTube link for Productivity Guru.md
- Add YouTube link and host name for Effective Remote Work.md (not Productivity Guru.md, as the commit message said)

## Checklist

- [x] I have renamed all attached images with descriptive file names (or I did not include any images)
- [x] Before creating a new note, I searched the vault (or I only edited existing notes)
