### PR TITLE
Update all the People files to use new template

### DIFF
--- a/.github/scripts/utils.py
+++ b/.github/scripts/utils.py
@@ -7,8 +7,8 @@ from urllib.request import urlopen
 from jinja2 import FileSystemLoader, Environment, DebugUndefined
 
 PLUGIN_MANIFEST = "https://raw.githubusercontent.com/{}/{}/manifest.json"
-PLUGINS_JSON_FILE = "https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/community-plugins.json"
-THEMES_JSON_FILE = "https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/community-css-themes.json"
+PLUGINS_JSON_FILE = "https://raw.githubusercontent.com/obsidianmd/obsidian-releases/c85911035e71e9ecaaf1dc94d012db150ac6f43d/community-plugins.json"
+THEMES_JSON_FILE = "https://raw.githubusercontent.com/obsidianmd/obsidian-releases/c85911035e71e9ecaaf1dc94d012db150ac6f43d/community-css-themes.json"
 THEME_CSS_FILE = "https://raw.githubusercontent.com/{}/{}/obsidian.css"
 
 OUTPUT_DIR = {

--- a/.github/scripts/utils.py
+++ b/.github/scripts/utils.py
@@ -7,8 +7,8 @@ from urllib.request import urlopen
 from jinja2 import FileSystemLoader, Environment, DebugUndefined
 
 PLUGIN_MANIFEST = "https://raw.githubusercontent.com/{}/{}/manifest.json"
-PLUGINS_JSON_FILE = "https://raw.githubusercontent.com/obsidianmd/obsidian-releases/c85911035e71e9ecaaf1dc94d012db150ac6f43d/community-plugins.json"
-THEMES_JSON_FILE = "https://raw.githubusercontent.com/obsidianmd/obsidian-releases/c85911035e71e9ecaaf1dc94d012db150ac6f43d/community-css-themes.json"
+PLUGINS_JSON_FILE = "https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/community-plugins.json"
+THEMES_JSON_FILE = "https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/community-css-themes.json"
 THEME_CSS_FILE = "https://raw.githubusercontent.com/{}/{}/obsidian.css"
 
 OUTPUT_DIR = {

--- a/01 - Community/People/AndreasStandar.md
+++ b/01 - Community/People/AndreasStandar.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - <Serice
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # <Serice
 
 - GitHub: [AndreasStandar](https://github.com/AndreasStandar/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/Arch-Storm.md
+++ b/01 - Community/People/Arch-Storm.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Nikolas Sturm
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Nikolas Sturm
 
 - GitHub: [Arch-Storm](https://github.com/Arch-Storm/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/Arch-Storm> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/ArianaKhit.md
+++ b/01 - Community/People/ArianaKhit.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Ariana Khitrova
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Ariana Khitrova
 
 - GitHub: [ArianaKhit](https://github.com/ArianaKhit/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/ArtexJay.md
+++ b/01 - Community/People/ArtexJay.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ArtexJay
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # ArtexJay
 
 - GitHub: [ArtexJay](https://github.com/ArtexJay/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/Benature.md
+++ b/01 - Community/People/Benature.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Benature
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Benature
 
 - GitHub: [Benature](https://github.com/Benature/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/Benature> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/Braweria.md
+++ b/01 - Community/People/Braweria.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Wiktoria Mielcarek
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Wiktoria Mielcarek
 
 - GitHub: [Braweria](https://github.com/Braweria/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/Bryan Jenks.md
+++ b/01 - Community/People/Bryan Jenks.md
@@ -1,5 +1,5 @@
 ---
-aliases: 
+aliases:
 - 
 tags:
 - seedling
@@ -8,6 +8,60 @@ publish: true
 
 # Bryan Jenks
 
-%% Add a description below this line. It doesn't need to be long: one or two sentences should be a good start. %%
+<!-- - GitHub: [Bryan Jenks](https://github.com/Bryan Jenks/) ^github-->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
-#placeholder/description 
+%% Feel free to add a bio below this comment %%
+
+
+## Author of
+
+%% Begin Hub: Released contributions %%
+
+<!--
+### Plugins
+
+- 
+-->
+
+<!--
+### Themes
+
+- 
+-->
+
+%% End Hub: Released contributions %%
+
+%% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
+
+<!--
+### Unlisted plugins
+
+- 
+-->
+
+<!--
+### Others
+
+- 
+-->
+
+<!--
+## Sponsor this author
+
+- [[GitHub sponsors]]: [Sponsor @Bryan Jenks on GitHub Sponsors](https://github.com/sponsors/Bryan Jenks) ^github-sponsor
+- [[Buy me a coffee]]: ^buy-me-a-coffee
+- [[PayPal]]: ^paypal
+- [[Patreon]]: ^patreon
+
+-->
+
+<!--
+## Follow this author
+
+- [[YouTube Channels|On YouTube]]: ^youtube
+- Twitter: ^twitter
+- ...
+-->

--- a/01 - Community/People/Bryan Jenks.md
+++ b/01 - Community/People/Bryan Jenks.md
@@ -8,9 +8,9 @@ publish: true
 
 # Bryan Jenks
 
-<!-- - GitHub: [Bryan Jenks](https://github.com/Bryan Jenks/) ^github-->
-<!-- - Discord: `@` ^discord-->
-<!-- - Website: <> ^website-->
+- GitHub: [Bryan Jenks](https://github.com/tallguyjenks/) ^github
+- Discord: `@tallguyjenks` ^discord
+- Website: <https://www.bryanjenks.dev> ^website
 <!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
@@ -42,26 +42,22 @@ publish: true
 - 
 -->
 
-<!--
 ### Others
 
-- 
--->
+- YouTube list: [Personal Knowledge Management & Zettelkasten](https://www.youtube.com/playlist?list=PL5fd4SsfvECy0zzf8Cyo20ZoipEt6YeL3)
 
-<!--
 ## Sponsor this author
 
-- [[GitHub sponsors]]: [Sponsor @Bryan Jenks on GitHub Sponsors](https://github.com/sponsors/Bryan Jenks) ^github-sponsor
+- [[GitHub sponsors]]: [Sponsor @tallguyjenks on GitHub Sponsors](https://github.com/sponsors/tallguyjenks) ^github-sponsor
+
+<!--
 - [[Buy me a coffee]]: ^buy-me-a-coffee
 - [[PayPal]]: ^paypal
 - [[Patreon]]: ^patreon
 
 -->
 
-<!--
 ## Follow this author
 
-- [[YouTube Channels|On YouTube]]: ^youtube
-- Twitter: ^twitter
-- ...
--->
+- [[YouTube Channels|On YouTube]]: [Bryan Jenks's YouTube account](https://www.youtube.com/c/BryanJenksTech) ^youtube
+- Twitter: [@tallguyjenks](https://twitter.com/tallguyjenks) ^twitter

--- a/01 - Community/People/Chrismettal.md
+++ b/01 - Community/People/Chrismettal.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Chrismettal
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Chrismettal
 
 - GitHub: [Chrismettal](https://github.com/Chrismettal/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/Clemens-E.md
+++ b/01 - Community/People/Clemens-E.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Clemens Ertle
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Clemens Ertle
 
 - GitHub: [Clemens-E](https://github.com/Clemens-E/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/Clemens-E> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/Creling.md
+++ b/01 - Community/People/Creling.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Creling
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Creling
 
 - GitHub: [Creling](https://github.com/Creling/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/Daeik.md
+++ b/01 - Community/People/Daeik.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Daeik Kim
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Daeik Kim
 
 - GitHub: [Daeik](https://github.com/Daeik/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/DahaWong.md
+++ b/01 - Community/People/DahaWong.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Daha
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Daha
 
 - GitHub: [DahaWong](https://github.com/DahaWong/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/Darakah.md
+++ b/01 - Community/People/Darakah.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - darakah
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # darakah
 
 - GitHub: [Darakah](https://github.com/Darakah/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/Darakah/> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -35,15 +32,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/Dmitriy-Shulha.md
+++ b/01 - Community/People/Dmitriy-Shulha.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Dmitriy Shulha
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Dmitriy Shulha
 
 - GitHub: [Dmitriy-Shulha](https://github.com/Dmitriy-Shulha/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/Dmitriy-Shulha> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/DominikPieper.md
+++ b/01 - Community/People/DominikPieper.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Dominik Pieper
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Dominik Pieper
 
 - GitHub: [DominikPieper](https://github.com/DominikPieper/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/DominikPieper> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/DubininDmitry.md
+++ b/01 - Community/People/DubininDmitry.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Dubinin Dmitry
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Dubinin Dmitry
 
 - GitHub: [DubininDmitry](https://github.com/DubininDmitry/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/Dyldog.md
+++ b/01 - Community/People/Dyldog.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Dylan Elliott
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Dylan Elliott
 
 - GitHub: [Dyldog](https://github.com/Dyldog/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/dyldog> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/Emrie-Candera.md
+++ b/01 - Community/People/Emrie-Candera.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Emrie Candera
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Emrie Candera
 
 - GitHub: [Emrie-Candera](https://github.com/Emrie-Candera/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/FHachez.md
+++ b/01 - Community/People/FHachez.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Hachez Floran
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Hachez Floran
 
 - GitHub: [FHachez](https://github.com/FHachez/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/FHachez> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/FlorianWoelki.md
+++ b/01 - Community/People/FlorianWoelki.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Florian Woelki
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Florian Woelki
 
 - GitHub: [FlorianWoelki](https://github.com/FlorianWoelki/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://florianwoelki.com/> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/George-debug.md
+++ b/01 - Community/People/George-debug.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - George Butco
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # George Butco
 
 - GitHub: [George-debug](https://github.com/George-debug/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/GuangluWu.md
+++ b/01 - Community/People/GuangluWu.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - MooddooM
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # MooddooM
 
 - GitHub: [GuangluWu](https://github.com/GuangluWu/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/HEmile.md
+++ b/01 - Community/People/HEmile.md
@@ -14,7 +14,7 @@ publish: true
 
 - Website: <https://twitter.com/emilevankrieken> ^website
 
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 

--- a/01 - Community/People/HEmile.md
+++ b/01 - Community/People/HEmile.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Emile
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,11 +9,8 @@ publish: true
 # Emile
 
 - GitHub: [HEmile](https://github.com/HEmile/) ^github
-
 <!-- - Discord: `@` ^discord-->
-
 - Website: <https://twitter.com/emilevankrieken> ^website
-
 <!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
@@ -31,15 +28,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/HEmile.md
+++ b/01 - Community/People/HEmile.md
@@ -10,7 +10,7 @@ publish: true
 
 - GitHub: [HEmile](https://github.com/HEmile/) ^github
 
-%% - Discord: `@` ^discord %%
+<!-- - Discord: `@` ^discord-->
 
 - Website: <https://twitter.com/emilevankrieken> ^website
 

--- a/01 - Community/People/JoshKasap.md
+++ b/01 - Community/People/JoshKasap.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Josh Kasap
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Josh Kasap
 
 - GitHub: [JoshKasap](https://github.com/JoshKasap/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/KjellConnelly.md
+++ b/01 - Community/People/KjellConnelly.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Kjell Connelly
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Kjell Connelly
 
 - GitHub: [KjellConnelly](https://github.com/KjellConnelly/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/KjellConnelly/obsidian-jsonifier.git> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/MSzturc.md
+++ b/01 - Community/People/MSzturc.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - MSzturc
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # MSzturc
 
 - GitHub: [MSzturc](https://github.com/MSzturc/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/MSzturc> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/MamoruDS.md
+++ b/01 - Community/People/MamoruDS.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - MamoruDS
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # MamoruDS
 
 - GitHub: [MamoruDS](https://github.com/MamoruDS/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/MamoruDS> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/Mara-Li.md
+++ b/01 - Community/People/Mara-Li.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Mara
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Mara
 
 - GitHub: [Mara-Li](https://github.com/Mara-Li/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/MarkMindCkm.md
+++ b/01 - Community/People/MarkMindCkm.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Mark
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Mark
 
 - GitHub: [MarkMindCkm](https://github.com/MarkMindCkm/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/MarkMindCkm/obsidian-markmind> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/MatheusZarkov.md
+++ b/01 - Community/People/MatheusZarkov.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Zarkov
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Zarkov
 
 - GitHub: [MatheusZarkov](https://github.com/MatheusZarkov/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/MichalBures.md
+++ b/01 - Community/People/MichalBures.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Michal Bureš
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Michal Bureš
 
 - GitHub: [MichalBures](https://github.com/MichalBures/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/MichalBures> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/NatiAris.md
+++ b/01 - Community/People/NatiAris.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - NatiAris
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # NatiAris
 
 - GitHub: [NatiAris](https://github.com/NatiAris/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/NatiAris/> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/Natumsol.md
+++ b/01 - Community/People/Natumsol.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Natumsol
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Natumsol
 
 - GitHub: [Natumsol](https://github.com/Natumsol/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/natumsol> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/Nilahn.md
+++ b/01 - Community/People/Nilahn.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Nilahn
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Nilahn
 
 - GitHub: [Nilahn](https://github.com/Nilahn/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/No3371.md
+++ b/01 - Community/People/No3371.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - No3371
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # No3371
 
 - GitHub: [No3371](https://github.com/No3371/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <github.com/No3371> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/NomarCub.md
+++ b/01 - Community/People/NomarCub.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - NomarCub
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # NomarCub
 
 - GitHub: [NomarCub](https://github.com/NomarCub/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/NomarCub> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/OfficerHalf.md
+++ b/01 - Community/People/OfficerHalf.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - OfficerHalf
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -26,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 ## Sponsor this author
 

--- a/01 - Community/People/OfficerHalf.md
+++ b/01 - Community/People/OfficerHalf.md
@@ -11,7 +11,7 @@ publish: true
 - GitHub: [OfficerHalf](https://github.com/OfficerHalf/) ^github
 <!-- - Discord: `@` ^discord-->
 - Website: <https://nathan-smith.org/> ^website
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 

--- a/01 - Community/People/OfficerHalf.md
+++ b/01 - Community/People/OfficerHalf.md
@@ -9,7 +9,7 @@ publish: true
 # OfficerHalf
 
 - GitHub: [OfficerHalf](https://github.com/OfficerHalf/) ^github
-%% - Discord: `@` ^discord %%
+<!-- - Discord: `@` ^discord-->
 - Website: <https://nathan-smith.org/> ^website
 <!-- - [[Publish sites|Publish site]]: ^publish -->
 

--- a/01 - Community/People/OliverBalfour.md
+++ b/01 - Community/People/OliverBalfour.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Oliver Balfour
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Oliver Balfour
 
 - GitHub: [OliverBalfour](https://github.com/OliverBalfour/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/OliverBalfour/obsidian-pandoc> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/OwnJoke.md
+++ b/01 - Community/People/OwnJoke.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - OwnJoke
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # OwnJoke
 
 - GitHub: [OwnJoke](https://github.com/OwnJoke/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://obsidian.md/about> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/Pseudonium.md
+++ b/01 - Community/People/Pseudonium.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Pseudonium
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Pseudonium
 
 - GitHub: [Pseudonium](https://github.com/Pseudonium/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/Pseudonium/Obsidian_to_Anki> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/RainCat1998.md
+++ b/01 - Community/People/RainCat1998.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - RainCat1998
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # RainCat1998
 
 - GitHub: [RainCat1998](https://github.com/RainCat1998/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/RainCat1998> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/Reocin.md
+++ b/01 - Community/People/Reocin.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Reocin
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Reocin
 
 - GitHub: [Reocin](https://github.com/Reocin/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/Reocin/obsidian-markdown-formatting-assistant-plugin> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/Robin-Haupt-1.md
+++ b/01 - Community/People/Robin-Haupt-1.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Robin Haupt
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Robin Haupt
 
 - GitHub: [Robin-Haupt-1](https://github.com/Robin-Haupt-1/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/Robin-Haupt-1/Obsidian-Map-of-Content> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/RuslanGagushin.md
+++ b/01 - Community/People/RuslanGagushin.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Ruslan Gagushin
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Ruslan Gagushin
 
 - GitHub: [RuslanGagushin](https://github.com/RuslanGagushin/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/SMUsamaShah.md
+++ b/01 - Community/People/SMUsamaShah.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - SMUsamaShah
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # SMUsamaShah
 
 - GitHub: [SMUsamaShah](https://github.com/SMUsamaShah/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/Seraaron.md
+++ b/01 - Community/People/Seraaron.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Seraaron
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Seraaron
 
 - GitHub: [Seraaron](https://github.com/Seraaron/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/ShockThunder.md
+++ b/01 - Community/People/ShockThunder.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ShockThunder
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # ShockThunder
 
 - GitHub: [ShockThunder](https://github.com/ShockThunder/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/ShockThunder> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/Signynt.md
+++ b/01 - Community/People/Signynt.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Signynt
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Signynt
 
 - GitHub: [Signynt](https://github.com/Signynt/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/Signynt> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/SilentVoid13.md
+++ b/01 - Community/People/SilentVoid13.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - SilentVoid
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # SilentVoid
 
 - GitHub: [SilentVoid13](https://github.com/SilentVoid13/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/SilentVoid13> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/SkepticMystic.md
+++ b/01 - Community/People/SkepticMystic.md
@@ -11,7 +11,7 @@ publish: true
 - GitHub: [SkepticMystic](https://github.com/SkepticMystic/) ^github
 <!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/SkepticMystic/advanced-cursors> ^website
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 

--- a/01 - Community/People/SkepticMystic.md
+++ b/01 - Community/People/SkepticMystic.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - SkepticMystic
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -33,6 +33,12 @@ publish: true
 
 - [Metadataframe](https://github.com/SkepticMystic/metadataframe)
 - [Phrase Bank](https://github.com/SkepticMystic/Phrase-Bank)
+
+<!--
+### Others
+
+- 
+-->
 
 ## Sponsor this author
 

--- a/01 - Community/People/SkepticMystic.md
+++ b/01 - Community/People/SkepticMystic.md
@@ -9,7 +9,7 @@ publish: true
 # SkepticMystic
 
 - GitHub: [SkepticMystic](https://github.com/SkepticMystic/) ^github
-%% - Discord: `@` ^discord %%
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/SkepticMystic/advanced-cursors> ^website
 <!-- - [[Publish sites|Publish site]]: ^publish -->
 

--- a/01 - Community/People/SlRvb.md
+++ b/01 - Community/People/SlRvb.md
@@ -11,7 +11,7 @@ publish: true
 - GitHub: [SlRvb](https://github.com/SlRvb/) ^github
 <!-- - Discord: `@` ^discord-->
 %% - Website: <> ^website %% 
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 

--- a/01 - Community/People/SlRvb.md
+++ b/01 - Community/People/SlRvb.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - SlRvb
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -10,7 +10,7 @@ publish: true
 
 - GitHub: [SlRvb](https://github.com/SlRvb/) ^github
 <!-- - Discord: `@` ^discord-->
-%% - Website: <> ^website %% 
+<!-- - Website: <> ^website-->
 <!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
@@ -37,15 +37,17 @@ publish: true
 - [[Folder Styles (SlRvb)|Folder Styles]]
 - [[Alternate Admonitions (SlRvb)]]
 
-%%
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 ## Sponsor this author
 

--- a/01 - Community/People/SlRvb.md
+++ b/01 - Community/People/SlRvb.md
@@ -9,7 +9,7 @@ publish: true
 # SlRvb
 
 - GitHub: [SlRvb](https://github.com/SlRvb/) ^github
-%% - Discord: `@` ^discord %%
+<!-- - Discord: `@` ^discord-->
 %% - Website: <> ^website %% 
 <!-- - [[Publish sites|Publish site]]: ^publish -->
 

--- a/01 - Community/People/Slowbad.md
+++ b/01 - Community/People/Slowbad.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Slowbad
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Slowbad
 
 - GitHub: [Slowbad](https://github.com/Slowbad/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/SuperChamp234.md
+++ b/01 - Community/People/SuperChamp234.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Leoh and Ran
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Leoh and Ran
 
 - GitHub: [SuperChamp234](https://github.com/SuperChamp234/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/TClark1011.md
+++ b/01 - Community/People/TClark1011.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Thomas Clark
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Thomas Clark
 
 - GitHub: [TClark1011](https://github.com/TClark1011/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://thomasclark.io/> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/THeK3nger.md
+++ b/01 - Community/People/THeK3nger.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Davide Aversa
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Davide Aversa
 
 - GitHub: [THeK3nger](https://github.com/THeK3nger/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://www.davideaversa.it> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/Taitava.md
+++ b/01 - Community/People/Taitava.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Jarkko Linnanvirta
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Jarkko Linnanvirta
 
 - GitHub: [Taitava](https://github.com/Taitava/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/TfTHacker.md
+++ b/01 - Community/People/TfTHacker.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - TfTHacker
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # TfTHacker
 
 - GitHub: [TfTHacker](https://github.com/TfTHacker/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/TfTHacker/obsidian42-brat> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -31,15 +28,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/TilBlechschmidt.md
+++ b/01 - Community/People/TilBlechschmidt.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Til Blechschmidt
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Til Blechschmidt
 
 - GitHub: [TilBlechschmidt](https://github.com/TilBlechschmidt/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/TilBlechschmidt/obsidian-plugin-abcjs> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/Vinzent03.md
+++ b/01 - Community/People/Vinzent03.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Vinzent
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Vinzent
 
 - GitHub: [Vinzent03](https://github.com/Vinzent03/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -33,15 +30,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/Wittionary.md
+++ b/01 - Community/People/Wittionary.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Witt Allen
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Witt Allen
 
 - GitHub: [Wittionary](https://github.com/Wittionary/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/Yaozhuwa.md
+++ b/01 - Community/People/Yaozhuwa.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - yaozhuwa
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # yaozhuwa
 
 - GitHub: [Yaozhuwa](https://github.com/Yaozhuwa/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/Yaozhuwa> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/ZaherAlMajed.md
+++ b/01 - Community/People/ZaherAlMajed.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Zaher Al Majed
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Zaher Al Majed
 
 - GitHub: [ZaherAlMajed](https://github.com/ZaherAlMajed/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/agathauy.md
+++ b/01 - Community/People/agathauy.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Agatha Uy
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Agatha Uy
 
 - GitHub: [agathauy](https://github.com/agathauy/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/agathauy> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/aidenlx.md
+++ b/01 - Community/People/aidenlx.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - AidenLx
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # AidenLx
 
 - GitHub: [aidenlx](https://github.com/aidenlx/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/aidenlx> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -35,15 +32,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/aidurber.md
+++ b/01 - Community/People/aidurber.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - aidurber
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # aidurber
 
 - GitHub: [aidurber](https://github.com/aidurber/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/akaalias.md
+++ b/01 - Community/People/akaalias.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Alexis Rondeau
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Alexis Rondeau
 
 - GitHub: [akaalias](https://github.com/akaalias/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://publish.obsidian.md/alexisrondeau> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -33,15 +30,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/akosbalasko.md
+++ b/01 - Community/People/akosbalasko.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Akos Balasko, Micha Brugger
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Akos Balasko, Micha Brugger
 
 - GitHub: [akosbalasko](https://github.com/akosbalasko/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/akosbalasko, https://github.com/michabrugger> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/aleksey-rezvov.md
+++ b/01 - Community/People/aleksey-rezvov.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - catalysm, aleksey-rezvov
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # catalysm, aleksey-rezvov
 
 - GitHub: [aleksey-rezvov](https://github.com/aleksey-rezvov/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/aleksey-rezvov/obsidian-local-images> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/amdecker.md
+++ b/01 - Community/People/amdecker.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - amdecker
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # amdecker
 
 - GitHub: [amdecker](https://github.com/amdecker/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/amdecker/> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/anstosa.md
+++ b/01 - Community/People/anstosa.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Ansel Santosa
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Ansel Santosa
 
 - GitHub: [anstosa](https://github.com/anstosa/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://ansel.santosa.family> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/argenos.md
+++ b/01 - Community/People/argenos.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Argentina Ortega Sainz
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Argentina Ortega Sainz
 
 - GitHub: [argenos](https://github.com/argenos/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/arnau.md
+++ b/01 - Community/People/arnau.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Arnau Siches
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Arnau Siches
 
 - GitHub: [arnau](https://github.com/arnau/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://www.seachess.net/> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/arpitbbhayani.md
+++ b/01 - Community/People/arpitbbhayani.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Arpit Bhayani
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Arpit Bhayani
 
 - GitHub: [arpitbbhayani](https://github.com/arpitbbhayani/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://arpitbhayani.me> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/auroral-ui.md
+++ b/01 - Community/People/auroral-ui.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Benny Guo
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Benny Guo
 
 - GitHub: [auroral-ui](https://github.com/auroral-ui/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/avirut.md
+++ b/01 - Community/People/avirut.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - avirut
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # avirut
 
 - GitHub: [avirut](https://github.com/avirut/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/aviskase.md
+++ b/01 - Community/People/aviskase.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Yuliya Bagriy
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Yuliya Bagriy
 
 - GitHub: [aviskase](https://github.com/aviskase/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/aviskase> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/avr.md
+++ b/01 - Community/People/avr.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - avr
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # avr
 
 - GitHub: [avr](https://github.com/avr/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/bcdavasconcelos.md
+++ b/01 - Community/People/bcdavasconcelos.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - bernardo_v
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # bernardo_v
 
 - GitHub: [bcdavasconcelos](https://github.com/bcdavasconcelos/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -34,15 +31,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/beaussan.md
+++ b/01 - Community/People/beaussan.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - @beaussan
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # @beaussan
 
 - GitHub: [beaussan](https://github.com/beaussan/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/beaussan> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/beet.md
+++ b/01 - Community/People/beet.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Mark Beattie
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Mark Beattie
 
 - GitHub: [beet](https://github.com/beet/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/bencodezen.md
+++ b/01 - Community/People/bencodezen.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Ben Hong
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Ben Hong
 
 - GitHub: [bencodezen](https://github.com/bencodezen/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/bennyxguo.md
+++ b/01 - Community/People/bennyxguo.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Benny Guo
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Benny Guo
 
 - GitHub: [bennyxguo](https://github.com/bennyxguo/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/bicarlsen.md
+++ b/01 - Community/People/bicarlsen.md
@@ -14,7 +14,7 @@ publish: true
 
 - Website: <https://github.com/bicarlsen> ^website
 
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 

--- a/01 - Community/People/bicarlsen.md
+++ b/01 - Community/People/bicarlsen.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Brian Carlsen
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,11 +9,8 @@ publish: true
 # Brian Carlsen
 
 - GitHub: [bicarlsen](https://github.com/bicarlsen/) ^github
-
 <!-- - Discord: `@` ^discord-->
-
 - Website: <https://github.com/bicarlsen> ^website
-
 <!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/bicarlsen.md
+++ b/01 - Community/People/bicarlsen.md
@@ -10,7 +10,7 @@ publish: true
 
 - GitHub: [bicarlsen](https://github.com/bicarlsen/) ^github
 
-%% - Discord: `@` ^discord %%
+<!-- - Discord: `@` ^discord-->
 
 - Website: <https://github.com/bicarlsen> ^website
 

--- a/01 - Community/People/bjsi.md
+++ b/01 - Community/People/bjsi.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Experimental Learning
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Experimental Learning
 
 - GitHub: [bjsi](https://github.com/bjsi/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/bjsi/incremental-writing> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/bkyle.md
+++ b/01 - Community/People/bkyle.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Bryan Kyle
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Bryan Kyle
 
 - GitHub: [bkyle](https://github.com/bkyle/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/blacksmithgu.md
+++ b/01 - Community/People/blacksmithgu.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Michael Brenan <blacksmithgu@gmail.com>
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Michael Brenan <blacksmithgu@gmail.com>
 
 - GitHub: [blacksmithgu](https://github.com/blacksmithgu/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/blacksmithgu> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/bramses.md
+++ b/01 - Community/People/bramses.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - bramses
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # bramses
 
 - GitHub: [bramses](https://github.com/bramses/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://stenography.dev/> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/bwydoogh.md
+++ b/01 - Community/People/bwydoogh.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Benny Wydooghe
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Benny Wydooghe
 
 - GitHub: [bwydoogh](https://github.com/bwydoogh/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://i-net.be> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/c4ctus5.md
+++ b/01 - Community/People/c4ctus5.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - cactus5
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # cactus5
 
 - GitHub: [c4ctus5](https://github.com/c4ctus5/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/c4ctus5> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/cannibalox.md
+++ b/01 - Community/People/cannibalox.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - _ph
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # _ph
 
 - GitHub: [cannibalox](https://github.com/cannibalox/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/caronchen.md
+++ b/01 - Community/People/caronchen.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - caronchen
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # caronchen
 
 - GitHub: [caronchen](https://github.com/caronchen/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/caronchen/obsidian-chartsview-plugin> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/cassidoo.md
+++ b/01 - Community/People/cassidoo.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - cassidoo
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # cassidoo
 
 - GitHub: [cassidoo](https://github.com/cassidoo/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/ceciliamay.md
+++ b/01 - Community/People/ceciliamay.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Cecilia May
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Cecilia May
 
 - GitHub: [ceciliamay](https://github.com/ceciliamay/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/chad-bennett.md
+++ b/01 - Community/People/chad-bennett.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - chad-bennett
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # chad-bennett
 
 - GitHub: [chad-bennett](https://github.com/chad-bennett/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/charliecm.md
+++ b/01 - Community/People/charliecm.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Charlie Chao
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Charlie Chao
 
 - GitHub: [charliecm](https://github.com/charliecm/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/charliecm> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/chetachiezikeuzor.md
+++ b/01 - Community/People/chetachiezikeuzor.md
@@ -9,7 +9,7 @@ publish: true
 # Chetachi E.
 
 - GitHub: [chetachiezikeuzor](https://github.com/chetachiezikeuzor/) ^github
-%% - Discord: `@` ^discord %%
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/chetachiezikeuzor> ^website
 <!-- - [[Publish sites|Publish site]]: ^publish -->
 

--- a/01 - Community/People/chetachiezikeuzor.md
+++ b/01 - Community/People/chetachiezikeuzor.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Chetachi E.
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -28,15 +28,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/chetachiezikeuzor.md
+++ b/01 - Community/People/chetachiezikeuzor.md
@@ -11,7 +11,7 @@ publish: true
 - GitHub: [chetachiezikeuzor](https://github.com/chetachiezikeuzor/) ^github
 <!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/chetachiezikeuzor> ^website
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 

--- a/01 - Community/People/chhoumann.md
+++ b/01 - Community/People/chhoumann.md
@@ -9,7 +9,7 @@ publish: true
 # Christian B. B. Houmann
 
 - GitHub: [chhoumann](https://github.com/chhoumann/) ^github
-%% - Discord: `@` ^discord %%
+<!-- - Discord: `@` ^discord-->
 - Website: <https://bagerbach.com> ^website
 <!-- - [[Publish sites|Publish site]]: ^publish -->
 

--- a/01 - Community/People/chhoumann.md
+++ b/01 - Community/People/chhoumann.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Christian B. B. Houmann
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -27,15 +27,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 ## Sponsor this author
 

--- a/01 - Community/People/chhoumann.md
+++ b/01 - Community/People/chhoumann.md
@@ -11,7 +11,7 @@ publish: true
 - GitHub: [chhoumann](https://github.com/chhoumann/) ^github
 <!-- - Discord: `@` ^discord-->
 - Website: <https://bagerbach.com> ^website
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 

--- a/01 - Community/People/chrisgrieser.md
+++ b/01 - Community/People/chrisgrieser.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - pseudometa
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # pseudometa
 
 - GitHub: [chrisgrieser](https://github.com/chrisgrieser/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/coddingtonbear.md
+++ b/01 - Community/People/coddingtonbear.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Adam Coddington <me@adamcoddington.net>
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Adam Coddington <me@adamcoddington.net>
 
 - GitHub: [coddingtonbear](https://github.com/coddingtonbear/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://coddingtonbear.net/> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/colineckert.md
+++ b/01 - Community/People/colineckert.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Colin Eckert
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Colin Eckert
 
 - GitHub: [colineckert](https://github.com/colineckert/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/cotemaxime.md
+++ b/01 - Community/People/cotemaxime.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - cotemaxime
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # cotemaxime
 
 - GitHub: [cotemaxime](https://github.com/cotemaxime/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/cristianvasquez.md
+++ b/01 - Community/People/cristianvasquez.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Cristian Vasquez
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Cristian Vasquez
 
 - GitHub: [cristianvasquez](https://github.com/cristianvasquez/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -30,15 +27,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/curio-heart.md
+++ b/01 - Community/People/curio-heart.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Curio Heart
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Curio Heart
 
 - GitHub: [curio-heart](https://github.com/curio-heart/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/cybeerboy.md
+++ b/01 - Community/People/cybeerboy.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - cybeerboy
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # cybeerboy
 
 - GitHub: [cybeerboy](https://github.com/cybeerboy/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/d-sauer.md
+++ b/01 - Community/People/d-sauer.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - d-sauer
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # d-sauer
 
 - GitHub: [d-sauer](https://github.com/d-sauer/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://www.linkedin.com/in/davorsauer/> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/damiankorcz.md
+++ b/01 - Community/People/damiankorcz.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Damian Korcz
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Damian Korcz
 
 - GitHub: [damiankorcz](https://github.com/damiankorcz/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/darlal.md
+++ b/01 - Community/People/darlal.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - darlal
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # darlal
 
 - GitHub: [darlal](https://github.com/darlal/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/darlal/obsidian-switcher-plus> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/davidgolding.md
+++ b/01 - Community/People/davidgolding.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - David Golding
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # David Golding
 
 - GitHub: [davidgolding](https://github.com/davidgolding/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/deathau.md
+++ b/01 - Community/People/deathau.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - death_au
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # death_au
 
 - GitHub: [deathau](https://github.com/deathau/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/deathau> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -41,15 +38,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/debanjandhar12.md
+++ b/01 - Community/People/debanjandhar12.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - debanjandhar12
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # debanjandhar12
 
 - GitHub: [debanjandhar12](https://github.com/debanjandhar12/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/debanjandhar12> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/delashum.md
+++ b/01 - Community/People/delashum.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - delashum
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # delashum
 
 - GitHub: [delashum](https://github.com/delashum/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://www.hivewire.co/about/careers> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/denisoed.md
+++ b/01 - Community/People/denisoed.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Denisoed
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Denisoed
 
 - GitHub: [denisoed](https://github.com/denisoed/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/denisoed> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/dennisseidel.md
+++ b/01 - Community/People/dennisseidel.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - dennis seidel
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # dennis seidel
 
 - GitHub: [dennisseidel](https://github.com/dennisseidel/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://dennisseidel.de> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/denolehov.md
+++ b/01 - Community/People/denolehov.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Denis Olehov
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Denis Olehov
 
 - GitHub: [denolehov](https://github.com/denolehov/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/derwish-pro.md
+++ b/01 - Community/People/derwish-pro.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Dmitry Savosh
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Dmitry Savosh
 
 - GitHub: [derwish-pro](https://github.com/derwish-pro/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/derwish-pro/> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -32,15 +29,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/dgarrett.md
+++ b/01 - Community/People/dgarrett.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Dylan Garrett
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Dylan Garrett
 
 - GitHub: [dgarrett](https://github.com/dgarrett/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://dylan-garrett.com> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/dhamaniasad.md
+++ b/01 - Community/People/dhamaniasad.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Asad Dhamani
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Asad Dhamani
 
 - GitHub: [dhamaniasad](https://github.com/dhamaniasad/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://www.asad.pw> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/dhruvik7.md
+++ b/01 - Community/People/dhruvik7.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Dhruvik Parikh
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Dhruvik Parikh
 
 - GitHub: [dhruvik7](https://github.com/dhruvik7/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/dhruvik7> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/dogwaddle.md
+++ b/01 - Community/People/dogwaddle.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - lizardmenfromspace
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # lizardmenfromspace
 
 - GitHub: [dogwaddle](https://github.com/dogwaddle/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/duoani.md
+++ b/01 - Community/People/duoani.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Duo
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Duo
 
 - GitHub: [duoani](https://github.com/duoani/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/duoani> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/dvcrn.md
+++ b/01 - Community/People/dvcrn.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - dvcrn
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # dvcrn
 
 - GitHub: [dvcrn](https://github.com/dvcrn/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/dvcrn/filename-header-sync> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/dxcore35.md
+++ b/01 - Community/People/dxcore35.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - dxcore35
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # dxcore35
 
 - GitHub: [dxcore35](https://github.com/dxcore35/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/ebullient.md
+++ b/01 - Community/People/ebullient.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ebullient
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # ebullient
 
 - GitHub: [ebullient](https://github.com/ebullient/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/ebullient> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -30,15 +27,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/egradman.md
+++ b/01 - Community/People/egradman.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - egradman
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # egradman
 
 - GitHub: [egradman](https://github.com/egradman/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://www.gradman.com> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/eleanorkonik.md
+++ b/01 - Community/People/eleanorkonik.md
@@ -11,7 +11,7 @@ publish: true
 I teach (& research) ancient civilizations, then write stories & articles inspired by all eras of history... which involves a fair amount of notetaking ;) I'm also a moderator for the Obsidian community (mostly on Discord and Reddit)
 
 - GitHub: [eleanorkonik](https://github.com/eleanorkonik/) ^github
-- Discord: `Eleanor#3466`
+- Discord: `Eleanor#3466` ^discord
 - Website: [eleanorkonik.com/](https://eleanorkonik.com/) ^website
 - Newsletter: [Eleanor's Iceberg](http://newsletter.eleanorkonik.com/)^newsletter
 - [[Publish sites|Publish site]]: [Eleanor's Notes](https://publish.obsidian.md/eleanorkonik/) ^publish
@@ -39,7 +39,6 @@ I teach (& research) ancient civilizations, then write stories & articles inspir
 ## Sponsor this author
 
 - [[GitHub sponsors]]: [Sponsor @eleanorkonik on GitHub Sponsors](https://github.com/sponsors/eleanorkonik) ^github
-%% - Discord: `@` ^discord %%-sponsor
 - [[Buy me a coffee]]: [Sponsor @eleanorkonik on Ko-fi](https://ko-fi.com/eleanorkonik) ^buy-me-a-coffee
 
 

--- a/01 - Community/People/eleanorkonik.md
+++ b/01 - Community/People/eleanorkonik.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Eleanor Konik
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -20,10 +20,8 @@ I teach (& research) ancient civilizations, then write stories & articles inspir
 
 %% Begin Hub: Released contributions %%
 
-
 ### Themes
 - [[Palatinate]]
-
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
@@ -47,7 +45,6 @@ I teach (& research) ancient civilizations, then write stories & articles inspir
 - [[PayPal]]: ^paypal
 - [[Patreon]]: ^patreon
 -->
-
 
 ## Follow this author
 

--- a/01 - Community/People/elias-sundqvist.md
+++ b/01 - Community/People/elias-sundqvist.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Obsidian
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Obsidian
 
 - GitHub: [elias-sundqvist](https://github.com/elias-sundqvist/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://obsidian.md/about> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -30,15 +27,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/elliotboyd.md
+++ b/01 - Community/People/elliotboyd.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Boyd
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Boyd
 
 - GitHub: [elliotboyd](https://github.com/elliotboyd/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/erichalldev.md
+++ b/01 - Community/People/erichalldev.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Eric Hall
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Eric Hall
 
 - GitHub: [erichalldev](https://github.com/erichalldev/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://erichall.io> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/esm7.md
+++ b/01 - Community/People/esm7.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - esm
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # esm
 
 - GitHub: [esm7](https://github.com/esm7/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -30,15 +27,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/firinael.md
+++ b/01 - Community/People/firinael.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - só erick mesmo
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # só erick mesmo
 
 - GitHub: [firinael](https://github.com/firinael/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/fivol.md
+++ b/01 - Community/People/fivol.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Boris Bondarenko
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Boris Bondarenko
 
 - GitHub: [fivol](https://github.com/fivol/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/fivol> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/fxal.md
+++ b/01 - Community/People/fxal.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Felix Almer
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Felix Almer
 
 - GitHub: [fxal](https://github.com/fxal/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://almer.dev> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/garyng.md
+++ b/01 - Community/People/garyng.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - GaryNg
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # GaryNg
 
 - GitHub: [garyng](https://github.com/garyng/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/garyng/obsidian-temple> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/gavvvr.md
+++ b/01 - Community/People/gavvvr.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Kirill Gavrilov
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Kirill Gavrilov
 
 - GitHub: [gavvvr](https://github.com/gavvvr/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/gavvvr> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/gitobsidiantutorial.md
+++ b/01 - Community/People/gitobsidiantutorial.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - foreveryone
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # foreveryone
 
 - GitHub: [gitobsidiantutorial](https://github.com/gitobsidiantutorial/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/gitobsidiantutorial/obsidian-tabs> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/gquental.md
+++ b/01 - Community/People/gquental.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Guilherme Quental
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Guilherme Quental
 
 - GitHub: [gquental](https://github.com/gquental/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://obsidian.md/about> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/gracejoseph1236.md
+++ b/01 - Community/People/gracejoseph1236.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Piglet1236
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Piglet1236
 
 - GitHub: [gracejoseph1236](https://github.com/gracejoseph1236/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -30,15 +27,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/graydon.md
+++ b/01 - Community/People/graydon.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Graydon Hoare
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Graydon Hoare
 
 - GitHub: [graydon](https://github.com/graydon/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/graydon> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/gregzuro.md
+++ b/01 - Community/People/gregzuro.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Greg Zuro
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Greg Zuro
 
 - GitHub: [gregzuro](https://github.com/gregzuro/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/gregzuro/> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/hadynz.md
+++ b/01 - Community/People/hadynz.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Hady Osman
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Hady Osman
 
 - GitHub: [hadynz](https://github.com/hadynz/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://hady.geek.nz> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/hans.md
+++ b/01 - Community/People/hans.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Jon Gauthier
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Jon Gauthier
 
 - GitHub: [hans](https://github.com/hans/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <http://foldl.me> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/heliostatic.md
+++ b/01 - Community/People/heliostatic.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Ben Lee-Cohen
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Ben Lee-Cohen
 
 - GitHub: [heliostatic](https://github.com/heliostatic/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/heliostatic/completed-task-display> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/hhhapz.md
+++ b/01 - Community/People/hhhapz.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - hhhapz
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # hhhapz
 
 - GitHub: [hhhapz](https://github.com/hhhapz/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/hhhapz> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/hipstersmoothie.md
+++ b/01 - Community/People/hipstersmoothie.md
@@ -14,7 +14,7 @@ publish: true
 
 - Website: <https://twitter.com/hipstersmoothie> ^website
 
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 

--- a/01 - Community/People/hipstersmoothie.md
+++ b/01 - Community/People/hipstersmoothie.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Andrew Lisowski
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,11 +9,8 @@ publish: true
 # Andrew Lisowski
 
 - GitHub: [hipstersmoothie](https://github.com/hipstersmoothie/) ^github
-
 <!-- - Discord: `@` ^discord-->
-
 - Website: <https://twitter.com/hipstersmoothie> ^website
-
 <!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
@@ -31,15 +28,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/hipstersmoothie.md
+++ b/01 - Community/People/hipstersmoothie.md
@@ -10,7 +10,7 @@ publish: true
 
 - GitHub: [hipstersmoothie](https://github.com/hipstersmoothie/) ^github
 
-%% - Discord: `@` ^discord %%
+<!-- - Discord: `@` ^discord-->
 
 - Website: <https://twitter.com/hipstersmoothie> ^website
 

--- a/01 - Community/People/hungsu.md
+++ b/01 - Community/People/hungsu.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Hung-Su
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Hung-Su
 
 - GitHub: [hungsu](https://github.com/hungsu/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/hungsu> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -30,15 +27,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/ikuyarihS.md
+++ b/01 - Community/People/ikuyarihS.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Shirayuki Nekomata
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Shirayuki Nekomata
 
 - GitHub: [ikuyarihS](https://github.com/ikuyarihS/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/ikuyarihS> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/imdone.md
+++ b/01 - Community/People/imdone.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Imdone
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Imdone
 
 - GitHub: [imdone](https://github.com/imdone/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://imdone.io> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/insanum.md
+++ b/01 - Community/People/insanum.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - insanum
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # insanum
 
 - GitHub: [insanum](https://github.com/insanum/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/ishgunacar.md
+++ b/01 - Community/People/ishgunacar.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Ish Gunacar
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Ish Gunacar
 
 - GitHub: [ishgunacar](https://github.com/ishgunacar/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/ivan-lednev.md
+++ b/01 - Community/People/ivan-lednev.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Ivan Lednev
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Ivan Lednev
 
 - GitHub: [ivan-lednev](https://github.com/ivan-lednev/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/ivan-lednev> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/izumin5210.md
+++ b/01 - Community/People/izumin5210.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - izumin5210
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # izumin5210
 
 - GitHub: [izumin5210](https://github.com/izumin5210/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/jamiebrynes7.md
+++ b/01 - Community/People/jamiebrynes7.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Jamie Brynes
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Jamie Brynes
 
 - GitHub: [jamiebrynes7](https://github.com/jamiebrynes7/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://obsidian.md/about> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -31,15 +28,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/jarodise.md
+++ b/01 - Community/People/jarodise.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - jarodise
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # jarodise
 
 - GitHub: [jarodise](https://github.com/jarodise/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/jdanielmourao.md
+++ b/01 - Community/People/jdanielmourao.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - jdanielmourao
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # jdanielmourao
 
 - GitHub: [jdanielmourao](https://github.com/jdanielmourao/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/jdbrice.md
+++ b/01 - Community/People/jdbrice.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - dandandan
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # dandandan
 
 - GitHub: [jdbrice](https://github.com/jdbrice/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/jdbrice/obsidian-css-snippets> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/jglev.md
+++ b/01 - Community/People/jglev.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Obsidian
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Obsidian
 
 - GitHub: [jglev](https://github.com/jglev/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://obsidian.md/about> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -30,15 +27,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/jillalberts.md
+++ b/01 - Community/People/jillalberts.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Jill Alberts
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Jill Alberts
 
 - GitHub: [jillalberts](https://github.com/jillalberts/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/jillalberts/privacy-glasses> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/jmilldotdev.md
+++ b/01 - Community/People/jmilldotdev.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Jonathan Miller
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Jonathan Miller
 
 - GitHub: [jmilldotdev](https://github.com/jmilldotdev/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://jmill.dev> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/joethei.md
+++ b/01 - Community/People/joethei.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Johannes Theiner
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Johannes Theiner
 
 - GitHub: [joethei](https://github.com/joethei/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/joethei> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/joeyuping.md
+++ b/01 - Community/People/joeyuping.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - joeyuping
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # joeyuping
 
 - GitHub: [joeyuping](https://github.com/joeyuping/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/joeyuping/quick_latex_obsidian> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/johackim.md
+++ b/01 - Community/People/johackim.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - johackim
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # johackim
 
 - GitHub: [johackim](https://github.com/johackim/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/jplattel.md
+++ b/01 - Community/People/jplattel.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Joost Plattel
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Joost Plattel
 
 - GitHub: [jplattel](https://github.com/jplattel/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://jplattel.nl> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/jsonMartin.md
+++ b/01 - Community/People/jsonMartin.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - jsonmartin
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # jsonmartin
 
 - GitHub: [jsonMartin](https://github.com/jsonMartin/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/jsonMartin/> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/kaizau.md
+++ b/01 - Community/People/kaizau.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - kaizau
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # kaizau
 
 - GitHub: [kaizau](https://github.com/kaizau/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/kaizau> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/kalbetredev.md
+++ b/01 - Community/People/kalbetredev.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Kalkidan Betre
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Kalkidan Betre
 
 - GitHub: [kalbetredev](https://github.com/kalbetredev/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/kalbetredev> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/kartik-karz.md
+++ b/01 - Community/People/kartik-karz.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - karz
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # karz
 
 - GitHub: [kartik-karz](https://github.com/kartik-karz/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/kbravh.md
+++ b/01 - Community/People/kbravh.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - kbravh
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # kbravh
 
 - GitHub: [kbravh](https://github.com/kbravh/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://kbravh.dev> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/kenset.md
+++ b/01 - Community/People/kenset.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - kenset
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # kenset
 
 - GitHub: [kenset](https://github.com/kenset/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/kenset> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/kenzan100.md
+++ b/01 - Community/People/kenzan100.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Yuta Miyama
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Yuta Miyama
 
 - GitHub: [kenzan100](https://github.com/kenzan100/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://twitter.com/kenzan100> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/kepano.md
+++ b/01 - Community/People/kepano.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - @kepano
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # @kepano
 
 - GitHub: [kepano](https://github.com/kepano/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://www.twitter.com/kepano> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -33,15 +30,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/kevboh.md
+++ b/01 - Community/People/kevboh.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Kevin Barrett
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Kevin Barrett
 
 - GitHub: [kevboh](https://github.com/kevboh/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://kevinbarrett.org> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/kinabalu.md
+++ b/01 - Community/People/kinabalu.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Andrew Lombardi
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Andrew Lombardi
 
 - GitHub: [kinabalu](https://github.com/kinabalu/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://mysticcoders.com> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/kingsquirrel152.md
+++ b/01 - Community/People/kingsquirrel152.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Alex Stewart
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Alex Stewart
 
 - GitHub: [kingsquirrel152](https://github.com/kingsquirrel152/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/kinmury.md
+++ b/01 - Community/People/kinmury.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Kinmury Ditamir
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Kinmury Ditamir
 
 - GitHub: [kinmury](https://github.com/kinmury/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/kognise.md
+++ b/01 - Community/People/kognise.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - kognise
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # kognise
 
 - GitHub: [kognise](https://github.com/kognise/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/kometenstaub.md
+++ b/01 - Community/People/kometenstaub.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - kometenstaub
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # kometenstaub
 
 - GitHub: [kometenstaub](https://github.com/kometenstaub/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/kometenstaub> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/konodyuk.md
+++ b/01 - Community/People/konodyuk.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Nikita Konodyuk
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Nikita Konodyuk
 
 - GitHub: [konodyuk](https://github.com/konodyuk/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/konodyuk> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/kurakart.md
+++ b/01 - Community/People/kurakart.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - kurakart
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # kurakart
 
 - GitHub: [kurakart](https://github.com/kurakart/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/kzhovn.md
+++ b/01 - Community/People/kzhovn.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - kzhovn
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # kzhovn
 
 - GitHub: [kzhovn](https://github.com/kzhovn/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/kzhovn> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -31,15 +28,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/larslockefeer.md
+++ b/01 - Community/People/larslockefeer.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Lars Lockefeer
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Lars Lockefeer
 
 - GitHub: [larslockefeer](https://github.com/larslockefeer/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://lars.lockefeer.online> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/lazercaveman.md
+++ b/01 - Community/People/lazercaveman.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Ali Soueidan
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Ali Soueidan
 
 - GitHub: [lazercaveman](https://github.com/lazercaveman/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/liamcain.md
+++ b/01 - Community/People/liamcain.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Liam Cain
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Liam Cain
 
 - GitHub: [liamcain](https://github.com/liamcain/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/liamcain/> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -30,15 +27,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/lifegems.md
+++ b/01 - Community/People/lifegems.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Joshua Michalik
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Joshua Michalik
 
 - GitHub: [lifegems](https://github.com/lifegems/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/lifegems/obsidian-related-notes-finder> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/linjunpop.md
+++ b/01 - Community/People/linjunpop.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Jun Lin
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Jun Lin
 
 - GitHub: [linjunpop](https://github.com/linjunpop/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/linjunpop/obsidian-gist> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/luckman212.md
+++ b/01 - Community/People/luckman212.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - luckman212
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # luckman212
 
 - GitHub: [luckman212](https://github.com/luckman212/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/luckman212/obsidian-reset-font-size> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/lukauskas.md
+++ b/01 - Community/People/lukauskas.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - lukauskas
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # lukauskas
 
 - GitHub: [lukauskas](https://github.com/lukauskas/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/luke-rmaki.md
+++ b/01 - Community/People/luke-rmaki.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Luke Ruokaismaki
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Luke Ruokaismaki
 
 - GitHub: [luke-rmaki](https://github.com/luke-rmaki/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/lukeleppan.md
+++ b/01 - Community/People/lukeleppan.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Luke Leppan
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Luke Leppan
 
 - GitHub: [lukeleppan](https://github.com/lukeleppan/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://lukeleppan.com> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/lynchjames.md
+++ b/01 - Community/People/lynchjames.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - James Lynch
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # James Lynch
 
 - GitHub: [lynchjames](https://github.com/lynchjames/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -30,15 +27,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/lyonsquark.md
+++ b/01 - Community/People/lyonsquark.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Adam Lyon
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Adam Lyon
 
 - GitHub: [lyonsquark](https://github.com/lyonsquark/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://lyon-fnal.github.io> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/manassadasivuni.md
+++ b/01 - Community/People/manassadasivuni.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Manas Sadasivuni
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Manas Sadasivuni
 
 - GitHub: [manassadasivuni](https://github.com/manassadasivuni/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/manogna4.md
+++ b/01 - Community/People/manogna4.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - mano
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # mano
 
 - GitHub: [manogna4](https://github.com/manogna4/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://manogna4.github.io> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/marcjulianschwarz.md
+++ b/01 - Community/People/marcjulianschwarz.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Marc Julian Schwarz
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Marc Julian Schwarz
 
 - GitHub: [marcjulianschwarz](https://github.com/marcjulianschwarz/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://www.marc-julian.de> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/marcusolsson.md
+++ b/01 - Community/People/marcusolsson.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Marcus Olsson
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Marcus Olsson
 
 - GitHub: [marcusolsson](https://github.com/marcusolsson/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://marcus.se.net> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -31,15 +28,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/martin-jw.md
+++ b/01 - Community/People/martin-jw.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Martin Jirlow
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Martin Jirlow
 
 - GitHub: [martin-jw](https://github.com/martin-jw/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/martin-jw/obsidian-recall> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/mcndt.md
+++ b/01 - Community/People/mcndt.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Maxime Cannoodt (@mcndt)
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Maxime Cannoodt (@mcndt)
 
 - GitHub: [mcndt](https://github.com/mcndt/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/mcndt> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/mdelobelle.md
+++ b/01 - Community/People/mdelobelle.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - mdelobelle
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # mdelobelle
 
 - GitHub: [mdelobelle](https://github.com/mdelobelle/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/mdelobelle/mdelobelle/tree/main> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/mediapathic.md
+++ b/01 - Community/People/mediapathic.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Mediapathic
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Mediapathic
 
 - GitHub: [mediapathic](https://github.com/mediapathic/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/meld-cp.md
+++ b/01 - Community/People/meld-cp.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - meld-cp
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # meld-cp
 
 - GitHub: [meld-cp](https://github.com/meld-cp/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/meld-cp/obsidian-calc> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/mgmeyers.md
+++ b/01 - Community/People/mgmeyers.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - mgmeyers
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # mgmeyers
 
 - GitHub: [mgmeyers](https://github.com/mgmeyers/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/mgmeyers/obsidian-copy-block-link> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -37,15 +34,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/michaellee.md
+++ b/01 - Community/People/michaellee.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Michael Lee
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Michael Lee
 
 - GitHub: [michaellee](https://github.com/michaellee/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://michaelsoolee.com> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/mimishahzad.md
+++ b/01 - Community/People/mimishahzad.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - mimishahzad
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # mimishahzad
 
 - GitHub: [mimishahzad](https://github.com/mimishahzad/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/mirnovov.md
+++ b/01 - Community/People/mirnovov.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Novov
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Novov
 
 - GitHub: [mirnovov](https://github.com/mirnovov/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://novov.me> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/mkozhukharenko.md
+++ b/01 - Community/People/mkozhukharenko.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - death_au
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # death_au
 
 - GitHub: [mkozhukharenko](https://github.com/mkozhukharenko/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/mkozhukharenko> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/motif-software.md
+++ b/01 - Community/People/motif-software.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Oliver Lade
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Oliver Lade
 
 - GitHub: [motif-software](https://github.com/motif-software/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://motif.software> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/mrglitchbyte.md
+++ b/01 - Community/People/mrglitchbyte.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - MrGlitchByte
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # MrGlitchByte
 
 - GitHub: [mrglitchbyte](https://github.com/mrglitchbyte/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/mrjackphil.md
+++ b/01 - Community/People/mrjackphil.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - MrJackphil
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # MrJackphil
 
 - GitHub: [mrjackphil](https://github.com/mrjackphil/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://mrjackphil.com> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -31,15 +28,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/mrzeroo00.md
+++ b/01 - Community/People/mrzeroo00.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Badr Bouslikhin
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Badr Bouslikhin
 
 - GitHub: [mrzeroo00](https://github.com/mrzeroo00/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/MrZeroo00> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/mybuddymichael.md
+++ b/01 - Community/People/mybuddymichael.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Michael Hanson
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Michael Hanson
 
 - GitHub: [mybuddymichael](https://github.com/mybuddymichael/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/mybuddymichael> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/nadavspi.md
+++ b/01 - Community/People/nadavspi.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Nadav Spiegelman
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Nadav Spiegelman
 
 - GitHub: [nadavspi](https://github.com/nadavspi/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://nadav.is> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/nemoandrea.md
+++ b/01 - Community/People/nemoandrea.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Nemo Andrea
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Nemo Andrea
 
 - GitHub: [nemoandrea](https://github.com/nemoandrea/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <http://nemoandrea.github.io/> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/nhaouari.md
+++ b/01 - Community/People/nhaouari.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Noureddine Haouari
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Noureddine Haouari
 
 - GitHub: [nhaouari](https://github.com/nhaouari/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/nickmilo.md
+++ b/01 - Community/People/nickmilo.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - nickmilo
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # nickmilo
 
 - GitHub: [nickmilo](https://github.com/nickmilo/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/nikbrunner.md
+++ b/01 - Community/People/nikbrunner.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - nikbrunner
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # nikbrunner
 
 - GitHub: [nikbrunner](https://github.com/nikbrunner/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/nmady.md
+++ b/01 - Community/People/nmady.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - nmady
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # nmady
 
 - GitHub: [nmady](https://github.com/nmady/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/nnshi-s.md
+++ b/01 - Community/People/nnshi-s.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - 
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # 
 
 - GitHub: [nnshi-s](https://github.com/nnshi-s/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/noatpad.md
+++ b/01 - Community/People/noatpad.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Danny Hernandez
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Danny Hernandez
 
 - GitHub: [noatpad](https://github.com/noatpad/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/noatpad> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/nothingislost.md
+++ b/01 - Community/People/nothingislost.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - NothingIsLost
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # NothingIsLost
 
 - GitHub: [nothingislost](https://github.com/nothingislost/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/nothingislost> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/nyable.md
+++ b/01 - Community/People/nyable.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - hafuhafu
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # hafuhafu
 
 - GitHub: [nyable](https://github.com/nyable/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/nyable/obsidian-code-block-enhancer> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/nybbles.md
+++ b/01 - Community/People/nybbles.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Nimalan Mahendran
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Nimalan Mahendran
 
 - GitHub: [nybbles](https://github.com/nybbles/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://twitter.com/nimalan> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/obsidian-ezs.md
+++ b/01 - Community/People/obsidian-ezs.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ezs
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # ezs
 
 - GitHub: [obsidian-ezs](https://github.com/obsidian-ezs/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/oeN.md
+++ b/01 - Community/People/oeN.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - diomedet
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # diomedet
 
 - GitHub: [oeN](https://github.com/oeN/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://diomedet.com/> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/oliveryh.md
+++ b/01 - Community/People/oliveryh.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - oliveryh
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # oliveryh
 
 - GitHub: [oliveryh](https://github.com/oliveryh/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/oliveryh/obsidian-emoji-toolbar> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/onlyafly.md
+++ b/01 - Community/People/onlyafly.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Kevin Albrecht (onlyafly@gmail.com)
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Kevin Albrecht (onlyafly@gmail.com)
 
 - GitHub: [onlyafly](https://github.com/onlyafly/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://www.kevinalbrecht.com> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/ozntel.md
+++ b/01 - Community/People/ozntel.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Ozan Tellioglu
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Ozan Tellioglu
 
 - GitHub: [ozntel](https://github.com/ozntel/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://ozan.pl> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -33,15 +30,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/pgalliford.md
+++ b/01 - Community/People/pgalliford.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Reggie
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Reggie
 
 - GitHub: [pgalliford](https://github.com/pgalliford/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/phibr0.md
+++ b/01 - Community/People/phibr0.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - phibr0
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # phibr0
 
 - GitHub: [phibr0](https://github.com/phibr0/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://phibr0.de> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -39,15 +36,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/pjeby.md
+++ b/01 - Community/People/pjeby.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - PJ Eby
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # PJ Eby
 
 - GitHub: [pjeby](https://github.com/pjeby/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -32,15 +29,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/platers.md
+++ b/01 - Community/People/platers.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Victor Tao
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Victor Tao
 
 - GitHub: [platers](https://github.com/platers/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/platers> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/pmorim.md
+++ b/01 - Community/People/pmorim.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - pmorim
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # pmorim
 
 - GitHub: [pmorim](https://github.com/pmorim/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/pmorim> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/pyrochlore.md
+++ b/01 - Community/People/pyrochlore.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - pyrochlore
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # pyrochlore
 
 - GitHub: [pyrochlore](https://github.com/pyrochlore/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/radekkozak.md
+++ b/01 - Community/People/radekkozak.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - @radekkozak
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # @radekkozak
 
 - GitHub: [radekkozak](https://github.com/radekkozak/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/radekkozak> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -30,15 +27,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/raineszm.md
+++ b/01 - Community/People/raineszm.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Zach Raines
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Zach Raines
 
 - GitHub: [raineszm](https://github.com/raineszm/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/raineszm/obsidian-export-to-tex> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/ravimashru.md
+++ b/01 - Community/People/ravimashru.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Ravi Mashru
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Ravi Mashru
 
 - GitHub: [ravimashru](https://github.com/ravimashru/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://ravimashru.dev> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/razumihin.md
+++ b/01 - Community/People/razumihin.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Razum
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Razum
 
 - GitHub: [razumihin](https://github.com/razumihin/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/Razumihin> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/rcvd.md
+++ b/01 - Community/People/rcvd.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - rcvd
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # rcvd
 
 - GitHub: [rcvd](https://github.com/rcvd/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/readwiseio.md
+++ b/01 - Community/People/readwiseio.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Readwise
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Readwise
 
 - GitHub: [readwiseio](https://github.com/readwiseio/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://readwise.io> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/renehernandez.md
+++ b/01 - Community/People/renehernandez.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Rene Hernandez
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Rene Hernandez
 
 - GitHub: [renehernandez](https://github.com/renehernandez/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://renehernandez.io> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/renmu123.md
+++ b/01 - Community/People/renmu123.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - renmu123
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # renmu123
 
 - GitHub: [renmu123](https://github.com/renmu123/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/renmu123/obsidian-markdown-index> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -30,15 +27,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/reuseman.md
+++ b/01 - Community/People/reuseman.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Alex Colucci
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Alex Colucci
 
 - GitHub: [reuseman](https://github.com/reuseman/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/reuseman> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/rudimuc.md
+++ b/01 - Community/People/rudimuc.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Rudi Häusler
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Rudi Häusler
 
 - GitHub: [rudimuc](https://github.com/rudimuc/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/rudimuc> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/ryanjamurphy.md
+++ b/01 - Community/People/ryanjamurphy.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Ryan J. A. Murphy
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -31,15 +31,18 @@ A mod for both Discord and forum and a plugin author.
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/ryanjamurphy.md
+++ b/01 - Community/People/ryanjamurphy.md
@@ -11,7 +11,7 @@ publish: true
 - GitHub: [ryanjamurphy](https://github.com/ryanjamurphy/) ^github
 <!-- - Discord: `@` ^discord-->
 - Website: <https://axle.design> ^website
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 A mod for both Discord and forum and a plugin author.

--- a/01 - Community/People/ryanjamurphy.md
+++ b/01 - Community/People/ryanjamurphy.md
@@ -9,7 +9,7 @@ publish: true
 # Ryan J. A. Murphy
 
 - GitHub: [ryanjamurphy](https://github.com/ryanjamurphy/) ^github
-%% - Discord: `@` ^discord %%
+<!-- - Discord: `@` ^discord-->
 - Website: <https://axle.design> ^website
 <!-- - [[Publish sites|Publish site]]: ^publish -->
 

--- a/01 - Community/People/ryanpcmcquen.md
+++ b/01 - Community/People/ryanpcmcquen.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - ryanpcmcquen
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # ryanpcmcquen
 
 - GitHub: [ryanpcmcquen](https://github.com/ryanpcmcquen/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/ryanpcmcquen> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -31,15 +28,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/ryjjin.md
+++ b/01 - Community/People/ryjjin.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - kitchenrunner
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # kitchenrunner
 
 - GitHub: [ryjjin](https://github.com/ryjjin/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -30,15 +27,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/sainadh-d.md
+++ b/01 - Community/People/sainadh-d.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Sainadh
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Sainadh
 
 - GitHub: [sainadh-d](https://github.com/sainadh-d/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/samlewis0602.md
+++ b/01 - Community/People/samlewis0602.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Sam Lewis
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Sam Lewis
 
 - GitHub: [samlewis0602](https://github.com/samlewis0602/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/samlewis0602> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/samwarnick.md
+++ b/01 - Community/People/samwarnick.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Sam Warnick
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Sam Warnick
 
 - GitHub: [samwarnick](https://github.com/samwarnick/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/samwarnick> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/santiyounger.md
+++ b/01 - Community/People/santiyounger.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Santi Younger
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Santi Younger
 
 - GitHub: [santiyounger](https://github.com/santiyounger/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/schemar.md
+++ b/01 - Community/People/schemar.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Martin Schenck
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Martin Schenck
 
 - GitHub: [schemar](https://github.com/schemar/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/schemar> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/schlundd.md
+++ b/01 - Community/People/schlundd.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Dominik Schlund
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Dominik Schlund
 
 - GitHub: [schlundd](https://github.com/schlundd/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/seanwcom.md
+++ b/01 - Community/People/seanwcom.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - SeanWcom
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # SeanWcom
 
 - GitHub: [seanwcom](https://github.com/seanwcom/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/selfire1.md
+++ b/01 - Community/People/selfire1.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Joschua
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Joschua
 
 - GitHub: [selfire1](https://github.com/selfire1/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/sergey900553.md
+++ b/01 - Community/People/sergey900553.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - sergey
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # sergey
 
 - GitHub: [sergey900553](https://github.com/sergey900553/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/shabegom.md
+++ b/01 - Community/People/shabegom.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - shabegom
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # shabegom
 
 - GitHub: [shabegom](https://github.com/shabegom/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://shbgm.ca> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/shaggyfeng.md
+++ b/01 - Community/People/shaggyfeng.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Mouth on Cloud
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Mouth on Cloud
 
 - GitHub: [shaggyfeng](https://github.com/shaggyfeng/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/shichongrui.md
+++ b/01 - Community/People/shichongrui.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Matt Sessions
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Matt Sessions
 
 - GitHub: [shichongrui](https://github.com/shichongrui/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://www.matthewsessions.com> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/sissilab.md
+++ b/01 - Community/People/sissilab.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - sissilab
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # sissilab
 
 - GitHub: [sissilab](https://github.com/sissilab/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/sissilab> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/skipadu.md
+++ b/01 - Community/People/skipadu.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Sami Korpela
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Sami Korpela
 
 - GitHub: [skipadu](https://github.com/skipadu/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/skipadu/> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/smikula.md
+++ b/01 - Community/People/smikula.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Scott Mikula
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Scott Mikula
 
 - GitHub: [smikula](https://github.com/smikula/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/smikula/obsidian-limelight> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/sparklau.md
+++ b/01 - Community/People/sparklau.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Spark
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Spark
 
 - GitHub: [sparklau](https://github.com/sparklau/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/spslater.md
+++ b/01 - Community/People/spslater.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Sean Slater
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Sean Slater
 
 - GitHub: [spslater](https://github.com/spslater/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/spslater/obsidian-cursor-location-plugin> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/st3v3nmw.md
+++ b/01 - Community/People/st3v3nmw.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Stephen Mwangi
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Stephen Mwangi
 
 - GitHub: [st3v3nmw](https://github.com/st3v3nmw/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/st3v3nmw> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/steven-kraft.md
+++ b/01 - Community/People/steven-kraft.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Steven Kraft
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Steven Kraft
 
 - GitHub: [steven-kraft](https://github.com/steven-kraft/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/steven-kraft/obsidian-markdown-furigana> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/superDuperCyberTechno.md
+++ b/01 - Community/People/superDuperCyberTechno.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - superDuperCyberTechno
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # superDuperCyberTechno
 
 - GitHub: [superDuperCyberTechno](https://github.com/superDuperCyberTechno/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/tadashi-aikawa.md
+++ b/01 - Community/People/tadashi-aikawa.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - tadashi-aikawa
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # tadashi-aikawa
 
 - GitHub: [tadashi-aikawa](https://github.com/tadashi-aikawa/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/tadashi-aikawa> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -30,15 +27,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/tgrosinger.md
+++ b/01 - Community/People/tgrosinger.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Tony Grosinger
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Tony Grosinger
 
 - GitHub: [tgrosinger](https://github.com/tgrosinger/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://grosinger.net> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -33,15 +30,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/tillahoffmann.md
+++ b/01 - Community/People/tillahoffmann.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Till Hoffmann
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Till Hoffmann
 
 - GitHub: [tillahoffmann](https://github.com/tillahoffmann/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/tillahoffmann/obsidian-jupyter> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/timhor.md
+++ b/01 - Community/People/timhor.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Tim Hor
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Tim Hor
 
 - GitHub: [timhor](https://github.com/timhor/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/timhor> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/toiq.md
+++ b/01 - Community/People/toiq.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Tousif Iqbal Anik (toiq)
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Tousif Iqbal Anik (toiq)
 
 - GitHub: [toiq](https://github.com/toiq/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/toiq> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/tokuhirom.md
+++ b/01 - Community/People/tokuhirom.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Tokuhiro Matsuno
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Tokuhiro Matsuno
 
 - GitHub: [tokuhirom](https://github.com/tokuhirom/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/tokuhirom/> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -30,15 +27,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/tomzorz.md
+++ b/01 - Community/People/tomzorz.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Tamás Deme - @tomzorz_
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Tamás Deme - @tomzorz_
 
 - GitHub: [tomzorz](https://github.com/tomzorz/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://tomzorz.me> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -30,15 +27,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/trashhalo.md
+++ b/01 - Community/People/trashhalo.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Stephen Solka
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Stephen Solka
 
 - GitHub: [trashhalo](https://github.com/trashhalo/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://obsidian-buffer.web.app> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -30,15 +27,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/triumphantomato.md
+++ b/01 - Community/People/triumphantomato.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - triumphantomato
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # triumphantomato
 
 - GitHub: [triumphantomato](https://github.com/triumphantomato/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/triumphantomato> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/trydalch.md
+++ b/01 - Community/People/trydalch.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Trevor Rydalch
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Trevor Rydalch
 
 - GitHub: [trydalch](https://github.com/trydalch/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/trydalch> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/twentytwokhz.md
+++ b/01 - Community/People/twentytwokhz.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Florin Bobis
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Florin Bobis
 
 - GitHub: [twentytwokhz](https://github.com/twentytwokhz/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://florinbobis.com> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/tylernguyen.md
+++ b/01 - Community/People/tylernguyen.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Tyler Nguyen
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Tyler Nguyen
 
 - GitHub: [tylernguyen](https://github.com/tylernguyen/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/uonr.md
+++ b/01 - Community/People/uonr.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Koppa
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Koppa
 
 - GitHub: [uonr](https://github.com/uonr/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/uonr> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/uphy.md
+++ b/01 - Community/People/uphy.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - uphy
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # uphy
 
 - GitHub: [uphy](https://github.com/uphy/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://obsidian.md/about> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/urishiraval.md
+++ b/01 - Community/People/urishiraval.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - urishiraval
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # urishiraval
 
 - GitHub: [urishiraval](https://github.com/urishiraval/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://urishiraval.github.io> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/valentine195.md
+++ b/01 - Community/People/valentine195.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Jeremy Valentine
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Jeremy Valentine
 
 - GitHub: [valentine195](https://github.com/valentine195/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/valentine195/obsidian-fantasy-calendar> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -35,15 +32,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/vanadium23.md
+++ b/01 - Community/People/vanadium23.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - vanadium23
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # vanadium23
 
 - GitHub: [vanadium23](https://github.com/vanadium23/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://vanadium23.me/> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -30,15 +27,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/visini.md
+++ b/01 - Community/People/visini.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Camillo Visini
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Camillo Visini
 
 - GitHub: [visini](https://github.com/visini/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/visini> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/vrtmrz.md
+++ b/01 - Community/People/vrtmrz.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - vorotamoroz
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # vorotamoroz
 
 - GitHub: [vrtmrz](https://github.com/vrtmrz/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/vrtmrz> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/vslinko.md
+++ b/01 - Community/People/vslinko.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Viacheslav Slinko
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Viacheslav Slinko
 
 - GitHub: [vslinko](https://github.com/vslinko/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/vslinko> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -29,15 +26,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/weichenw.md
+++ b/01 - Community/People/weichenw.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - weichenw
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # weichenw
 
 - GitHub: [weichenw](https://github.com/weichenw/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/weichenw> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/whyt-byte.md
+++ b/01 - Community/People/whyt-byte.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Whyl
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Whyl
 
 - GitHub: [whyt-byte](https://github.com/whyt-byte/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/xldenis.md
+++ b/01 - Community/People/xldenis.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Xavier Denis
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Xavier Denis
 
 - GitHub: [xldenis](https://github.com/xldenis/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/xldenis/obsidian-latex> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/xpgo.md
+++ b/01 - Community/People/xpgo.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - xpgo
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # xpgo
 
 - GitHub: [xpgo](https://github.com/xpgo/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/xpgo/obsidian-folder-note> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/yajamon.md
+++ b/01 - Community/People/yajamon.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - yajamon<yajamon.cmnct@gmail.com>
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # yajamon<yajamon.cmnct@gmail.com>
 
 - GitHub: [yajamon](https://github.com/yajamon/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/yajamon/obsidian-command-alias-plugin> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/yeboster.md
+++ b/01 - Community/People/yeboster.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Yeboster
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Yeboster
 
 - GitHub: [yeboster](https://github.com/yeboster/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/Yeboster/> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/yo-goto.md
+++ b/01 - Community/People/yo-goto.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - PADAone
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # PADAone
 
 - GitHub: [yo-goto](https://github.com/yo-goto/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/yo-goto> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/yuanotes.md
+++ b/01 - Community/People/yuanotes.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Yuan Chen
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Yuan Chen
 
 - GitHub: [yuanotes](https://github.com/yuanotes/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/yuanotes> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/zacharyc.md
+++ b/01 - Community/People/zacharyc.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - zacharyc
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # zacharyc
 
 - GitHub: [zacharyc](https://github.com/zacharyc/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/zapthedingbat.md
+++ b/01 - Community/People/zapthedingbat.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Sam Greenhalgh
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Sam Greenhalgh
 
 - GitHub: [zapthedingbat](https://github.com/zapthedingbat/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://www.radicalresearch.co.uk/> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/zcysxy.md
+++ b/01 - Community/People/zcysxy.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - zcysxy
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # zcysxy
 
 - GitHub: [zcysxy](https://github.com/zcysxy/) ^github
-
-%% - Discord: `@` ^discord %%
-
-%% - Website: <> ^website %% 
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - Discord: `@` ^discord-->
+<!-- - Website: <> ^website-->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/zolrath.md
+++ b/01 - Community/People/zolrath.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Matt Furden
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Matt Furden
 
 - GitHub: [zolrath](https://github.com/zolrath/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://github.com/zolrath> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/zsviczian.md
+++ b/01 - Community/People/zsviczian.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - Zsolt Viczian
-tags: 
+tags:
 - 
 publish: true
 ---
@@ -9,12 +9,9 @@ publish: true
 # Zsolt Viczian
 
 - GitHub: [zsviczian](https://github.com/zsviczian/) ^github
-
-%% - Discord: `@` ^discord %%
-
+<!-- - Discord: `@` ^discord-->
 - Website: <https://zsolt.blog> ^website
-
-<!-- - [[Publish sites|Publish site]]: ^publish -->
+<!-- - [[Publish sites|Publish site]]: ^publish-->
 
 %% Feel free to add a bio below this comment %%
 
@@ -28,15 +25,18 @@ publish: true
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
-%%
+
+<!--
 ### Unlisted plugins
 
 - 
+-->
 
+<!--
 ### Others
 
 - 
-%%
+-->
 
 <!--
 ## Sponsor this author


### PR DESCRIPTION
<!-- Add a small description here of the changes you added -->

Probably best reviewed via the individual commits: all but the fully scripted one are small

Observable differences:

- A bunch of stray block anchors such as `^github` will hopefully no longer be visible on the  published site (they've disappeared from preview in Obsidian)
    - ![image](https://user-images.githubusercontent.com/4840096/141982696-331d5ccd-8775-48f2-8f90-0823a070f69a.png)
- Bryan Jenks.md has some content added - this was the only existing author file that wasn't re-created from `update-releases.py`

Note: I worked out that the data from obsidian-releases currently in the Hub is from this revision, and so re-populated the authors content from that version - https://github.com/obsidianmd/obsidian-releases/commit/c85911035e71e9ecaaf1dc94d012db150ac6f43d - which really helped with checking all the changes 

## Checklist

- [x] I have renamed all attached images with descriptive file names (or I did not include any images)
- [x] Before creating a new note, I searched the vault (or I only edited existing notes)
