### PR TITLE
Tidy up the notes that were moved in from the GitHub wiki

### DIFF
--- a/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.01 Structure/Checklist for reviewing Pull Requests.md
+++ b/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.01 Structure/Checklist for reviewing Pull Requests.md
@@ -1,3 +1,10 @@
+---
+aliases:
+- 
+tags:
+- 
+---
+
 # Checklist for reviewing Pull Requests
 
 An optional checklist of things that might be worth checking when reviewing pull requests.

--- a/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.01 Structure/🗂️ 03.01 Structure.md
+++ b/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.01 Structure/🗂️ 03.01 Structure.md
@@ -8,7 +8,9 @@ publish: true
 
 # 🗂️ 03.01 Structure
 
-#placeholder/description 
+This section will grow to contain notes about how information is structured in this vault.
+
+There is already a lot of information about this in [[CONTRIBUTING]].
 
 ## MOC
 

--- a/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.02 Design Decisions/Content Comments.md
+++ b/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.02 Design Decisions/Content Comments.md
@@ -1,3 +1,12 @@
+---
+aliases:
+- 
+tags:
+- 
+---
+
+# Content: Comments
+
 ## Agree a standard for optional text, that is commented out and then enabled...
 
 Suggested standard:

--- a/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.02 Design Decisions/Content Lifecycle of Extensions.md
+++ b/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.02 Design Decisions/Content Lifecycle of Extensions.md
@@ -1,3 +1,12 @@
+---
+aliases:
+- 
+tags:
+- 
+---
+
+# Content: Lifecycle of Extensions
+
 ## Purpose
 
 Try to capture the stages that community extensions (Plugins and Themes) go though.

--- a/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.02 Design Decisions/Content Lifecycle of Extensions.md
+++ b/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.02 Design Decisions/Content Lifecycle of Extensions.md
@@ -9,7 +9,7 @@ tags:
 
 ## Purpose
 
-Try to capture the stages that community extensions (Plugins and Themes) go though.
+Try to capture the stages that community extensions (Plugins and Themes) go through.
 
 ## Questions on the following...
 

--- a/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.02 Design Decisions/Content Lists.md
+++ b/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.02 Design Decisions/Content Lists.md
@@ -1,3 +1,12 @@
+---
+aliases:
+- 
+tags:
+- 
+---
+
+# Content: Lists
+
 ## Sorting of lists, to aid readability
 
 ### Decisions and conclusions

--- a/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.02 Design Decisions/Content People.md
+++ b/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.02 Design Decisions/Content People.md
@@ -1,3 +1,12 @@
+---
+aliases:
+- 
+tags:
+- 
+---
+
+# Content: People
+
 ## Ideas to reduce the overhead of these pages
 
 *There is some overlap between these ideas...*

--- a/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.02 Design Decisions/Content Plugins.md
+++ b/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.02 Design Decisions/Content Plugins.md
@@ -1,4 +1,13 @@
-# Change plugins template to simplify manual intervention, when running `update-releases.py`
+---
+aliases:
+- 
+tags:
+- 
+---
+
+# Content: Plugins
+
+## Change plugins template to simplify manual intervention, when running `update-releases.py`
 
 Apply the conventions proposed in [[Content Comments]] to this file.
 

--- a/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.02 Design Decisions/Content Themes.md
+++ b/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.02 Design Decisions/Content Themes.md
@@ -1,4 +1,13 @@
-# Change themes template to simplify manual intervention, when running `update-releases.py`
+---
+aliases:
+- 
+tags:
+- 
+---
+
+# Content: Themes
+
+## Change themes template to simplify manual intervention, when running `update-releases.py`
 
 
 

--- a/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.02 Design Decisions/🗂️ 03.02 Design Decisions.md
+++ b/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.02 Design Decisions/🗂️ 03.02 Design Decisions.md
@@ -8,7 +8,7 @@ publish: true
 
 # 🗂️ 03.02 Design Decisions
 
-#placeholder/description 
+In this folder, you can find notes about proposals for changes to the content of this vault, together with the thinking behind these proposals.
 
 ## MOC
 

--- a/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.03 Scripts and Automation/GitHub Actions for the Hub.md
+++ b/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.03 Scripts and Automation/GitHub Actions for the Hub.md
@@ -11,6 +11,8 @@ tags:
 
 There are some maintenance steps that are currently done manually, and that could be run automatically, either on a cron schedule, or upon changes to the main branch.
 
