### PR TITLE
Put guides under guide heading in theme designer guide

### DIFF
--- a/04 - Guides, Workflows, & Courses/for Theme Designers.md
+++ b/04 - Guides, Workflows, & Courses/for Theme Designers.md
@@ -23,6 +23,11 @@ This note collects resources and guides for beginner and expert theme designers 
 - [[Why and How to use Stylelint for your Obsidian Theme]] by [[chrisgrieser|pseudometa]]
 - [[Want some Sass with your obsidian theme‽ here's How and Why]] by [[jdanielmourao]]
 - [[Best Practices and Tips for Theme Development]]
+- [[css-obsidian-layout.png|Visual guide to primary Obsidian CSS Classes]]
+- [🎬 Create a Custom Theme in Obsidian](https://www.youtube.com/watch?v=lyaEnxgow4E)
+- [custom-css at Obsidian Forum](https://forum.obsidian.md/tag/custom-css)
+  - [Getting comfortable with Obsidian CSS](https://forum.obsidian.md/t/getting-comfortable-with-obsidian-css/133)
+  - [Common Selectors for Custom CSS](https://forum.obsidian.md/t/common-selectors-for-custom-css/1984)
 
 ## Community Talks
 
@@ -34,11 +39,4 @@ This note collects resources and guides for beginner and expert theme designers 
 - [**Transfonter**](https://transfonter.org/) Online `@font-face` generator for offline fonts
 - [**Iconify Icon Sets**](https://icon-sets.iconify.design/) Website to search and find icons from multiple icon sets
 - [**URL-encoder for SVG**](https://yoksel.github.io/url-encoder/) Encodes icon's svg code into useful `background-image` url
-- [[css-obsidian-layout.png|Visual guide to primary Obsidian CSS Classes]]
-- [custom-css at Obsidian Forum](https://forum.obsidian.md/tag/custom-css)
-  - [Getting comfortable with Obsidian CSS](https://forum.obsidian.md/t/getting-comfortable-with-obsidian-css/133)
-  - [Common Selectors for Custom CSS](https://forum.obsidian.md/t/common-selectors-for-custom-css/1984)
-  - [CSS Themes Showcase](https://forum.obsidian.md/t/meta-post-css-themes-showcase/76)
-- [🎬 Create a Custom Theme in Obsidian](https://www.youtube.com/watch?v=lyaEnxgow4E)
-- [ReggieNotes' about Obsidian CSS Themes](https://publish.obsidian.md/reggienotes/Quickstart+CSS+Guide/010+Obsidian+CSS+Themes)
 - [obsidian-style-settings:](https://github.com/mgmeyers/obsidian-style-settings) allows snippet, theme, and plugin CSS files to define a set of configuration options. It then allows users to see all the tweakable settings in one settings pane.


### PR DESCRIPTION
I also removed a broken link (ReggieNotes) and removed the link to the CSS showcase post, because the theme store can be used to discover themes.

## Checklist

- [x] I have renamed all attached images with descriptive file names (or I did not include any images)
- [x] Before creating a new note, I searched the vault (or I only edited existing notes)
- [x] (Optional) In case I created a new note in the folder `04 - Guides, Workflows, & Courses`, I added a link to the new note(s) in one of the `for {group X}` overviews ([listed here](https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses)).
