### PR TITLE
Add new "--update-download-counts" argument

### DIFF
--- a/.github/scripts/update-releases.py
+++ b/.github/scripts/update-releases.py
@@ -203,6 +203,11 @@ def set_theme_download_count(template, current_name, new_download_count, verbose
         print("Download count updated       {} - {} -> {}".format(file_name, previous_download_count, new_download_count))
 
 
+def update_theme_download_count(template, theme_downloads, current_name, verbose):
+    download_count = get_theme_current_download_count(theme_downloads, current_name)
+    set_theme_download_count(template, current_name, download_count, verbose)
+
+
 def get_uncategorized_plugins(overwrite=True, verbose=False):
     print("Finding uncategorized plugins....\n")
     template = get_template("category")
@@ -296,8 +301,7 @@ def update_theme_download_counts(verbose):
 
     for theme in theme_list:
         current_name = theme.get("name")
-        download_count = get_theme_current_download_count(theme_downloads, current_name)
-        set_theme_download_count(template, current_name, download_count, verbose)
+        update_theme_download_count(template, theme_downloads, current_name, verbose)
 
 
 def main(argv=sys.argv[1:]):

--- a/.github/scripts/update-releases.py
+++ b/.github/scripts/update-releases.py
@@ -92,7 +92,7 @@ def process_released_themes(overwrite=False, verbose=False):
         plugin_support = get_theme_plugin_support(css_file)
 
         current_name = theme.get("name")
-        download_count = theme_downloads[current_name]["download"]
+        download_count = get_theme_current_download_count(theme_downloads, current_name)
 
         theme.update(
             user=user,
@@ -114,6 +114,10 @@ def process_released_themes(overwrite=False, verbose=False):
     print_file_summary(file_groups)
 
     return designers
+
+
+def get_theme_current_download_count(theme_downloads, current_name):
+    return theme_downloads[current_name]["download"]
 
 
 def get_uncategorized_plugins(overwrite=True, verbose=False):

--- a/.github/scripts/update-releases.py
+++ b/.github/scripts/update-releases.py
@@ -103,10 +103,10 @@ def process_released_themes(overwrite=False, verbose=False):
             download_count= download_count,
         )
         group = write_file(
-            template, theme.get("name"), overwrite=overwrite, verbose=verbose, **theme
+            template, current_name, overwrite=overwrite, verbose=verbose, **theme
         )
         designers.append(theme)
-        file_groups.setdefault(group, list()).append(theme.get("name"))
+        file_groups.setdefault(group, list()).append(current_name)
         print_progress_bar(
             theme_list.index(theme) + 1, len(theme_list),
         )

--- a/.github/scripts/update-releases.py
+++ b/.github/scripts/update-releases.py
@@ -32,6 +32,11 @@ LIGHT_MODE_THEMES = "[[Light-mode themes|light]]"
 DOWNLOAD_COUNT_SEARCH = re.compile(r"https://img.shields.io/badge/downloads-(\d+)-")
 
 
+def get_theme_downloads():
+    theme_downloads: dict = requests.get('https://releases.obsidian.md/stats/theme').json()
+    return theme_downloads
+
+
 def process_released_plugins(overwrite=False, verbose=False):
     print("-----\nProcessing plugins....\n")
     template = get_template("plugin")
@@ -80,7 +85,7 @@ def process_released_themes(overwrite=False, verbose=False):
         0, len(theme_list),
     )
 
-    theme_downloads: dict = requests.get('https://releases.obsidian.md/stats/theme').json()
+    theme_downloads = get_theme_downloads()
 
     for theme in theme_list:
         repo = theme.get("repo")
@@ -282,7 +287,7 @@ def update_theme_download_counts(verbose):
     template = get_template("theme")
     theme_list = get_json_from_github(THEMES_JSON_FILE)
 
-    theme_downloads: dict = requests.get('https://releases.obsidian.md/stats/theme').json() # TODO Remove repetition
+    theme_downloads = get_theme_downloads()
 
     for theme in theme_list:
         current_name = theme.get("name")

--- a/.github/scripts/update-releases.py
+++ b/.github/scripts/update-releases.py
@@ -37,6 +37,11 @@ def get_theme_downloads():
     return theme_downloads
 
 
+def get_url_pattern_for_downloads_shield(placeholder_for_download_count):
+    old_text = f"https://img.shields.io/badge/downloads-{placeholder_for_download_count}-"
+    return old_text
+
+
 def process_released_plugins(overwrite=False, verbose=False):
     print("-----\nProcessing plugins....\n")
     template = get_template("plugin")
