### PR TITLE
Remove "Apple Reminders" from "Plugins Designed for Mobile"

### DIFF
--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins Designed for Mobile.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins Designed for Mobile.md
@@ -14,7 +14,6 @@ Special plugins for the Obsidian mobile app.
 ## Plugins in this category
 
 - [[advanced-toolbar|Advanced Mobile Toolbar]]
-- [[obsidian-apple-reminders-plugin|Apple Reminders]]
 - [[customjs|CustomJS]]
 
 ## Related categories


### PR DESCRIPTION
- Remove "Apple Reminders" from "Plugins Designed for Mobile"

It doesn't run on mobile.
Spotted by user Epiphanic Synchronicity in Discord.
https://discord.com/channels/686053708261228577/915679988118863933/924886915461812306

## Checklist

- [x] I have renamed all attached images with descriptive file names (or I did not include any images)
- [x] Before creating a new note, I searched the vault (or I only edited existing notes)
- [x] (Optional) In case I created a new note in the folder `04 - Guides, Workflows, & Courses`, I added a link to the new note(s) in one of the `for {group X}` overviews ([listed here](https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses)).
