### PR TITLE
Fix 2 wiki links

### DIFF
--- a/01 - Community/Obsidian Roundup/2021.08.21.md
+++ b/01 - Community/Obsidian Roundup/2021.08.21.md
@@ -25,7 +25,7 @@ _Remember, you can manually install any plugin by copying the `main.js`, `manife
 
 ### Under The Radar
 
-- The plugin that [[obsidian-auto-link-title||automatically fetches a page title when you link to it]] got resurfaced this week.
+- The plugin that [[obsidian-auto-link-title|automatically fetches a page title when you link to it]] got resurfaced this week.
 - The [[extract-highlights-plugin|Extract Highlights]] plugin lets you create and extract highlights from a current markdown note in Obsidian onto your clipboard.
 
 ### For Developers

--- a/04 - Guides, Workflows, & Courses/Community Talks/Breadcrumbs Showcase.md
+++ b/04 - Guides, Workflows, & Courses/Community Talks/Breadcrumbs Showcase.md
@@ -10,7 +10,7 @@ publish: true
 
 By [[SkepticMystic]]
 
-A [[Obsidian Community Talks|Obsidian Community Talk|showcase]] for the [[breadcrumbs|Breadcrumbs]] plugin. 
+A [[Obsidian Community Talks|showcase]] for the [[breadcrumbs|Breadcrumbs]] plugin. 
 The [[YouTube|video]] of this talk:
 
 <iframe width="100%" height="400px" src="https://www.youtube.com/embed/DXXB7fHcArg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>


### PR DESCRIPTION
## Edited

Remove duplicate aliases in two wiki links:

- `01 - Community/Obsidian Roundup/2021.08.21.md`
- `04 - Guides, Workflows, & Courses/Community Talks/Breadcrumbs Showcase.md`

This fixes #222

## Checklist

*Not applicable*

