### PR TITLE
Fix line height of h1

### DIFF
--- a/publish.css
+++ b/publish.css
@@ -2,6 +2,10 @@
 	display: none;
 }
 
+.markdown-preview-view h1{
+	line-height: 2.1em;
+}
+
 .site-body-left-column-site-logo {
 	max-width: 120px;
 }


### PR DESCRIPTION
My OCD coerced me to fix this 🙈 

before:
<img width="635" alt="Screenshot 2021-12-02 19 09 10" src="https://user-images.githubusercontent.com/73286100/144479226-9422d986-dda5-4e10-85c1-bad94c2dd3ae.png">

after:
<img width="632" alt="Screenshot 2021-12-02 19 12 03" src="https://user-images.githubusercontent.com/73286100/144479338-992f5c11-86dd-4e51-8533-04651ae13700.png">
