### PR TITLE
Feature: Add edit on GitHub footer (closes #154)

### DIFF
--- a/.github/scripts/add-edit-on-github.py
+++ b/.github/scripts/add-edit-on-github.py
@@ -1,0 +1,79 @@
+from os import walk, getcwd
+from os.path import join
+from utils import get_template
+from re import sub
+
+# The path to the vault. For now set to current working directory, as I assume all scripts are ran from the root path by default
+VAULT_PATH = getcwd()
+
+# Set to False to disable informational logging
+LOG = True
+
+
+def add_edit_on_github():
+    """
+    Walks through the filetree rooted at VAULT_PATH.
+    For each markdown file that it finds, it replaces a particular comment line with the corresponding template.
+    """
+    # Grab the template
+    template = get_template("footer")
+
+    # This is the line to search for
+    comment = r"%% Hub footer: Please don't edit anything below this line %%"
+
+    # Loop through the files
+    for root, _, files in walk(VAULT_PATH, topdown=True):
+        for file in files:
+            # We only care about markdown files
+            # Note: Alternative implementation is to use os.splitext;
+            # both work for this usecase
+            if file.endswith(".md"):
+                # Get the full filepath
+                the_file = join(root, file)
+
+                if LOG:
+                    print(f"Processing '{the_file}'...")
+
+                # Get the rendered template
+                render = template.render(file_path=the_file)
+
+                # Open the file in read/write mode
+                with open(the_file, "r+") as f:
+                    # Read the file contents
+                    contents = f.read()
+
+                    # Create variable holding the replacement text
+                    # By default, don't replace anything
+                    replacement = contents
+
+                    # If the comment is found
+                    if comment in contents:
+                        # And we don't have the entire template yet
+                        if render not in contents:
+                            replacement = sub(comment, render, contents)
+
+                            if LOG:
+                                print("\t=> Replacing the line with the template.")
+
+                    else:
+                        # Comment not found!
+                        replacement = contents + "\n" + render
+
+                        if LOG:
+                            print("\t=> Adding the template.")
+
+                    # Actually write
+                    # This is done by seeking to the beginning of the file
+                    f.seek(0)
+                    # Then writing the replacement string
+                    f.write(replacement)
+                    # And finally truncating the file to close it, and remove possible dangling information (e.g. if replacement is shorter than original contents)
+                    f.truncate()
+
+
+def main():
+    add_edit_on_github()
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/templates/footer.md.jinja
+++ b/.github/scripts/templates/footer.md.jinja
@@ -1,0 +1,7 @@
+%% Hub footer: Please don't edit anything below this line %%
+
+<span class="github-edit-note">[Edit In Github](https://github.dev/obsidian-community/obsidian-hub/blob/{{ file_path }})</span>
+
+<span class="github-copy-note"> [Copy this note](https://raw.githubusercontent.com/obsidian-community/obsidian-hub/main/{{ file_path }})</span>
+
+<span class="github-vault-download">[Download this vault](https://github.com/obsidian-community/obsidian-hub/archive/refs/heads/main.zip)</span>

--- a/.github/scripts/utils.py
+++ b/.github/scripts/utils.py
@@ -19,13 +19,34 @@ OUTPUT_DIR = {
 }
 
 
-def get_template(template_name):
+def get_template(template_name: str):
+    """
+    Gets a particular template with template_name as name.
+    """
+    # Default templates directory
     directory = "./templates"
-    template_file_name = "{}.md.jinja".format(template_name)
+
+    # Grab the current working directory to figure out where the template dir is.
+    cwd = os.getcwd()
+    if cwd.endswith("obsidian-hub"):
+        # We're in root. Need to go down into .github/scripts/templates
+        directory = os.path.join(cwd, ".github", "scripts", "templates")
+    if cwd.endswith("github"):
+        # We're in .github. Need to do down into scripts/templates
+        directory = os.path.join(cwd, "scripts", "templates")
+    if cwd.endswith("scripts"):
+        # We're in scripts. Need to go down into templates
+        directory = os.path.join(cwd, "templates")
+    if cwd.endswith("templates"):
+        # We're already there. Current directory.
+        directory = cwd
+
+    # Construct the filename and return the template
+    template_file_name = f"{template_name}.md.jinja"
     return get_template_from_directory(directory, template_file_name)
 
 
-def get_template_from_directory(directory, template_name_with_extensions):
+def get_template_from_directory(directory: str, template_name_with_extensions: str):
     file_loader = FileSystemLoader(directory)
     # A note on writing templates...
     # trim_blocks and lstrip_blocks remove a lot of whitespace.
@@ -112,7 +133,8 @@ def get_plugin_manifest(repository, branch):
 
 def get_category_files():
     return glob.glob(
-        os.path.abspath(os.path.join("../..", OUTPUT_DIR["category"])) + "/*.md"
+        os.path.abspath(os.path.join(
+            "../..", OUTPUT_DIR["category"])) + "/*.md"
     )
 
 
@@ -153,7 +175,7 @@ def print_progress_bar(
     Call in a loop to create terminal progress bar
 
     Source: https://stackoverflow.com/questions/3173320/text-progress-bar-in-the-console
-    
+
     @params:
         iteration   - Required  : current iteration (Int)
         total       - Required  : total iterations (Int)
@@ -164,7 +186,8 @@ def print_progress_bar(
         fill        - Optional  : bar fill character (Str)
         printEnd    - Optional  : end character (e.g. "\r", "\r\n") (Str)
     """
-    percent = ("{0:." + str(decimals) + "f}").format(100 * (iteration / float(total)))
+    percent = ("{0:." + str(decimals) + "f}").format(100 *
+                                                     (iteration / float(total)))
     filledLength = int(length * iteration // total)
     bar = fill * filledLength + "-" * (length - filledLength)
     print(f"\r{prefix} |{bar}| {percent}% {suffix}", end=printEnd)


### PR DESCRIPTION
- [x] Add `# This note in GitHub` into jinja template.
- [x] For each MD note: change `![[note]]` to ``![[note#header]]`` this.
- [x] Fix spaces in jinja template.
- [ ] Add tests for the script.
- [x] Exclude `.github` directory.
- [x] Exclude `DO NOT COMMIT` directory.
- [x] HTML-encode file and folder names in links.
- [x] Provide relative paths in stead of absolute ones for template.
- [ ] Test that all 3 URLs work.
- [x] Refactor script (and fix the buggy behaviour).
- [x] Always overwrite everything below %% comment line.

## File Additions

* Script: `obsidian-hub/.github/scripts/add-edit-on-github.py` 
* Jinja template: `obsidian-hub/.github/templates/footer.md.jinja`

## Script explanation

* Walks through the filetree to search for markdown files.
* For each file, checks whether or not a particular comment has been written.
* If it has the comment: Replace it with the template.
* If the comment is not present: Add the template.
* If the entire template is present: Do nothing.
* Has a `LOG` boolean that can be set to enable/disable informational logging.
* Assumes that the script is ran from `obsidian-hub` directory.


## Template explanation

* Taken directly from the issue discussion from [#154](https://github.com/obsidian-community/obsidian-hub/issues/154).


## Checklist

- [x] I have renamed all attached images with descriptive file names (or I **did not include any images**)
- [x] Before creating a new note, I searched the vault (or I only edited existing notes) => **Did not change notes, only scripts.**
- [x] (Optional) In case I created a new note in the folder `04 - Guides, Workflows, & Courses`, I added a link to the new note(s) in one of the `for {group X}` overviews ([listed here](https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses)).
