### PR TITLE
Refactor update-releases.py, extracting functions and moving them to plugins.py and themes.py

### DIFF
--- a/.github/scripts/plugins.py
+++ b/.github/scripts/plugins.py
@@ -162,6 +162,22 @@ def get_core_plugins():
         md_file.write(new_contents)
 
 
+def validate_plugin(plugin, manifest, repo, file_groups):
+    return validate_plugin_ids(plugin, manifest, repo, file_groups)
+
+
+def validate_plugin_ids(plugin, manifest, repo, file_groups):
+    ids_match = True
+    releases_id = plugin.get('id')
+    manifest_id = manifest.get('id')
+    if releases_id != manifest_id:
+        print(
+            f"ERROR repo:{repo} ID {releases_id} does not match ID in manifest: {manifest_id}")
+        file_groups.setdefault("error", list()).append(f"{releases_id}/{manifest_id}")
+        ids_match = False
+    return ids_match
+
+
 def main(argv=sys.argv[1:]):
     get_core_plugins()
 

--- a/.github/scripts/themes.py
+++ b/.github/scripts/themes.py
@@ -6,8 +6,10 @@ import requests
 from plugins import CORE_PLUGINS
 from utils import (
     PLUGINS_JSON_FILE,
+    THEME_CSS_FILE,
     get_json_from_github,
-    get_output_dir
+    get_output_dir,
+    get_theme_css
 )
 
 settings_regex = r"\/\*\s*@settings[\r\n]+?([\s\S]+?)\*\/"
@@ -15,6 +17,9 @@ plugins_regex = r"\/\*\s*@plugins[\r\n]+?([\s\S]+?)\*\/"
 
 DOWNLOAD_COUNT_SHIELDS_URL_PREFIX = 'https://img.shields.io/badge/downloads-'
 DOWNLOAD_COUNT_SEARCH = re.compile(DOWNLOAD_COUNT_SHIELDS_URL_PREFIX + r"(\d+)-")
+
+DARK_MODE_THEMES = "[[Dark-mode themes|dark]]"
+LIGHT_MODE_THEMES = "[[Light-mode themes|light]]"
 
 
 def get_theme_settings(theme_css):
@@ -129,6 +134,41 @@ def get_theme_downloads():
 def get_url_pattern_for_downloads_shield(placeholder_for_download_count):
     old_text = f"{DOWNLOAD_COUNT_SHIELDS_URL_PREFIX}{placeholder_for_download_count}-"
     return old_text
+
+
+def collect_data_for_theme(theme, theme_downloads, template):
+    """
+    Take raw plugin data from a community theme, and add information to it.
+
+    :param theme: A dict with data about the theme, to be updated by this function
+    :param theme_downloads: The download count of all themes
+    :param template: The template used for writing themes - needed to obtain the location of existing themes
+    :return: The name of the theme
+    """
+    repo = theme.get("repo")
+    user = repo.split("/")[0]
+    modes = (
+        ", ".join(theme.get("modes"))
+            .replace("dark", DARK_MODE_THEMES)
+            .replace("light", LIGHT_MODE_THEMES)
+    )
+    branch = theme.get("branch", "master")
+    css_file = get_theme_css(THEME_CSS_FILE.format(repo, branch))
+    settings = get_theme_settings(css_file)
+    plugin_support = get_theme_plugin_support(css_file)
+
+    current_name = theme.get("name")
+    download_count = get_theme_download_count_preferring_previous(template, theme_downloads, current_name)
+
+    theme.update(
+        user=user,
+        modes=modes,
+        branch=branch,
+        settings=settings,
+        plugins=plugin_support,
+        download_count=download_count,
+    )
+    return current_name
 
 
 def get_theme_download_count_preferring_previous(template, theme_downloads, current_name):

