### PR TITLE
Clean Embeds CSS for TTRPG

### DIFF
--- a/04 - Guides, Workflows, & Courses/for TTRPG.md
+++ b/04 - Guides, Workflows, & Courses/for TTRPG.md
@@ -14,17 +14,14 @@ This note collects resources for those using Obsidian for tabletop role-playing 
 
 - [[Obsidian and TTRPG|Obsidian for TTRPG]]
 - [Lazy D&D Talk Show: Obsidian for DM Prep - Slyflourish](https://www.youtube.com/watch?v=Dh1nybxv_vQ&t=235s)
-
-![[apolaine#^052eef]]
-![[nvanderhoevan#^b28090]]
+- ![[apolaine#^052eef|clean+bullet]]
+- ![[nvanderhoevan#^b28090|clean+bullet]]
 
 ## Blog posts
 
 - [Running Tabletop Games with Obsidian — blog.mjb.im](https://blog.mjb.im/running-tabletop-games-with-obsidian)
-
-![[nvanderhoevan#^f5500b]]
-![[nvanderhoevan#^b2167e]]
-
+- ![[nvanderhoevan#^f5500b|clean+bullet]]
+- ![[nvanderhoevan#^b2167e|clean+bullet]]
 
 ## Sample notes and vaults
 

--- a/publish.css
+++ b/publish.css
@@ -44,3 +44,21 @@ button#HH:hover:before {
 
 .external-link[href^="obsidian://goto-plugin?"] { background-image: none; }
 .tooltip { --layer-tooltip: 1; }
+
+
+/* Embed Adjustments */
+.internal-embed[alt*="clean"] .markdown-embed,
+.markdown-preview-view .internal-embed[alt*="clean"]:not(.image-embed),
+.internal-embed[alt*="clean"] .markdown-embed .markdown-preview-view {
+    border: 0;
+    margin: 0;
+    padding: 0;
+}
+
+/*Fix Embed Link Icon Alignment*/
+.internal-embed[alt*="clean"] .markdown-embed-link { top: 0px; }
+/*Hide Embed Link Icon Unless Hovered*/
+.internal-embed[alt*="clean"]:not(:hover) .markdown-embed-link { display: none; }
+
+/*"Hide" Bullet*/
+.internal-embed[alt*="bullet"] .markdown-embed ul { padding-inline-start: 0; }

--- a/publish.css
+++ b/publish.css
@@ -41,6 +41,7 @@ button#HH:hover:before {
 	padding: 20px;
 	z-index: 5;
 }
+body:not(.popover.is-loaded) button#HH:hover:before { margin-left: -2vh; }
 
 .external-link[href^="obsidian://goto-plugin?"] { background-image: none; }
 .tooltip { --layer-tooltip: 1; }


### PR DESCRIPTION
- Added the embed adjustments to the publish css
- Uses `![[|clean]]` to remove embed padding & borders, also only shows embed link icon when hovering over the embed
- Uses `![[|bullet]]` to move over the bullet
- Fixed TTRPG page's embedded block links to use CSS

Should look far better now:
![Obsidian_ma5XPENOrw](https://user-images.githubusercontent.com/54087190/144658671-0b3dd0ab-ebb5-4d9d-9025-d33c1a896e45.png)

