### PR TITLE
Split plugin and theme templates into smaller modular templates

### DIFF
--- a/.github/scripts/templates/funding.md.jinja
+++ b/.github/scripts/templates/funding.md.jinja
@@ -1,0 +1,3 @@
+%% Does the repository or author have any sponsoring links? Uncomment the next line and add them to the author's note. If they don't, please delete the placeholder tag: #placeholder/author %%
+%% ![[{{ user }}#Sponsor this author]] %%
+

--- a/.github/scripts/templates/plugin.md.jinja
+++ b/.github/scripts/templates/plugin.md.jinja
@@ -1,34 +1,11 @@
----
-plugin-id: {{id}}
-aliases:
-- {{name}}
-tags: 
-- 
-publish: true
----
+{% include "plugins/frontmatter.md.jinja" %}
 
-%% ----- Badges ----- %%
 
-![GitHub all releases](https://img.shields.io/github/downloads/{{repo}}/total?color=573E7A&logo=github&style=for-the-badge)   
-![GitHub manifest version](https://img.shields.io/github/manifest-json/v/{{repo}}?color=573E7A&logo=github&style=for-the-badge)   
-![GitHub issues by-label](https://img.shields.io/github/issues/{{repo}}/help%20wanted?color=573E7A&logo=github&style=for-the-badge)   
-![GitHub Repo stars](https://img.shields.io/github/stars/{{repo}}?color=573E7A&logo=github&style=for-the-badge)
+{% include "plugins/badges.md.jinja" %}
 
-%% ----- Badges ----- %%
 
-%% ----- Do not edit this section ----- %%
+{% include "plugins/plugin_info.md.jinja" %}
 
-# {{name}}
 
-Plugin ID: `{{id}}`
-Links: [GitHub repository](https://github.com/{{repo}}) or [<button id=HH>Open in Obsidian</button>](obsidian://goto-plugin?id={{id}})
-Developed by: [[{{user}}]]
-Mobile compatible: {{mobile}}
-
-{{description}}
-
-%% ----- Do not edit anything above this line ----- %% 
-
-%% Does the repository or author have any sponsoring links? Uncomment the next line and add them to the author's note. If they don't, please delete the placeholder tag: #placeholder/author %%
-%% ![[{{ user }}#Sponsor this author]] %%
+{% include "funding.md.jinja" %}
 

--- a/.github/scripts/templates/plugins/badges.md.jinja
+++ b/.github/scripts/templates/plugins/badges.md.jinja
@@ -1,0 +1,8 @@
+%% ----- Badges ----- %%
+
+![GitHub all releases](https://img.shields.io/github/downloads/{{repo}}/total?color=573E7A&logo=github&style=for-the-badge)   
+![GitHub manifest version](https://img.shields.io/github/manifest-json/v/{{repo}}?color=573E7A&logo=github&style=for-the-badge)   
+![GitHub issues by-label](https://img.shields.io/github/issues/{{repo}}/help%20wanted?color=573E7A&logo=github&style=for-the-badge)   
+![GitHub Repo stars](https://img.shields.io/github/stars/{{repo}}?color=573E7A&logo=github&style=for-the-badge)
+
+%% ----- Badges ----- %%

--- a/.github/scripts/templates/plugins/frontmatter.md.jinja
+++ b/.github/scripts/templates/plugins/frontmatter.md.jinja
@@ -1,0 +1,8 @@
+---
+plugin-id: {{id}}
+aliases:
+- {{name}}
+tags: 
+- 
+publish: true
+---

--- a/.github/scripts/templates/plugins/plugin_info.md.jinja
+++ b/.github/scripts/templates/plugins/plugin_info.md.jinja
@@ -1,0 +1,12 @@
+%% ----- Do not edit this section ----- %%
+
+# {{name}}
+
+Plugin ID: `{{id}}`
+Links: [GitHub repository](https://github.com/{{repo}}) or [<button id=HH>Open in Obsidian</button>](obsidian://goto-plugin?id={{id}})
+Developed by: [[{{user}}]]
+Mobile compatible: {{mobile}}
+
+{{description}}
+
+%% ----- Do not edit anything above this line ----- %% 

--- a/.github/scripts/templates/theme.md.jinja
+++ b/.github/scripts/templates/theme.md.jinja
@@ -1,36 +1,13 @@
----
-aliases:
-- 
-tags: 
-- 
-publish: true
----
+{% include "themes/frontmatter.md.jinja"%}
 
-%% ----- Badges ----- %%
 
-![Downloads](https://img.shields.io/badge/downloads-{{download_count}}-573E7A?style=for-the-badge&logo=)
-![GitHub last commit](https://img.shields.io/github/last-commit/{{repo}}?color=573E7A&label=last%20update&logo=github&style=for-the-badge)
-![GitHub issues by-label](https://img.shields.io/github/issues/{{repo}}/help%20wanted?color=573E7A&logo=github&style=for-the-badge) 
-![GitHub Repo stars](https://img.shields.io/github/stars/{{repo}}?color=573E7A&logo=github&style=for-the-badge)
+{% include "themes/badges.md.jinja" %}
 
-%% ----- Badges ----- %%
 
-%% ----- Do not edit this section ----- %%
+{% include "themes/theme_info.md.jinja" %}
 
-# {{name}}
 
-Repository: [GitHub](https://github.com/{{repo}})
-Designed by: [[{{user}}]]
-Modes: {{modes}}
-
-{{description}}
-
-![screenshot](https://github.com/{{repo}}/raw/{{branch}}/{{screenshot}})
-
-%% ----- Do not edit anything above this line ----- %% 
-
-%% Does the repository or author have any sponsoring links? Uncomment the next line and add them to the author's note. If they don't, please delete the placeholder tag: #placeholder/author %%
-%% ![[{{ user }}#Sponsor this author]] %%
+{% include "funding.md.jinja" %}
 
 
 ## Features
@@ -38,33 +15,13 @@ Modes: {{modes}}
 {% if settings %}
 - [[Themes with Friendly Settings|Friendly settings]]: Supports the [[obsidian-style-settings|Style Settings]] plugin
 
-## Customization Options (Style Settings Plugin) 
-{% for s in settings %}
-{% if s.type == "heading" %}
-
-{{ s.header }}
-{% else %}
-{{ s.title }}
-{% endif %}
-{% endfor %}
+{% include "themes/style_settings.md.jinja" %}
 {% endif %}
 
 {% if plugins %}
 ## Plugin Compatibility[^1]
 
-{% if plugins.core %}
-**Core plugins**:
-{% endif %}
-{% for plugin in plugins.core %}
-- [[{{ plugin }}]]
-{% endfor %}
-{% if plugins.community %}
-
-**Community plugins**:
-{% endif %}
-{% for plugin in plugins.community %}
-- [[{{ plugin }}]]
-{% endfor %}
+{% include "themes/plugin_compatibility.md.jinja" %}
 
 [^1]: Generally, Obsidian themes work with any plugins. That a plugin is not listed here does not mean that it won't work together with the theme. Plugins listed here only received special attention and/or styling by the theme designer.
 {% endif%}

--- a/.github/scripts/templates/themes/badges.md.jinja
+++ b/.github/scripts/templates/themes/badges.md.jinja
@@ -1,0 +1,8 @@
+%% ----- Badges ----- %%
+
+![Downloads](https://img.shields.io/badge/downloads-{{download_count}}-573E7A?style=for-the-badge&logo=)
+![GitHub last commit](https://img.shields.io/github/last-commit/{{repo}}?color=573E7A&label=last%20update&logo=github&style=for-the-badge)
+![GitHub issues by-label](https://img.shields.io/github/issues/{{repo}}/help%20wanted?color=573E7A&logo=github&style=for-the-badge) 
+![GitHub Repo stars](https://img.shields.io/github/stars/{{repo}}?color=573E7A&logo=github&style=for-the-badge)
+
+%% ----- Badges ----- %%

--- a/.github/scripts/templates/themes/frontmatter.md.jinja
+++ b/.github/scripts/templates/themes/frontmatter.md.jinja
@@ -1,0 +1,7 @@
+---
+aliases:
+- 
+tags: 
+- 
+publish: true
+---

--- a/.github/scripts/templates/themes/plugin_compatibility.md.jinja
+++ b/.github/scripts/templates/themes/plugin_compatibility.md.jinja
@@ -1,0 +1,13 @@
+{% if plugins.core %}
+**Core plugins**:
+{% endif %}
+{% for plugin in plugins.core %}
+- [[{{ plugin }}]]
+{% endfor %}
+{% if plugins.community %}
+
+**Community plugins**:
+{% endif %}
+{% for plugin in plugins.community %}
+- [[{{ plugin }}]]
+{% endfor %}

--- a/.github/scripts/templates/themes/style_settings.md.jinja
+++ b/.github/scripts/templates/themes/style_settings.md.jinja
@@ -1,0 +1,9 @@
+## Customization Options (Style Settings Plugin) 
+{% for s in settings %}
+{% if s.type == "heading" %}
+
+{{ s.header }}
+{% else %}
+{{ s.title }}
+{% endif %}
+{% endfor %}

--- a/.github/scripts/templates/themes/theme_info.md.jinja
+++ b/.github/scripts/templates/themes/theme_info.md.jinja
@@ -1,0 +1,13 @@
+%% ----- Do not edit this section ----- %%
+
+# {{name}}
+
+Repository: [GitHub](https://github.com/{{repo}})
+Designed by: [[{{user}}]]
+Modes: {{modes}}
+
+{{description}}
+
+![screenshot](https://github.com/{{repo}}/raw/{{branch}}/{{screenshot}})
+
+%% ----- Do not edit anything above this line ----- %% 


### PR DESCRIPTION
<!-- Add a small description here of the changes you added -->

- The jinja templates are divided into smaller files, which means they can be used to update smaller sections of other templates (e.g. for #166)
- This PR only partially addresses #156 

## Checklist

- [x] I have renamed all attached images with descriptive file names (or I did not include any images)
- [x] Before creating a new note, I searched the vault (or I only edited existing notes)
- [x] (Optional) In case I created a new note in the folder `04 - Guides, Workflows, & Courses`, I added a link to the new note(s) in one of the `for {group X}` overviews ([listed here](https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses)).