@@ -186,8 +191,8 @@ def set_theme_download_count(template, current_name, new_download_count, verbose
         old_contents = file.read()
 
     # TODO Remove the repetition of URL - see also DOWNLOAD_COUNT_SEARCH
-    old_text = f"https://img.shields.io/badge/downloads-{previous_download_count}-"
-    new_text = f"https://img.shields.io/badge/downloads-{new_download_count}-"
+    old_text = get_url_pattern_for_downloads_shield(previous_download_count)
+    new_text = get_url_pattern_for_downloads_shield(new_download_count)
     new_contents = old_contents.replace(old_text, new_text)
     assert new_contents != old_contents
 

--- a/.github/scripts/update-releases.py
+++ b/.github/scripts/update-releases.py
@@ -29,7 +29,8 @@ DESKTOP_ONLY = "[[Desktop-only plugins|No]]"
 DARK_MODE_THEMES = "[[Dark-mode themes|dark]]"
 LIGHT_MODE_THEMES = "[[Light-mode themes|light]]"
 
-DOWNLOAD_COUNT_SEARCH = re.compile(r"https://img.shields.io/badge/downloads-(\d+)-")
+DOWNLOAD_COUNT_SHIELDS_URL_PREFIX = 'https://img.shields.io/badge/downloads-'
+DOWNLOAD_COUNT_SEARCH = re.compile(DOWNLOAD_COUNT_SHIELDS_URL_PREFIX + r"(\d+)-")
 
 
 def get_theme_downloads():
@@ -38,7 +39,7 @@ def get_theme_downloads():
 
 
 def get_url_pattern_for_downloads_shield(placeholder_for_download_count):
-    old_text = f"https://img.shields.io/badge/downloads-{placeholder_for_download_count}-"
+    old_text = f"{DOWNLOAD_COUNT_SHIELDS_URL_PREFIX}{placeholder_for_download_count}-"
     return old_text
 
 

--- a/.github/scripts/update-releases.py
+++ b/.github/scripts/update-releases.py
@@ -132,7 +132,7 @@ def process_released_themes(overwrite=False, verbose=False):
 
 
 def get_theme_download_count_preferring_previous(template, theme_downloads, current_name):
-    previous_download_count = get_previous_download_count_or_none(template, current_name)
+    previous_download_count = get_theme_previous_download_count_or_none(template, current_name)
     if previous_download_count:
         return previous_download_count
 
@@ -143,7 +143,7 @@ def get_theme_current_download_count(theme_downloads, current_name):
     return theme_downloads[current_name]["download"]
 
 
-def get_previous_download_count_or_none(template, current_name):
+def get_theme_previous_download_count_or_none(template, current_name):
     """
     Read the theme file from disk, and return the previously-saved download count
     :return: The saved theme download count, or None if this could not be obtained 
@@ -171,7 +171,7 @@ def set_theme_download_count(template, current_name, new_download_count, verbose
             print("No note for theme            {}".format(file_name))
         return
 
-    previous_download_count = get_previous_download_count_or_none(template, current_name)
+    previous_download_count = get_theme_previous_download_count_or_none(template, current_name)
     if not previous_download_count:
         if verbose:
             print("Cannot read download count   {}".format(file_name))

--- a/.github/scripts/update-releases.py
+++ b/.github/scripts/update-releases.py
@@ -2,11 +2,7 @@
 
 import sys
 import argparse
-import glob
-import os
-import re
 from themes import get_theme_plugin_support, get_theme_settings
-import requests
 
 from utils import (
     THEME_CSS_FILE,
@@ -20,7 +16,8 @@ from utils import (
     get_json_from_github,
     get_plugin_manifest,
 )
-from utils import PLUGINS_JSON_FILE, THEMES_JSON_FILE, OUTPUT_DIR, get_output_dir
+from utils import PLUGINS_JSON_FILE, THEMES_JSON_FILE
+from themes import get_theme_downloads, get_theme_download_count_preferring_previous, update_theme_download_count
 
 
 MOBILE_COMPATIBLE = "[[Mobile-compatible plugins|Yes]]"
@@ -28,20 +25,6 @@ DESKTOP_ONLY = "[[Desktop-only plugins|No]]"
 
 DARK_MODE_THEMES = "[[Dark-mode themes|dark]]"
 LIGHT_MODE_THEMES = "[[Light-mode themes|light]]"
-
-DOWNLOAD_COUNT_SHIELDS_URL_PREFIX = 'https://img.shields.io/badge/downloads-'
-DOWNLOAD_COUNT_SEARCH = re.compile(DOWNLOAD_COUNT_SHIELDS_URL_PREFIX + r"(\d+)-")
-
-
-def get_theme_downloads():
-    theme_downloads: dict = requests.get('https://releases.obsidian.md/stats/theme').json()
-    return theme_downloads
-
-
-def get_url_pattern_for_downloads_shield(placeholder_for_download_count):
-    old_text = f"{DOWNLOAD_COUNT_SHIELDS_URL_PREFIX}{placeholder_for_download_count}-"
-    return old_text
-
 
 def process_released_plugins(overwrite=False, verbose=False):
     print("-----\nProcessing plugins....\n")
@@ -129,83 +112,6 @@ def process_released_themes(overwrite=False, verbose=False):
     print_file_summary(file_groups)
 
     return designers
-
-
-def get_theme_download_count_preferring_previous(template, theme_downloads, current_name):
-    previous_download_count = get_theme_previous_download_count_or_none(template, current_name)
-    if previous_download_count:
-        return previous_download_count
-
-    return get_theme_current_download_count(theme_downloads, current_name)
-
-
-def get_theme_current_download_count(theme_downloads, current_name):
-    return theme_downloads[current_name]["download"]
-
-
-def get_theme_previous_download_count_or_none(template, current_name):
-    """
-    Read the theme file from disk, and return the previously-saved download count
-    :return: The saved theme download count, or None if this could not be obtained 
-    """
-    file_name = get_output_dir(template, current_name)
-    if not os.path.exists(file_name):
-        # This is a new theme, so we don't yet have a previous download count:
-        return None
-
-    with open(file_name) as file:
-        contents = file.read()
-        result = DOWNLOAD_COUNT_SEARCH.search(contents)
-        if not result:
-            # We could not extract the previous download count.
-            # Perhaps the URL in the theme template has been modified?
-            return None
-        return int(result.group(1))
-
-
-def set_theme_download_count(template, current_name, new_download_count, verbose):
-    file_name = get_output_dir(template, current_name)
-
-    if not os.path.exists(file_name):
-        if verbose:
-            print("No note for theme            {}".format(file_name))
-        return
-
-    previous_download_count = get_theme_previous_download_count_or_none(template, current_name)
-    if not previous_download_count:
-        if verbose:
-            print("Cannot read download count   {}".format(file_name))
-        return
-
-    # If the download count has decreased, there is something gone fundamentally wrong:
-    assert new_download_count >= previous_download_count
-
-    if new_download_count == previous_download_count:
-        if verbose:
-            print("Download count unchanged     {}".format(file_name))
-        return
-
-    # This is a bit hacky, as the call to get_previous_download_count_or_none()
-    # already read the file. However, this code is so very fast to run
-    # that, for simplicity, it's easier to just re-read the file for now.
-    with open(file_name) as file:
-        old_contents = file.read()
-
-    old_text = get_url_pattern_for_downloads_shield(previous_download_count)
-    new_text = get_url_pattern_for_downloads_shield(new_download_count)
-    new_contents = old_contents.replace(old_text, new_text)
-    assert new_contents != old_contents
-
-    with open(file_name, 'w') as file:
-        file.write(new_contents)
-
-    if verbose:
-        print("Download count updated       {} - {} -> {}".format(file_name, previous_download_count, new_download_count))
-
-
-def update_theme_download_count(template, theme_downloads, current_name, verbose):
-    download_count = get_theme_current_download_count(theme_downloads, current_name)
-    set_theme_download_count(template, current_name, download_count, verbose)
 
 
 def get_uncategorized_plugins(overwrite=True, verbose=False):

--- a/.github/scripts/update-releases.py
+++ b/.github/scripts/update-releases.py
@@ -186,12 +186,11 @@ def set_theme_download_count(template, current_name, new_download_count, verbose
         return
 
     # This is a bit hacky, as the call to get_previous_download_count_or_none()
-    # already read the file. However, this code is so very fast to run,
-    # that for simplicity, it's easier to just re-read the file for now.
+    # already read the file. However, this code is so very fast to run
+    # that, for simplicity, it's easier to just re-read the file for now.
     with open(file_name) as file:
         old_contents = file.read()
 
-    # TODO Remove the repetition of URL - see also DOWNLOAD_COUNT_SEARCH
     old_text = get_url_pattern_for_downloads_shield(previous_download_count)
     new_text = get_url_pattern_for_downloads_shield(new_download_count)
     new_contents = old_contents.replace(old_text, new_text)


### PR DESCRIPTION
<!-- Add a small description here of the changes you added -->

- Theme download counts are now only updated when new `--update-download-counts` is supplied
- The existing `--themes` argument now preserves the previous theme count, making updates easier to review

If this is OK, I'll later update the wiki instructions:
https://github.com/obsidian-community/obsidian-hub/wiki/Updating-Extensions

## Checklist

- [x] I have renamed all attached images with descriptive file names (or I did not include any images)
- [x] Before creating a new note, I searched the vault (or I only edited existing notes)
