### PR TITLE
Fix copy-and-paste error s/Plugins/Themes/ in Themes section

### DIFF
--- a/01 - Community/Events/Gems of the Year 2021.md
+++ b/01 - Community/Events/Gems of the Year 2021.md
@@ -56,7 +56,7 @@ Please provide the following information:
 
 ##### Themes
 
-Nominate your favorite theme. The theme needs to be in the community store to qualify. Plugins that have won in the past years cannot enter again either (namely, Minimal and Blue Topaz).
+Nominate your favorite theme. The theme needs to be in the community store to qualify. Themes that have won in the past years cannot enter again either (namely, Minimal and Blue Topaz).
 
 Please provide the following information:
 


### PR DESCRIPTION
Typo kindly spotted by @jdanielmourao

> In the new event page, in the Themes section, it's written "Plugins that have won" instead of "Themes that have won". I'm not on my pc so I can't PR a change.