--- a/.github/scripts/themes.py
+++ b/.github/scripts/themes.py
@@ -138,7 +138,7 @@ def get_url_pattern_for_downloads_shield(placeholder_for_download_count):
 
 def collect_data_for_theme(theme, theme_downloads, template):
     """
-    Take raw plugin data from a community theme, and add information to it.
+    Take raw theme data from a community theme, and add information to it.
 
     :param theme: A dict with data about the theme, to be updated by this function
     :param theme_downloads: The download count of all themes

--- a/.github/scripts/themes.py
+++ b/.github/scripts/themes.py
@@ -4,7 +4,11 @@ import re
 import requests
 
 from plugins import CORE_PLUGINS
-from utils import PLUGINS_JSON_FILE, get_json_from_github, get_output_dir
+from utils import (
+    PLUGINS_JSON_FILE,
+    get_json_from_github,
+    get_output_dir
+)
 
 settings_regex = r"\/\*\s*@settings[\r\n]+?([\s\S]+?)\*\/"
 plugins_regex = r"\/\*\s*@plugins[\r\n]+?([\s\S]+?)\*\/"

--- a/.github/scripts/update-releases.py
+++ b/.github/scripts/update-releases.py
@@ -42,7 +42,7 @@ def process_released_plugins(overwrite=False, verbose=False):
         branch = plugin.get("branch", "master")
         manifest = get_plugin_manifest(repo, branch)
 
-        if not check_ids_match(plugin, manifest, repo, file_groups):
+        if not validate_plugin_ids(plugin, manifest, repo, file_groups):
             continue
 
         user = repo.split("/")[0]
@@ -67,7 +67,7 @@ def process_released_plugins(overwrite=False, verbose=False):
     return devs
 
 
-def check_ids_match(plugin, manifest, repo, file_groups):
+def validate_plugin_ids(plugin, manifest, repo, file_groups):
     ids_match = True
     releases_id = plugin.get('id')
     manifest_id = manifest.get('id')

--- a/.github/scripts/update-releases.py
+++ b/.github/scripts/update-releases.py
@@ -42,7 +42,7 @@ def process_released_plugins(overwrite=False, verbose=False):
         branch = plugin.get("branch", "master")
         manifest = get_plugin_manifest(repo, branch)
 
-        if not validate_plugin_ids(plugin, manifest, repo, file_groups):
+        if not validate_plugin(plugin, manifest, repo, file_groups):
             continue
 
         user = repo.split("/")[0]
@@ -65,6 +65,11 @@ def process_released_plugins(overwrite=False, verbose=False):
     print_file_summary(file_groups)
 
     return devs
+
+
+def validate_plugin(plugin, manifest, repo, file_groups):
+    xxx = validate_plugin_ids(plugin, manifest, repo, file_groups)
+    return xxx
 
 
 def validate_plugin_ids(plugin, manifest, repo, file_groups):

--- a/.github/scripts/update-releases.py
+++ b/.github/scripts/update-releases.py
@@ -3,6 +3,7 @@
 import sys
 import argparse
 from themes import get_theme_plugin_support, get_theme_settings
+from plugins import validate_plugin
 
 from utils import (
     THEME_CSS_FILE,
@@ -65,22 +66,6 @@ def process_released_plugins(overwrite=False, verbose=False):
     print_file_summary(file_groups)
 
     return devs
-
-
-def validate_plugin(plugin, manifest, repo, file_groups):
-    return validate_plugin_ids(plugin, manifest, repo, file_groups)
-
-
-def validate_plugin_ids(plugin, manifest, repo, file_groups):
-    ids_match = True
-    releases_id = plugin.get('id')
-    manifest_id = manifest.get('id')
-    if releases_id != manifest_id:
-        print(
-            f"ERROR repo:{repo} ID {releases_id} does not match ID in manifest: {manifest_id}")
-        file_groups.setdefault("error", list()).append(f"{releases_id}/{manifest_id}")
-        ids_match = False
-    return ids_match
 
 
 def process_released_themes(overwrite=False, verbose=False):

--- a/.github/scripts/update-releases.py
+++ b/.github/scripts/update-releases.py
@@ -44,8 +44,6 @@ def process_released_plugins(overwrite=False, verbose=False):
         manifest = get_plugin_manifest(repo, branch)
 
         plugin_is_valid = validate_plugin(plugin, manifest, repo, file_groups)
-        if not plugin_is_valid:
-            continue
 
         user = repo.split("/")[0]
         if manifest.get("isDesktopOnly"):
@@ -54,6 +52,10 @@ def process_released_plugins(overwrite=False, verbose=False):
             mobile = MOBILE_COMPATIBLE
 
         plugin.update(mobile=mobile, user=user, **manifest)
+
+        if not plugin_is_valid:
+            continue
+
         group = write_file(
             template, plugin.get("id"), overwrite=overwrite, verbose=verbose, **plugin
         )

--- a/.github/scripts/update-releases.py
+++ b/.github/scripts/update-releases.py
@@ -2,26 +2,19 @@
 
 import sys
 import argparse
-from themes import get_theme_plugin_support, get_theme_settings
 from plugins import collect_data_for_plugin
 
 from utils import (
-    THEME_CSS_FILE,
     format_link,
     get_category_files,
     get_template,
-    get_theme_css,
     print_file_summary,
     print_progress_bar,
     write_file,
     get_json_from_github,
 )
 from utils import PLUGINS_JSON_FILE, THEMES_JSON_FILE
-from themes import get_theme_downloads, get_theme_download_count_preferring_previous, update_theme_download_count
-
-
-DARK_MODE_THEMES = "[[Dark-mode themes|dark]]"
-LIGHT_MODE_THEMES = "[[Light-mode themes|light]]"
+from themes import get_theme_downloads, update_theme_download_count, collect_data_for_theme
 
 def process_released_plugins(overwrite=False, verbose=False):
     print("-----\nProcessing plugins....\n")
@@ -82,41 +75,6 @@ def process_released_themes(overwrite=False, verbose=False):
     print_file_summary(file_groups)
 
     return designers
-
-
-def collect_data_for_theme(theme, theme_downloads, template):
-    """
-    Take raw plugin data from a community theme, and add information to it.
-
-    :param theme: A dict with data about the theme, to be updated by this function
-    :param theme_downloads: The download count of all themes
-    :param template: The template used for writing themes - needed to obtain the location of existing themes
-    :return: The name of the theme
-    """
-    repo = theme.get("repo")
-    user = repo.split("/")[0]
-    modes = (
-        ", ".join(theme.get("modes"))
-            .replace("dark", DARK_MODE_THEMES)
-            .replace("light", LIGHT_MODE_THEMES)
-    )
-    branch = theme.get("branch", "master")
-    css_file = get_theme_css(THEME_CSS_FILE.format(repo, branch))
-    settings = get_theme_settings(css_file)
-    plugin_support = get_theme_plugin_support(css_file)
-
-    current_name = theme.get("name")
-    download_count = get_theme_download_count_preferring_previous(template, theme_downloads, current_name)
-
-    theme.update(
-        user=user,
-        modes=modes,
-        branch=branch,
-        settings=settings,
-        plugins=plugin_support,
-        download_count=download_count,
-    )
-    return current_name
 
 
 def get_uncategorized_plugins(overwrite=True, verbose=False):

--- a/.github/scripts/update-releases.py
+++ b/.github/scripts/update-releases.py
@@ -16,6 +16,7 @@ from utils import (
 from utils import PLUGINS_JSON_FILE, THEMES_JSON_FILE
 from themes import get_theme_downloads, update_theme_download_count, collect_data_for_theme
 
+
 def process_released_plugins(overwrite=False, verbose=False):
     print("-----\nProcessing plugins....\n")
     template = get_template("plugin")
@@ -202,7 +203,6 @@ def main(argv=sys.argv[1:]):
         help="Only update the download counts in existing themes. "
              "This ignores the overwrite argument, and always updates.",
     )
-
 
     args = parser.parse_args(argv)
 

--- a/.github/scripts/update-releases.py
+++ b/.github/scripts/update-releases.py
@@ -3,7 +3,7 @@
 import sys
 import argparse
 from themes import get_theme_plugin_support, get_theme_settings
-from plugins import validate_plugin
+from plugins import collect_data_for_plugin
 
 from utils import (
     THEME_CSS_FILE,
@@ -15,14 +15,10 @@ from utils import (
     print_progress_bar,
     write_file,
     get_json_from_github,
-    get_plugin_manifest,
 )
 from utils import PLUGINS_JSON_FILE, THEMES_JSON_FILE
 from themes import get_theme_downloads, get_theme_download_count_preferring_previous, update_theme_download_count
 
-
-MOBILE_COMPATIBLE = "[[Mobile-compatible plugins|Yes]]"
-DESKTOP_ONLY = "[[Desktop-only plugins|No]]"
 
 DARK_MODE_THEMES = "[[Dark-mode themes|dark]]"
 LIGHT_MODE_THEMES = "[[Light-mode themes|light]]"
@@ -57,32 +53,6 @@ def process_released_plugins(overwrite=False, verbose=False):
     print_file_summary(file_groups)
 
     return devs
-
-
-def collect_data_for_plugin(plugin, file_groups):
-    """
-    Take raw plugin data from a community plugin, and add information to it,
-    typically from its manifest file.
-
-    :param plugin: A dict with data about the plugin, to be updated by this function
-    :param file_groups: Place to store error message if the plugin is invalid
-    :return: Whether the plugin is valid, and is OK to be added to the Hub
-    """
-    repo = plugin.get("repo")
-    branch = plugin.get("branch", "master")
-    manifest = get_plugin_manifest(repo, branch)
-
-    plugin_is_valid = validate_plugin(plugin, manifest, repo, file_groups)
-
-    user = repo.split("/")[0]
-    if manifest.get("isDesktopOnly"):
-        mobile = DESKTOP_ONLY
-    else:
-        mobile = MOBILE_COMPATIBLE
-
-    plugin.update(mobile=mobile, user=user, **manifest)
-
-    return plugin_is_valid
 
 
 def process_released_themes(overwrite=False, verbose=False):

--- a/.github/scripts/update-releases.py
+++ b/.github/scripts/update-releases.py
@@ -99,29 +99,7 @@ def process_released_themes(overwrite=False, verbose=False):
     theme_downloads = get_theme_downloads()
 
     for theme in theme_list:
-        repo = theme.get("repo")
-        user = repo.split("/")[0]
-        modes = (
-            ", ".join(theme.get("modes"))
-            .replace("dark", DARK_MODE_THEMES)
-            .replace("light", LIGHT_MODE_THEMES)
-        )
-        branch = theme.get("branch", "master")
-        css_file = get_theme_css(THEME_CSS_FILE.format(repo, branch))
-        settings = get_theme_settings(css_file)
-        plugin_support = get_theme_plugin_support(css_file)
-
-        current_name = theme.get("name")
-        download_count = get_theme_download_count_preferring_previous(template, theme_downloads, current_name)
-
-        theme.update(
-            user=user,
-            modes=modes,
-            branch=branch,
-            settings=settings,
-            plugins=plugin_support,
-            download_count= download_count,
-        )
+        current_name = collect_data_for_theme(theme, theme_downloads, template)
         group = write_file(
             template, current_name, overwrite=overwrite, verbose=verbose, **theme
         )
@@ -134,6 +112,41 @@ def process_released_themes(overwrite=False, verbose=False):
     print_file_summary(file_groups)
 
     return designers
+
+
+def collect_data_for_theme(theme, theme_downloads, template):
+    """
+    Take raw plugin data from a community theme, and add information to it.
+
+    :param theme: A dict with data about the theme, to be updated by this function
+    :param theme_downloads: The download count of all themes
+    :param template: The template used for writing themes - needed to obtain the location of existing themes
+    :return: The name of the theme
+    """
+    repo = theme.get("repo")
+    user = repo.split("/")[0]
+    modes = (
+        ", ".join(theme.get("modes"))
+            .replace("dark", DARK_MODE_THEMES)
+            .replace("light", LIGHT_MODE_THEMES)
+    )
+    branch = theme.get("branch", "master")
+    css_file = get_theme_css(THEME_CSS_FILE.format(repo, branch))
+    settings = get_theme_settings(css_file)
+    plugin_support = get_theme_plugin_support(css_file)
+
+    current_name = theme.get("name")
+    download_count = get_theme_download_count_preferring_previous(template, theme_downloads, current_name)
+
+    theme.update(
+        user=user,
+        modes=modes,
+        branch=branch,
+        settings=settings,
+        plugins=plugin_support,
+        download_count=download_count,
+    )
+    return current_name
 
 
 def get_uncategorized_plugins(overwrite=True, verbose=False):

--- a/.github/scripts/update-releases.py
+++ b/.github/scripts/update-releases.py
@@ -68,8 +68,7 @@ def process_released_plugins(overwrite=False, verbose=False):
 
 
 def validate_plugin(plugin, manifest, repo, file_groups):
-    xxx = validate_plugin_ids(plugin, manifest, repo, file_groups)
-    return xxx
+    return validate_plugin_ids(plugin, manifest, repo, file_groups)
 
 
 def validate_plugin_ids(plugin, manifest, repo, file_groups):

--- a/.github/scripts/update-releases.py
+++ b/.github/scripts/update-releases.py
@@ -43,7 +43,8 @@ def process_released_plugins(overwrite=False, verbose=False):
         branch = plugin.get("branch", "master")
         manifest = get_plugin_manifest(repo, branch)
 
-        if not validate_plugin(plugin, manifest, repo, file_groups):
+        plugin_is_valid = validate_plugin(plugin, manifest, repo, file_groups)
+        if not plugin_is_valid:
             continue
 
         user = repo.split("/")[0]

--- a/.github/scripts/update-releases.py
+++ b/.github/scripts/update-releases.py
@@ -39,19 +39,7 @@ def process_released_plugins(overwrite=False, verbose=False):
         0, len(plugin_list),
     )
     for plugin in plugin_list:
-        repo = plugin.get("repo")
-        branch = plugin.get("branch", "master")
-        manifest = get_plugin_manifest(repo, branch)
-
-        plugin_is_valid = validate_plugin(plugin, manifest, repo, file_groups)
-
-        user = repo.split("/")[0]
-        if manifest.get("isDesktopOnly"):
-            mobile = DESKTOP_ONLY
-        else:
-            mobile = MOBILE_COMPATIBLE
-
-        plugin.update(mobile=mobile, user=user, **manifest)
+        plugin_is_valid = collect_data_for_plugin(plugin, file_groups)
 
         if not plugin_is_valid:
             continue
@@ -69,6 +57,32 @@ def process_released_plugins(overwrite=False, verbose=False):
     print_file_summary(file_groups)
 
     return devs
+
+
+def collect_data_for_plugin(plugin, file_groups):
+    """
+    Take raw plugin data from a community plugin, and add information to it,
+    typically from its manifest file.
+
+    :param plugin: A dict with data about the plugin, to be updated by this function
+    :param file_groups: Place to store error message if the plugin is invalid
+    :return: Whether the plugin is valid, and is OK to be added to the Hub
+    """
+    repo = plugin.get("repo")
+    branch = plugin.get("branch", "master")
+    manifest = get_plugin_manifest(repo, branch)
+
+    plugin_is_valid = validate_plugin(plugin, manifest, repo, file_groups)
+
+    user = repo.split("/")[0]
+    if manifest.get("isDesktopOnly"):
+        mobile = DESKTOP_ONLY
+    else:
+        mobile = MOBILE_COMPATIBLE
+
+    plugin.update(mobile=mobile, user=user, **manifest)
+
+    return plugin_is_valid
 
 
 def process_released_themes(overwrite=False, verbose=False):


### PR DESCRIPTION
<!-- Add a small description here of the changes you added -->

This is a series of pure refactorings, that is, there is absolutely no change in behaviour of behaviour.

It's 12 un-interesting refactorings, all of which were automated except the ones that moved functions from one file to another, as PyCharm was complaining it couldn't update the imports automatically, so refused to move the functions automatically.

The end result is:

- `process_released_plugins()` and `process_released_themes()` are rather shorter 
- their code for processing individual extensions having been moved to plugins.py and themes.py

The output files of `./update-releases.py --all --overwrite` are unchanged - and the tests still pass.

This is preparation for later steps that will reduce the need for reverting changes when updating extensions, such as fixing #143

