### PR TITLE
Detect inconsistent plugin ids

### DIFF
--- a/.github/scripts/update-releases.py
+++ b/.github/scripts/update-releases.py
@@ -69,12 +69,12 @@ def process_released_plugins(overwrite=False, verbose=False):
 
 def check_ids_match(plugin, manifest, repo, file_groups):
     ids_match = True
-    id_according_to_releases = plugin.get('id')
-    id_according_to_manifest = manifest.get('id')
-    if id_according_to_releases != id_according_to_manifest:
+    releases_id = plugin.get('id')
+    manifest_id = manifest.get('id')
+    if releases_id != manifest_id:
         print(
-            f"ERROR repo:{repo} ID {id_according_to_releases} does not match ID in manifest: {id_according_to_manifest}")
-        file_groups.setdefault("error", list()).append(f"{id_according_to_releases}/{id_according_to_manifest}")
+            f"ERROR repo:{repo} ID {releases_id} does not match ID in manifest: {manifest_id}")
+        file_groups.setdefault("error", list()).append(f"{releases_id}/{manifest_id}")
         ids_match = False
     return ids_match
 

--- a/.github/scripts/update-releases.py
+++ b/.github/scripts/update-releases.py
@@ -41,6 +41,18 @@ def process_released_plugins(overwrite=False, verbose=False):
         repo = plugin.get("repo")
         branch = plugin.get("branch", "master")
         manifest = get_plugin_manifest(repo, branch)
+
+        ids_match = True
+        id_according_to_releases = plugin.get('id')
+        id_according_to_manifest = manifest.get('id')
+        if id_according_to_releases != id_according_to_manifest:
+            print(f"ERROR repo:{repo} ID {id_according_to_releases} does not match ID in manifest: {id_according_to_manifest}")
+            file_groups.setdefault("error", list()).append(f"{id_according_to_releases}/{id_according_to_manifest}")
+            ids_match = False
+
+        if not ids_match:
+            continue
+
         user = repo.split("/")[0]
         if manifest.get("isDesktopOnly"):
             mobile = DESKTOP_ONLY

--- a/.github/scripts/update-releases.py
+++ b/.github/scripts/update-releases.py
@@ -42,9 +42,7 @@ def process_released_plugins(overwrite=False, verbose=False):
         branch = plugin.get("branch", "master")
         manifest = get_plugin_manifest(repo, branch)
 
-        ids_match = check_ids_match(plugin, manifest, repo, file_groups)
-
-        if not ids_match:
+        if not check_ids_match(plugin, manifest, repo, file_groups):
             continue
 
         user = repo.split("/")[0]

--- a/.github/scripts/update-releases.py
+++ b/.github/scripts/update-releases.py
@@ -42,13 +42,7 @@ def process_released_plugins(overwrite=False, verbose=False):
         branch = plugin.get("branch", "master")
         manifest = get_plugin_manifest(repo, branch)
 
-        ids_match = True
-        id_according_to_releases = plugin.get('id')
-        id_according_to_manifest = manifest.get('id')
-        if id_according_to_releases != id_according_to_manifest:
-            print(f"ERROR repo:{repo} ID {id_according_to_releases} does not match ID in manifest: {id_according_to_manifest}")
-            file_groups.setdefault("error", list()).append(f"{id_according_to_releases}/{id_according_to_manifest}")
-            ids_match = False
+        ids_match = check_ids_match(plugin, manifest, repo, file_groups)
 
         if not ids_match:
             continue
@@ -73,6 +67,18 @@ def process_released_plugins(overwrite=False, verbose=False):
     print_file_summary(file_groups)
 
     return devs
+
+
+def check_ids_match(plugin, manifest, repo, file_groups):
+    ids_match = True
+    id_according_to_releases = plugin.get('id')
+    id_according_to_manifest = manifest.get('id')
+    if id_according_to_releases != id_according_to_manifest:
+        print(
+            f"ERROR repo:{repo} ID {id_according_to_releases} does not match ID in manifest: {id_according_to_manifest}")
+        file_groups.setdefault("error", list()).append(f"{id_according_to_releases}/{id_according_to_manifest}")
+        ids_match = False
+    return ids_match
 
 
 def process_released_themes(overwrite=False, verbose=False):

--- a/.github/scripts/utils.py
+++ b/.github/scripts/utils.py
@@ -125,6 +125,7 @@ def format_link(note_name, alias=None):
 
 def print_file_summary(file_groups, verbose=False):
     messages = {
+        "error": "has an error, so was ignored.",
         "exists": "exist but no changes were detected.",
         "modified": "exist, but file contents and filled out template don't match.",
         "new": "were newly created.",


### PR DESCRIPTION
<!-- Add a small description here of the changes you added -->

- If a plugin's ID is different in `community-plugins.json` and the plugin's own `manifest.json`, then write an error and skip the plugin, to avoid potentially writing content to an incorrect location.

