### PR TITLE
Miss typed the link for the People folder

### DIFF
--- a/03 - Showcases & Templates/Vaults/OB_Template.md
+++ b/03 - Showcases & Templates/Vaults/OB_Template.md
@@ -7,7 +7,7 @@ publish: true
 ---
 
 # OB_Template
-Author: [[Zektor|Zektor]]
+Author: [[Zektor]]
 
 %% Add a description below this comment. It doesn't need to be long: one or two sentences should be a good start. 
 


### PR DESCRIPTION
When i created the file i added the connection for the User information under People incorrectly

<!-- Add a small description here of the changes you added -->

- Added/Edited note ...

## Checklist

- [x] I have renamed all attached images with descriptive file names (or I did not include any images)
- [x] Before creating a new note, I searched the vault (or I only edited existing notes)
- [x] (Optional) In case I created a new note in the folder `04 - Guides, Workflows, & Courses`, I added a link to the new note(s) in one of the `for {group X}` overviews ([listed here](https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses)).
