### PR TITLE
Fix dangling link to note called Overdue

### DIFF
--- a/01 - Community/Obsidian Roundup/2021-11-27  Rearrange Outlines and Integrate your Content Discovery Process.md
+++ b/01 - Community/Obsidian Roundup/2021-11-27  Rearrange Outlines and Integrate your Content Discovery Process.md
@@ -31,7 +31,7 @@ _Note: Not all new plugins are available in the community list yet, as they need
 
 -   For folks who like the idea of saving Twitter threads to Readwise but don't want to get a whole Readwise subscription just to do that, check out the [Tressel](https://www.tressel.xyz/) app, which now has an [Obsidian plugin](https://github.com/aseem-thakar/obsidian-tressel/).
 -   The new [Calibre plugin](https://github.com/caronchen/obsidian-calibre-plugin) lets users access Calibre libraries and read books directly in Obsidian.
--   [Obsidian Overdue](https://github.com/parente/obsidian-overdue) Obsidian plugin that marks items as [[Overdue]] if they are not checked off by their due date
+-   [Obsidian Overdue](https://github.com/parente/obsidian-overdue) Obsidian plugin that marks items as `[[Overdue]]` if they are not checked off by their due date
 
 ### Updates
 


### PR DESCRIPTION
<!-- Add a small description here of the changes you added -->

- Fix dangling link to note called Overdue

## Checklist

- [x] I have renamed all attached images with descriptive file names (or I did not include any images)
- [x] Before creating a new note, I searched the vault (or I only edited existing notes)
- [x] (Optional) In case I created a new note in the folder `04 - Guides, Workflows, & Courses`, I added a link to the new note(s) in one of the `for {group X}` overviews ([listed here](https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses)).
