### PR TITLE
Typo fix and add a link to Breadcrumbs plugin on showcase note

### DIFF
--- a/01 - Community/People/lkadre.md
+++ b/01 - Community/People/lkadre.md
@@ -14,7 +14,7 @@ publish: true
  - [Publish Site](https://brain.lkadre.com/§+001+HOMEPAGE): ^publish
 
 %% Feel free to add a bio below this comment %%
-I'm a Law student and a PKM enthusiast. My focuses are comparative law and international financial law, though I'm also deeply interest in philosophy, aesthetics and literature.
+I'm a Law student with focuses in comparative law and international financial law. I'm also deeply interested in philosophy, aesthetics and literature. Some of my notes are published online in what I call my "second brain".
 
 <!--## Author of-->
 

--- a/03 - Showcases & Templates/Plugin Showcases/Breadcrumbs for Comparative Law.md
+++ b/03 - Showcases & Templates/Plugin Showcases/Breadcrumbs for Comparative Law.md
@@ -9,9 +9,11 @@ publish: true
 
 *Note: this is a refined version of the post by [[lkadre]] on [this discussion](https://github.com/SkepticMystic/breadcrumbs/discussions/175) on Github about [[How to get the most out of the Breadcrumbs plugin]].*
 
-#### Example: Concept notes (Law)
+Since the [[breadcrumbs|Breadcrumbs]] plugin is so powerful, it can be useful to see an example (showcase?) of how other people use it to maximise creativity and analysis. 
 
 This is specifically about my notes on Law, which I acknowledge is probably very niche but hopefully it can give you some ideas of how to set up your hierarchies and especially how to work with notes in multiple hierarchies. You don't have to choose one!
+
+#### Example: Concept notes (Law)
 
 The first line in my note for Limited Liability Company in Delaware reads:
 

--- a/03 - Showcases & Templates/Plugin Showcases/Breadcrumbs for Comparative Law.md
+++ b/03 - Showcases & Templates/Plugin Showcases/Breadcrumbs for Comparative Law.md
@@ -9,7 +9,7 @@ publish: true
 
 *Note: this is a refined version of the post by [[lkadre]] on [this discussion](https://github.com/SkepticMystic/breadcrumbs/discussions/175) on Github about [[How to get the most out of the Breadcrumbs plugin]].*
 
-Since the [[breadcrumbs|Breadcrumbs]] plugin is so powerful, it can be useful to see an showcase for how other people use it to maximise creativity and analysis. 
+Since the [[breadcrumbs|Breadcrumbs]] plugin is so powerful, it can be useful to see a showcase of how other people use it to maximise creativity and analysis. 
 
 This is specifically about my notes on Law, which I acknowledge is probably a very niche topic but hopefully it can give you some ideas of how to set up your hierarchies and especially how to work with notes in multiple hierarchies. You don't have to choose one!
 
@@ -19,7 +19,7 @@ The first line in my note for Limited Liability Company in Delaware reads:
 
 `#j/US/DEL #t/entity #law/corporate `
 
-This automatically places that note within three different hierarchies: jurisdiction (the "j"), type (the "t"), and topic. These are tags and subtags I already used before the Breadcrumbs plugin and clearly denoted "hierarchies", even if they're not immediately explicit. 
+This automatically places that note within three different hierarchies: jurisdiction (the `j`), type (the `t`), and topic. These are tags and subtags I already used before the Breadcrumbs plugin and clearly denoted "hierarchies", even if they're not immediately explicit. 
 
 Separating by topic feels the most natural because that's how we're used to categorising things. In school I have subjects like "Corporate Law" and "Constitutional Law", so naturally I want to be able to see all my notes related to this topic easily. Similarly, I have tags and subtags for `#philosophy/scepticism` or `#literature/realism`.
 

--- a/03 - Showcases & Templates/Plugin Showcases/Breadcrumbs for Comparative Law.md
+++ b/03 - Showcases & Templates/Plugin Showcases/Breadcrumbs for Comparative Law.md
@@ -9,9 +9,9 @@ publish: true
 
 *Note: this is a refined version of the post by [[lkadre]] on [this discussion](https://github.com/SkepticMystic/breadcrumbs/discussions/175) on Github about [[How to get the most out of the Breadcrumbs plugin]].*
 
-Since the [[breadcrumbs|Breadcrumbs]] plugin is so powerful, it can be useful to see an example (showcase?) of how other people use it to maximise creativity and analysis. 
+Since the [[breadcrumbs|Breadcrumbs]] plugin is so powerful, it can be useful to see an showcase for how other people use it to maximise creativity and analysis. 
 
-This is specifically about my notes on Law, which I acknowledge is probably very niche but hopefully it can give you some ideas of how to set up your hierarchies and especially how to work with notes in multiple hierarchies. You don't have to choose one!
+This is specifically about my notes on Law, which I acknowledge is probably a very niche topic but hopefully it can give you some ideas of how to set up your hierarchies and especially how to work with notes in multiple hierarchies. You don't have to choose one!
 
 #### Example: Concept notes (Law)
 


### PR DESCRIPTION
<!-- Add a small description here of the changes you added -->

- lkadre
- Breadcrumbs plugin showcase

## Checklist

- [x] I have renamed all attached images with descriptive file names (or I did not include any images)
- [x] Before creating a new note, I searched the vault (or I only edited existing notes)
- [x] (Optional) In case I created a new note in the folder `04 - Guides, Workflows, & Courses`, I added a link to the new note(s) in one of the `for {group X}` overviews ([listed here](https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses)).
