### PR TITLE
Fix/ignore do not commit dir

### DIFF
--- a/.github/scripts/make_mocs.py
+++ b/.github/scripts/make_mocs.py
@@ -175,7 +175,7 @@ class MocFileAndDirectoryFilter:
     """Various filtering functions, to determine what is included in the generated MOC"""
 
     def __init__(self):
-        self.DIRECTORIES_TO_EXCLUDE = ['venv']  # Directories beginning '.' are also excluded
+        self.DIRECTORIES_TO_EXCLUDE = ['venv', 'DO NOT COMMIT']  # Directories beginning '.' are also excluded
 
     def include_directory_in_moc(self, directory):
         if directory[0] == '.':

--- a/.github/scripts/tests/approved_files/test_make_mocs.test_moc_for_root_directory.approved.md
+++ b/.github/scripts/tests/approved_files/test_make_mocs.test_moc_for_root_directory.approved.md
@@ -2,6 +2,7 @@
 -  [[01 - This directory should be listed before directory 02.../🗂️ 01 - This directory should be listed before directory 02...|🗂️ 01 - This directory should be listed before directory 02...]]
 -  [[02 - This directory should be listed after directory 01 .../🗂️ 02 - This directory should be listed after directory 01 ...|🗂️ 02 - This directory should be listed after directory 01 ...]]
 -  [[03 - There should not be a directory called "venv" in the output/🗂️ 03 - There should not be a directory called "venv" in the output|🗂️ 03 - There should not be a directory called "venv" in the output]]
+-  [[04 - There should not be a directory called "DO NOT COMMIT" in the output/🗂️ 04 - There should not be a directory called "DO NOT COMMIT" in the output|🗂️ 04 - There should not be a directory called "DO NOT COMMIT" in the output]]
 -  [[00 - there should not be a link to a file called 🗂️ hub|00 - there should not be a link to a file called 🗂️ hub]]
 -  [[01 - all files should be listed after all folders|01 - all files should be listed after all folders]]
 -  [[02 - This file should be listed before file 03...|02 - This file should be listed before file 03...]]

--- a/.github/scripts/tests/test_make_mocs.py
+++ b/.github/scripts/tests/test_make_mocs.py
@@ -148,6 +148,8 @@ def test_moc_for_root_directory():
         # Python virtual environment directory should also not be included
         '03 - There should not be a directory called "venv" in the output',
         'venv',
+        '04 - There should not be a directory called "DO NOT COMMIT" in the output',
+        'DO NOT COMMIT',
     ]
     files = [
         # Files that should not be included

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ $RECYCLE.BIN/
 # Local History for Visual Studio Code
 .history/
 
+# See https://github.com/obsidian-community/obsidian-hub/wiki/Tip:-Keeping-Hub-TODO-lists
+/DO NOT COMMIT/


### PR DESCRIPTION
<!-- Add a small description here of the changes you added -->

- Make git ignore any "DO NOT COMMIT" directory at root of hub vault
- Make update-mocs.py any "DO NOT COMMIT" directory at root of hub vault - adds a test for this too.

For intent and details, see https://github.com/obsidian-community/obsidian-hub/wiki/Tip:-Keeping-Hub-TODO-lists

## Checklist

- [x] I have renamed all attached images with descriptive file names (or I did not include any images)
- [x] Before creating a new note, I searched the vault (or I only edited existing notes)
