### PR TITLE
Retain manually edited author names when running update-releases.py

### DIFF
--- a/.github/scripts/authors.py
+++ b/.github/scripts/authors.py
@@ -1,15 +1,18 @@
-def adjust_author(extension):
+from typing import Dict
+
+
+def adjust_author(plugin: Dict[str, str]) -> None:
     """
     
-    :param extension: 
+    :param plugin: 
     :return: 
     """
     # extension is a dict - either a plugin or a theme
-    author = extension['author']
+    author = plugin['author']
     substitutions = {
         "Andrew Brown & Tim Hor": "Tim Hor",
         "Chetachi": "Chetachi E.",
         "ryanjamurphy": "Ryan J. A. Murphy"
     }
     if author in substitutions:
-        extension.update(author=substitutions[author])
+        plugin.update(author=substitutions[author])

--- a/.github/scripts/authors.py
+++ b/.github/scripts/authors.py
@@ -1,0 +1,13 @@
+def adjust_author(extension):
+    """
+    
+    :param extension: 
+    :return: 
+    """
+    # extension is a dict - either a plugin or a theme
+    author = extension['author']
+    substitutions = {
+        "ryanjamurphy": "Ryan J. A. Murphy"
+    }
+    if author in substitutions:
+        extension.update(author=substitutions[author])

--- a/.github/scripts/authors.py
+++ b/.github/scripts/authors.py
@@ -8,7 +8,6 @@ def adjust_author(extension):
     author = extension['author']
     substitutions = {
         "Andrew Brown & Tim Hor": "Tim Hor",
-        "bicarlsen": "Brian Carlsen", # remove when https://github.com/bicarlsen/obsidian_image_caption/pull/7 closed
         "Chetachi": "Chetachi E.",
         "ryanjamurphy": "Ryan J. A. Murphy"
     }

--- a/.github/scripts/authors.py
+++ b/.github/scripts/authors.py
@@ -7,6 +7,9 @@ def adjust_author(extension):
     # extension is a dict - either a plugin or a theme
     author = extension['author']
     substitutions = {
+        "Andrew Brown & Tim Hor": "Tim Hor",
+        "bicarlsen": "Brian Carlsen", # remove when https://github.com/bicarlsen/obsidian_image_caption/pull/7 closed
+        "Chetachi": "Chetachi E.",
         "ryanjamurphy": "Ryan J. A. Murphy"
     }
     if author in substitutions:

--- a/.github/scripts/authors.py
+++ b/.github/scripts/authors.py
@@ -3,9 +3,19 @@ from typing import Dict
 
 def update_author_name_for_manual_exceptions(plugin: Dict[str, str]) -> None:
     """
+    If the author name would require a manual edit by hub maintainers,
+    we update it here to save human time.
+
+    A few of the notes for authors of plugins have manually-adjusted
+    names, that are not represented in either the community plugins list
+    or the plugin's manifest file.
     
-    :param plugin: 
-    :return: 
+    These automated edits used to be reverted manually, by people running
+    update-releases.py. This function removes the need to know to do that.
+    
+    :param plugin: A dict() with the plugins properties, from both the community
+                   plugins list and the plugin's own manifest.
+    :return: None
     """
     # extension is a dict - either a plugin or a theme
     author = plugin['author']

--- a/.github/scripts/authors.py
+++ b/.github/scripts/authors.py
@@ -1,7 +1,7 @@
 from typing import Dict
 
 