+This work is being tracked in [Automate (some) scripts with GitHub Actions · Issue #153](https://github.com/obsidian-community/obsidian-hub/issues/153)
+
 - Updating theme download counts
   - Part of [[Updating Extensions]]
 - Adding new theme, plugin and people pages

--- a/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.03 Scripts and Automation/GitHub Actions for the Hub.md
+++ b/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.03 Scripts and Automation/GitHub Actions for the Hub.md
@@ -1,3 +1,12 @@
+---
+aliases:
+- 
+tags:
+- 
+---
+
+# GitHub Actions for the Hub
+
 ## Potentially automatable
 
 There are some maintenance steps that are currently done manually, and that could be run automatically, either on a cron schedule, or upon changes to the main branch.

--- a/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.03 Scripts and Automation/Scripts for Maintenance.md
+++ b/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.03 Scripts and Automation/Scripts for Maintenance.md
@@ -7,6 +7,8 @@ tags:
 
 # Scripts for Maintenance
 
+We use Python scripts to machine-generate some of the content of the Hub.
+
 - Scripts location: [.github/scripts](https://github.com/obsidian-community/obsidian-hub/tree/main/.github/scripts)
 - For `update-releases.py`, see [[Updating Extensions]]
 - For `update-mocs.py`, see [[Updating MOC files]]

--- a/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.03 Scripts and Automation/Scripts for Maintenance.md
+++ b/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.03 Scripts and Automation/Scripts for Maintenance.md
@@ -1,3 +1,12 @@
+---
+aliases:
+- 
+tags:
+- 
+---
+
+# Scripts for Maintenance
+
 - Scripts location: [.github/scripts](https://github.com/obsidian-community/obsidian-hub/tree/main/.github/scripts)
 - For `update-releases.py`, see [[Updating Extensions]]
 - For `update-mocs.py`, see [[Updating MOC files]]

--- a/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.03 Scripts and Automation/Testing Python Code with Approval Tests.md
+++ b/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.03 Scripts and Automation/Testing Python Code with Approval Tests.md
@@ -1,4 +1,14 @@
-# About the Python tests in [.github/scripts](https://github.com/obsidian-community/obsidian-hub/tree/main/.github/scripts)
+---
+aliases:
+- 
+tags:
+- 
+---
+
+# Testing Python Code with Approval Tests
+
+
+About the Python tests in [.github/scripts](https://github.com/obsidian-community/obsidian-hub/tree/main/.github/scripts)
 
 ## TL;DR
 

--- a/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.03 Scripts and Automation/Updating Extensions.md
+++ b/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.03 Scripts and Automation/Updating Extensions.md
@@ -1,3 +1,12 @@
+---
+aliases:
+- 
+tags:
+- 
+---
+
+# Updating Extensions
+
 The script `update-releases.py` reads current data from the Obsidian Releases repo, and generates outputs for any newly-added plugins or themes.
 
 ## Running the script

--- a/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.03 Scripts and Automation/Updating MOC files.md
+++ b/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.03 Scripts and Automation/Updating MOC files.md
@@ -1,3 +1,12 @@
+---
+aliases:
+- 
+tags:
+- 
+---
+
+# Updating MOC files
+
 The script `update-mocs.py` examines the current Hub vault contents and updates the MOC files (🗂️*.md) to match.
 
 ## Running the script

--- a/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.03 Scripts and Automation/🗂️ 03.03 Scripts and Automation.md
+++ b/00 - Contribute to the Obsidian Hub/03 Contributor Notes/03.03 Scripts and Automation/🗂️ 03.03 Scripts and Automation.md
@@ -8,7 +8,7 @@ publish: true
 
 # 🗂️ 03.03 Scripts and Automation
 
-#placeholder/description 
+In this folder, you can find notes about the scripting and automation processes that we use, to streamline maintenance of this vault.
 
 ## MOC
 

--- a/00 - Contribute to the Obsidian Hub/03 Contributor Notes/Discussion Needed.md
+++ b/00 - Contribute to the Obsidian Hub/03 Contributor Notes/Discussion Needed.md
@@ -1,3 +1,12 @@
+---
+aliases:
+- 
+tags:
+- 
+---
+
+# Discussion Needed
+
 Mostly minor improvements over what we already have:
 
 - [[Content Comments]]

--- a/00 - Contribute to the Obsidian Hub/03 Contributor Notes/🗂️ 03 Contributor Notes.md
+++ b/00 - Contribute to the Obsidian Hub/03 Contributor Notes/🗂️ 03 Contributor Notes.md
@@ -8,11 +8,7 @@ publish: true
 
 # 🗂️ 03 Contributor Notes
 
-#placeholder/description 
-
-Welcome to the obsidian-hub wiki!
-
-See the list of "Pages" on the right hand side or below.
+The notes in this folder are a kind of behind-the-scenes place to keep notes about managing this vault.
 
 ## MOC
 

--- a/00 - Contribute to the Obsidian Hub/Tip for Keeping Hub TODO lists.md
+++ b/00 - Contribute to the Obsidian Hub/Tip for Keeping Hub TODO lists.md
@@ -1,3 +1,12 @@
+---
+aliases:
+- 
+tags:
+- 
+---
+
+# Tip for Keeping Hub TODO lists
+
 ## Target Audience
 
 This tip is really intended for anyone doing largish amounts of tidying up or handle-turning in the Hub content, which is cloned on their own machine.

--- a/00 - Contribute to the Obsidian Hub/🗂️ 00 - Contribute to the Obsidian Hub.md
+++ b/00 - Contribute to the Obsidian Hub/🗂️ 00 - Contribute to the Obsidian Hub.md
@@ -16,6 +16,8 @@ In this folder, you can find all the resources you need to make contributions to
 
 Got some question left? Check out the [[FAQ]] or drop by in the `#Obsidian-Hub` at [the Obsidian Discord Server](https://discord.gg/veuWUTm) Wondering how a certain tag is used? Refer to the [[Tag glossary]].
 
+Want to know more about behind-the-scenes tending to this Community Vault? Check out the [[🗂️ 03 Contributor Notes|Contributor Notes]].
+
 ## MOC
 
 %% Hub MOCs: Don’t edit below  %%

--- a/00 - Contribute to the Obsidian Hub/🗂️ 00 - Contribute to the Obsidian Hub.md
+++ b/00 - Contribute to the Obsidian Hub/🗂️ 00 - Contribute to the Obsidian Hub.md
@@ -14,7 +14,7 @@ publish: true
 
 In this folder, you can find all the resources you need to make contributions to the collective knowledge base of the Obsidian Community – this Community Vault. To keep this community vault manageable and consistent, we have standardized [[🗂️ 01 Templates|Templates for new pages]] and a [[Tag glossary]]. Furthermore, we use [[🗂️ 02 Attachments|one central attachment folder]], where all images and other attachments are stored.
 
-Got some question left? Check out the [[FAQ]] or drop by in the `#Obsidian-Hub` at [the Obsidian Discord Server](https://discord.gg/veuWUTm) Wondering how a certain tag is used? Refer to the [[Tag glossary]].
+Got some question left? Check out the [[FAQ]] or drop by in the `#hub` at [the Obsidian Discord Server](https://discord.gg/veuWUTm) Wondering how a certain tag is used? Refer to the [[Tag glossary]].
 
 Want to know more about behind-the-scenes tending to this Community Vault? Check out the [[🗂️ 03 Contributor Notes|Contributor Notes]].
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,7 @@ If you found a broken link, a typo or a mistake [please open an issue](https://g
 
 
 ## Further Questions?
-Got some question left? Check out the [[FAQ]] or drop by in the `#Obsidian-Hub` at [the Obsidian Discord Server](https://discord.gg/veuWUTm) Wondering how a certain tag is used? Refer to the [[Tag glossary]].
+Got some question left? Check out the [[FAQ]] or drop by in the `#hub` at [the Obsidian Discord Server](https://discord.gg/veuWUTm) Wondering how a certain tag is used? Refer to the [[Tag glossary]].
 
 Please [open a new discussion at GitHub](https://github.com/obsidian-community/obsidian-hub/discussions/new) if you have suggestions or ideas for this vault.
 


### PR DESCRIPTION
We moved these files in in a bit of a hurry... This is a first pass at tidying them up a bit.

## Edited

- Added YAML and level-1 heading to pages moved in from the GitHub wiki
- Replace the MOC placeholders in these directories with brief descriptions of their intent
- Updated a couple of references to the old Discord Hub thread to now refer to the Hub channel
- Add one link to a GitHub issue - the one for adding GitHub Actions

## Checklist

Not applicable

- [ ] before creating a new note, I searched the vault
- [ ] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
