### PR TITLE
added link for people management + fixed LYT link

### DIFF
--- a/04 - Guides, Workflows, & Courses/for Knowledge Management.md
+++ b/04 - Guides, Workflows, & Courses/for Knowledge Management.md
@@ -22,7 +22,7 @@ tags:
 - [GTD in 15 minutes – A Pragmatic Guide to Getting Things Done](https://hamberg.no/gtd)
 
 ### Linking your Thinking
-- [The PARA Method: A Universal System for Organizing Digital Information - Forte Labs](https://fortelabs.co/blog/para/)
+- [Linking Your Thinking - YouTube Channel](https://www.youtube.com/channel/UC85D7ERwhke7wVqskV_DZUA)
 
 ### PARA
 - [The PARA Method: A Universal System for Organizing Digital Information - Forte Labs](https://fortelabs.co/blog/para/)
@@ -30,6 +30,9 @@ tags:
 
 ### Johnny Decimal
 - [Johnny•Decimal](https://johnnydecimal.com/)
+
+## People Management
+- [Obsidian for people managers - Obsidian Forum](https://forum.obsidian.md/t/obsidian-for-people-managers/25495)
 
 ## Collaborative Knowledge Management
 - [Obsidian, Taming a Collective Consciousness - TrustedSec](https://www.trustedsec.com/blog/obsidian-taming-a-collective-consciousness/)


### PR DESCRIPTION
## Checklist

- [x] I have renamed all attached images with descriptive file names (or I did not include any images)
- [x] Before creating a new note, I searched the vault (or I only edited existing notes)
- [x] (Optional) In case I created a new note in the folder `04 - Guides, Workflows, & Courses`, I added a link to the new note(s) in one of the `for {group X}` overviews ([listed here](https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses)).