-def adjust_author(plugin: Dict[str, str]) -> None:
+def update_author_name_for_manual_exceptions(plugin: Dict[str, str]) -> None:
     """
     
     :param plugin: 

--- a/.github/scripts/plugins.py
+++ b/.github/scripts/plugins.py
@@ -4,7 +4,7 @@ import re
 import os
 import sys
 
-from authors import adjust_author
+from authors import update_author_name_for_manual_exceptions
 from utils import get_template, get_plugin_manifest
 
 MOBILE_COMPATIBLE = "[[Mobile-compatible plugins|Yes]]"
@@ -192,7 +192,7 @@ def collect_data_for_plugin_and_manifest(plugin, manifest, file_groups):
         mobile = MOBILE_COMPATIBLE
 
     plugin.update(mobile=mobile, user=user, **manifest)
-    adjust_author(plugin)
+    update_author_name_for_manual_exceptions(plugin)
 
     return plugin_is_valid
 

--- a/.github/scripts/plugins.py
+++ b/.github/scripts/plugins.py
@@ -191,8 +191,8 @@ def collect_data_for_plugin_and_manifest(plugin, manifest, file_groups):
     else:
         mobile = MOBILE_COMPATIBLE
 
-    adjust_author(manifest)
     plugin.update(mobile=mobile, user=user, **manifest)
+    adjust_author(plugin)
 
     return plugin_is_valid
 

--- a/.github/scripts/plugins.py
+++ b/.github/scripts/plugins.py
@@ -177,6 +177,10 @@ def collect_data_for_plugin(plugin, file_groups):
     branch = plugin.get("branch", "master")
     manifest = get_plugin_manifest(repo, branch)
 
+    return collect_data_for_plugin_and_manifest(repo, plugin, manifest, file_groups)
+
+
+def collect_data_for_plugin_and_manifest(repo, plugin, manifest, file_groups):
     plugin_is_valid = validate_plugin(plugin, manifest, repo, file_groups)
 
     user = repo.split("/")[0]

--- a/.github/scripts/plugins.py
+++ b/.github/scripts/plugins.py
@@ -4,6 +4,7 @@ import re
 import os
 import sys
 
+from authors import adjust_author
 from utils import get_template, get_plugin_manifest
 
 MOBILE_COMPATIBLE = "[[Mobile-compatible plugins|Yes]]"
@@ -190,6 +191,7 @@ def collect_data_for_plugin_and_manifest(plugin, manifest, file_groups):
     else:
         mobile = MOBILE_COMPATIBLE
 
+    adjust_author(manifest)
     plugin.update(mobile=mobile, user=user, **manifest)
 
     return plugin_is_valid

--- a/.github/scripts/plugins.py
+++ b/.github/scripts/plugins.py
@@ -177,10 +177,11 @@ def collect_data_for_plugin(plugin, file_groups):
     branch = plugin.get("branch", "master")
     manifest = get_plugin_manifest(repo, branch)
 
-    return collect_data_for_plugin_and_manifest(repo, plugin, manifest, file_groups)
+    return collect_data_for_plugin_and_manifest(plugin, manifest, file_groups)
 
 
-def collect_data_for_plugin_and_manifest(repo, plugin, manifest, file_groups):
+def collect_data_for_plugin_and_manifest(plugin, manifest, file_groups):
+    repo = plugin.get("repo")
     plugin_is_valid = validate_plugin(plugin, manifest, repo, file_groups)
 
     user = repo.split("/")[0]

--- a/.github/scripts/tests/approved_files/test_plugins.test_author_augmented_for_ryanjamurphy.approved.md
+++ b/.github/scripts/tests/approved_files/test_plugins.test_author_augmented_for_ryanjamurphy.approved.md
@@ -1,0 +1,13 @@
+{
+    "author": "ryanjamurphy",
+    "authorUrl": "https://axle.design",
+    "description": "Open or reveal the current note in DEVONthink.",
+    "id": "DEVONlink-obsidian",
+    "isDesktopOnly": true,
+    "minAppVersion": "0.9.12",
+    "mobile": "[[Desktop-only plugins|No]]",
+    "name": "DEVONlink",
+    "repo": "ryanjamurphy/DEVONlink-obsidian",
+    "user": "ryanjamurphy",
+    "version": "2.2.1"
+}

--- a/.github/scripts/tests/approved_files/test_plugins.test_author_augmented_for_ryanjamurphy.approved.md
+++ b/.github/scripts/tests/approved_files/test_plugins.test_author_augmented_for_ryanjamurphy.approved.md
@@ -1,5 +1,5 @@
 {
-    "author": "ryanjamurphy",
+    "author": "Ryan J. A. Murphy",
     "authorUrl": "https://axle.design",
     "description": "Open or reveal the current note in DEVONthink.",
     "id": "DEVONlink-obsidian",

--- a/.github/scripts/tests/approved_files/test_plugins.test_author_missing_from_manifest.approved.md
+++ b/.github/scripts/tests/approved_files/test_plugins.test_author_missing_from_manifest.approved.md
@@ -1,0 +1,12 @@
+{
+    "author": "Denis Olehov",
+    "description": "Backup your vault with git.",
+    "id": "obsidian-git",
+    "isDesktopOnly": true,
+    "js": "main.js",
+    "mobile": "[[Desktop-only plugins|No]]",
+    "name": "Obsidian Git",
+    "repo": "denolehov/obsidian-git",
+    "user": "denolehov",
+    "version": "1.19.0"
+}

--- a/.github/scripts/tests/test_plugins.py
+++ b/.github/scripts/tests/test_plugins.py
@@ -15,6 +15,14 @@ from test_make_mocs import approval_test_options
 #  "ryanjamurphy" -> "Ryan J. A. Murphy"
 
 
+def verify_plugin(manifest_as_json, plugin_as_json):
+    plugin = json.loads(plugin_as_json)
+    manifest = json.loads(manifest_as_json)
+    file_groups = dict()
+    result = plugins.collect_data_for_plugin_and_manifest(plugin, manifest, file_groups)
+    verify_as_json(plugin, options=approval_test_options())
+
+
 def test_author_augmented_for_ryanjamurphy():
     # Copied from https://github.com/obsidianmd/obsidian-releases/blob/30b6c827db345e92ce62d50c431878b80ede9d17/community-plugins.json
     plugin_as_json = '''
@@ -26,7 +34,6 @@ def test_author_augmented_for_ryanjamurphy():
         "repo": "ryanjamurphy/DEVONlink-obsidian"
     }
     '''
-    plugin = json.loads(plugin_as_json)
 
     manifest_as_json = '''
     {
@@ -40,8 +47,4 @@ def test_author_augmented_for_ryanjamurphy():
         "isDesktopOnly": true
     }
     '''
-    manifest = json.loads(manifest_as_json)
-
-    file_groups = dict()
-    result = plugins.collect_data_for_plugin_and_manifest(plugin, manifest, file_groups)
-    verify_as_json(plugin, options=approval_test_options())
+    verify_plugin(manifest_as_json, plugin_as_json)

--- a/.github/scripts/tests/test_plugins.py
+++ b/.github/scripts/tests/test_plugins.py
@@ -48,3 +48,29 @@ def test_author_augmented_for_ryanjamurphy():
     }
     '''
     verify_plugin(manifest_as_json, plugin_as_json)
+
+
+def test_author_missing_from_manifest():
+    # This plugin has the author name in the community plugins file, but not in its own manifest.json
+    # This test verifies that this situation is handled correctly.
+    plugin_as_json = '''
+    {
+        "id": "obsidian-git",
+        "name": "Obsidian Git",
+        "author": "Denis Olehov",
+        "description": "Backup your vault with git.",
+        "repo": "denolehov/obsidian-git"
+    }
+    '''
+
+    manifest_as_json = '''
+    {
+        "id": "obsidian-git",
+        "name": "Obsidian Git",
+        "description": "Backup your vault with git.",
+        "isDesktopOnly": true,
+        "js": "main.js",
+        "version": "1.19.0"
+    }
+    '''
+    verify_plugin(manifest_as_json, plugin_as_json)

--- a/.github/scripts/tests/test_plugins.py
+++ b/.github/scripts/tests/test_plugins.py
@@ -1,0 +1,33 @@
+import json
+
+import plugins
+
+from approvaltests.approvals import verify_as_json
+
+from test_make_mocs import approval_test_options
+
+
+# Names that are currently manually edited when update-releases.py is run:
+#  "Andrew Brown & Tim Hor" -> "Tim Hor",
+#  "bicarlsen" -> "Brian Carlsen",
+#       https://github.com/bicarlsen/obsidian_image_caption/pull/7
+#  "Chetachi" -> "Chetachi E.",
+#  "ryanjamurphy" -> "Ryan J. A. Murphy"
+
+
+def test_author_augmented_for_ryanjamurphy():
+    # Copied from https://github.com/obsidianmd/obsidian-releases/blob/30b6c827db345e92ce62d50c431878b80ede9d17/community-plugins.json
+    plugin_as_json = '''
+    {
+        "id": "DEVONlink-obsidian",
+        "name": "DEVONlink - Open or reveal notes in DEVONthink",
+        "description": "Open or reveal the current note in DEVONthink.",
+        "author": "ryanjamurphy",
+        "repo": "ryanjamurphy/DEVONlink-obsidian"
+    }
+    '''
+
+    plugin = json.loads(plugin_as_json)
+    file_groups = dict()
+    result = plugins.collect_data_for_plugin(plugin, file_groups)
+    verify_as_json(plugin, options=approval_test_options())

--- a/.github/scripts/tests/test_plugins.py
+++ b/.github/scripts/tests/test_plugins.py
@@ -7,14 +7,6 @@ from approvaltests.approvals import verify_as_json
 from test_make_mocs import approval_test_options
 
 
-# Names that are currently manually edited when update-releases.py is run:
-#  "Andrew Brown & Tim Hor" -> "Tim Hor",
-#  "bicarlsen" -> "Brian Carlsen",
-#       https://github.com/bicarlsen/obsidian_image_caption/pull/7
-#  "Chetachi" -> "Chetachi E.",
-#  "ryanjamurphy" -> "Ryan J. A. Murphy"
-
-
 def verify_plugin(manifest_as_json, plugin_as_json):
     plugin = json.loads(plugin_as_json)
     manifest = json.loads(manifest_as_json)

--- a/.github/scripts/tests/test_plugins.py
+++ b/.github/scripts/tests/test_plugins.py
@@ -26,8 +26,22 @@ def test_author_augmented_for_ryanjamurphy():
         "repo": "ryanjamurphy/DEVONlink-obsidian"
     }
     '''
-
     plugin = json.loads(plugin_as_json)
+
+    manifest_as_json = '''
+    {
+        "id": "DEVONlink-obsidian",
+        "name": "DEVONlink",
+        "version": "2.2.1",
+        "minAppVersion": "0.9.12",
+        "description": "Open or reveal the current note in DEVONthink.",
+        "author": "ryanjamurphy",
+        "authorUrl": "https://axle.design",
+        "isDesktopOnly": true
+    }
+    '''
+    manifest = json.loads(manifest_as_json)
+
     file_groups = dict()
-    result = plugins.collect_data_for_plugin(plugin, file_groups)
+    result = plugins.collect_data_for_plugin_and_manifest(plugin, manifest, file_groups)
     verify_as_json(plugin, options=approval_test_options())

--- a/01 - Community/People/bicarlsen.md
+++ b/01 - Community/People/bicarlsen.md
@@ -6,7 +6,7 @@ tags:
 publish: true
 ---
 
-# bicarlsen
+# Brian Carlsen
 
 - GitHub: [bicarlsen](https://github.com/bicarlsen/) ^github
 <!-- - Discord: `@` ^discord-->


### PR DESCRIPTION
<!-- Add a small description here of the changes you added -->

- Added new function `adjust_author()` in new file `authors.py`
- Extract part of `collect_data_for_plugin()` out in to a new function `collect_data_for_plugin_and_manifest()` to enable writing of self-contained tests that do not depend on data in a plugin's GitHub repo
- Wrote some approval tests to understand the behaviour of `collect_data_for_plugin()`
- **Adjust the behaviour so that 3 author names and aliases that have previously been manually edited are now preserved automatically**.
- A 4th edit - "bicarlsen" -> "Brian Carlsen" - has been fixed via a pull request to the relevant plugin
- Reinstated a lost edit in `bicarlsen.md` (that I had lost in af9189c568aa5764c82662ca110ef5a89ae2c3c4)

This fixes #150

I am aware that it's possible that later work to only selectively update outputs from `update-releases.py` may enable this work to be removed... I did it anyway because:

- It was a way to learn about the behaviour of data storage for plugins
- It will simplify data updates until the bigger work is done
- It enabled me to add some tests for the plugin code, that will be useful when we get to the refactorings for #151 (adding classes to represent concepts)

## Checklist

- Not applicable