### PR TITLE
Fix link (PR #220)

### DIFF
--- a/04 - Guides, Workflows, & Courses/Guides/How to Style Obsidian.md
+++ b/04 - Guides, Workflows, & Courses/Guides/How to Style Obsidian.md
@@ -6,7 +6,7 @@ By [[ryanjamurphy|Ryan J. A. Murphy]]
 Ancient proverb:
 > Give a person some CSS, style them for a day. Teach them CSS, and they'll procrastinate for a lifetime.
 
-So you've downloaded that sleek new theme everyone's talking about. Your notes have never looked better. You sit at your desk, coffee steaming, hands hovering over your keyboard, and the most important thought you'll ever have is—wait, no, that header is the wrong shade of [Pantone's 2015 colour of the year, marsala!](https://www.pantone.com/color-intelligence/color-of-the-year/color-of-the-year-2015)
+So you've downloaded that sleek new theme everyone's talking about. Your notes have never looked better. You sit at your desk, coffee steaming, hands hovering over your keyboard, and the most important thought you'll ever have is—wait, no, that header is the wrong shade of [Pantone's 2015 colour of the year, marsala!](https://www.diamondvogel.com/architectural/blog/2015-pantone-color-of-the-year)
 
 EVERYTHING IS RUINED.
 


### PR DESCRIPTION
## Edited
Fixes a link that Craftidore found was dead.

## Added
N/A
## Checklist
- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
- [x] (if applicable) attached images have descriptive file names
- [x] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
