### PR TITLE
add css to two code blocks in css guide

### DIFF
--- a/04 - Guides, Workflows, & Courses/Guides/How to Style Obsidian.md
+++ b/04 - Guides, Workflows, & Courses/Guides/How to Style Obsidian.md
@@ -47,7 +47,7 @@ In real CSS, that declaration looks like:
 
 CSS is interpreted sequentially. The last declaration rules over any that came before it. So, if you were to make the following declarations:
 
-```
+```css
 .markdown-source-view {
 	color: blue;
 }
@@ -60,7 +60,7 @@ CSS is interpreted sequentially. The last declaration rules over any that came b
 The text colour would be black, not blue. I.e., the app would layer what comes last in the document over whatever came before it.
 
 However, if you want to insist, you can write `!important`, like so:
-```
+```css
 .markdown-source-view {
 	color: blue !important;
 }


### PR DESCRIPTION
## Edited
<!-- Add a brief description here -->

`04 - Guides, Workflows, & Courses/Guides/How to Style Obsidian.md`

## Added
<!-- Add a brief description here-->

## Checklist
- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
- [x] (if applicable) attached images have descriptive file names
- [x] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
