### PR TITLE
Fix Matter plugin not being included in Uncategorized plugins

### DIFF
--- a/.github/scripts/update-releases.py
+++ b/.github/scripts/update-releases.py
@@ -96,7 +96,8 @@ def get_uncategorized_plugins(overwrite=True, verbose=False):
         with open(file) as category_file:
             contents = category_file.read()
             for plugin in plugin_list:
-                if plugin in contents:
+                link = f'[{plugin}|'
+                if link in contents:
                     categorized.add(plugin)
 
     uncategorized = list()


### PR DESCRIPTION
Make search for plugins in categories stricter.

- Just searching for the plugin's ID gives false matches, for plugins with short names, or names that are sub-strings of other plugin IDs.

Fixes #180

The next run of update-releases.py will add these existing plugins to Uncategorized plugins (unless anyone else categorises them beforehand):

- `[[obsidian-chess|Obsidian Chess]]`
- `[[matter|Matter]]`