### PR TITLE
Add a warning for any duplicate aliases in wiki links

### DIFF
--- a/.github/scripts/check_content.py
+++ b/.github/scripts/check_content.py
@@ -86,7 +86,11 @@ def check_file_markdown_content(file) -> None:
 def check_link(file, link) -> None:
     number_of_pipes = link.count('|')
     if number_of_pipes > 1:
-        logger.log_warning(file, f"Too many aliases in wiki link: {link}")
+        allowed_links_with_pipes = [
+            '[[obsidian-plugin-todo|Obsidian TODO | Text-based GTD]]'
+        ]
+        if link not in allowed_links_with_pipes:
+            logger.log_warning(file, f"Too many aliases in wiki link: {link}")
 
 
 def check_content_of_vault() -> None:

--- a/.github/scripts/check_content.py
+++ b/.github/scripts/check_content.py
@@ -16,27 +16,26 @@ class ErrorLogger:
 
     def log_error(self, relative_path, message):
         print(f'Error:\n  {message}:\n  {relative_path} ')
+        self.error_count += 1
 
 
 logger = ErrorLogger()
 
 
-def check_content_of_working_directory() -> int:
+def check_content_of_working_directory() -> None:
     """
     Walks through the filetree rooted at the current working directory.
     For each file that it finds, it validates the file
     """
-    error_count = 0
     moc_filter = MocFileAndDirectoryFilter()
     for root, dirs, files in walk('.', topdown=True):
         moc_filter.filter_directories(dirs)
         for file in files:
             relative_path = os.path.join(root, file)
-            error_count += check_file(relative_path, file)
-    return error_count
+            check_file(relative_path, file)
 
 
-def check_file(relative_path: str, file: str) -> int:
+def check_file(relative_path: str, file: str) -> None:
     """
     Check the given file for any issues.
 
@@ -52,30 +51,26 @@ def check_file(relative_path: str, file: str) -> int:
     if file[0] == '.':
         return 0
 
-    errors = 0
-
     if '.' not in file:
         logger.log_error(relative_path, 'This file has no extension: consider adding ".md" to its name')
-        errors += 1
 
     # Other checks may be added here in future
-    return errors
 
 
-def check_content_of_vault() -> int:
+def check_content_of_vault() -> None:
     os.chdir(get_root_of_vault())
-    return check_content_of_working_directory()
+    check_content_of_working_directory()
 
 
-def main(argv=sys.argv[1:]):
+def main(argv=sys.argv[1:]) -> None:
     parser = argparse.ArgumentParser(
         description="Check for issues with the content of the Hub vault (such as errors in file names)."
     )
     args = parser.parse_args(argv)
 
-    return check_content_of_vault()
+    check_content_of_vault()
 
 
 if __name__ == "__main__":
-    result = main()
-    exit(result)
+    main()
+    exit(logger.error_count)

--- a/.github/scripts/check_content.py
+++ b/.github/scripts/check_content.py
@@ -10,6 +10,17 @@ from make_mocs import MocFileAndDirectoryFilter
 from utils import get_root_of_vault
 
 
+class ErrorLogger:
+    def __init__(self):
+        self.error_count = 0
+
+    def log_error(self, relative_path, message):
+        print(f'Error:\n  {message}:\n  {relative_path} ')
+
+
+logger = ErrorLogger()
+
+
 def check_content_of_working_directory() -> int:
     """
     Walks through the filetree rooted at the current working directory.
@@ -44,7 +55,7 @@ def check_file(relative_path: str, file: str) -> int:
     errors = 0
 
     if '.' not in file:
-        print(f'Error:\n  This file has no extension: consider adding ".md" to its name:\n  {relative_path} ')
+        logger.log_error(relative_path, 'This file has no extension: consider adding ".md" to its name')
         errors += 1
 
     # Other checks may be added here in future

--- a/.github/scripts/check_content.py
+++ b/.github/scripts/check_content.py
@@ -1,5 +1,6 @@
 import argparse
 import os.path
+import re
 import sys
 from os import walk
 
@@ -15,7 +16,7 @@ class ErrorLogger:
         self.error_count = 0
 
     def log_error(self, relative_path, message):
-        print(f'Error:\n  {message}:\n  {relative_path} ')
+        print(f'\nError:\n  {message}:\n  {relative_path} ')
         self.error_count += 1
 
 
@@ -49,12 +50,34 @@ def check_file(relative_path: str, file: str) -> None:
     """
     # Ignore 'dot' files, such as '.gitignore'
     if file[0] == '.':
-        return 0
+        return
 
     if '.' not in file:
         logger.log_error(relative_path, 'This file has no extension: consider adding ".md" to its name')
 
-    # Other checks may be added here in future
+    check_file_markdown_content(relative_path)
+
+
+def get_internal_links(content):
+    regex = r'\[\[[^[]*]]'
+    return re.findall(regex, content)
+
+
+def check_file_markdown_content(file) -> None:
+    if not file.endswith('.md'):
+        return
+    with open(file) as f:
+        content = f.read()
+
+        internal_links = get_internal_links(content)
+        for link in internal_links:
+            check_link(file, link)
+
+
+def check_link(file, link) -> None:
+    number_of_pipes = link.count('|')
+    if number_of_pipes > 1:
+        logger.log_error(file, f"Too many aliases in wiki link: {link}")
 
 
 def check_content_of_vault() -> None:

--- a/.github/scripts/check_content.py
+++ b/.github/scripts/check_content.py
@@ -16,8 +16,17 @@ class ErrorLogger:
         self.error_count = 0
 
     def log_error(self, relative_path, message):
+        """
+        Log an error. Errors are treated as failures, giving a non-zero exit code from the script.
+        """
         print(f'\nError:\n  {message}:\n  {relative_path} ')
         self.error_count += 1
+
+    def log_warning(self, relative_path, message):
+        """
+        Log a warning. These will not cause the script to fail.
+        """
+        print(f'\nWarning:\n  {message}:\n  {relative_path} ')
 
 
 logger = ErrorLogger()
@@ -77,7 +86,7 @@ def check_file_markdown_content(file) -> None:
 def check_link(file, link) -> None:
     number_of_pipes = link.count('|')
     if number_of_pipes > 1:
-        logger.log_error(file, f"Too many aliases in wiki link: {link}")
+        logger.log_warning(file, f"Too many aliases in wiki link: {link}")
 
 
 def check_content_of_vault() -> None:


### PR DESCRIPTION
## Edited

Edited `.github/scripts/check_content.py` to:

- Add `ErrorLogger` class to print messages and count errors - to simplify adding new checks
- Add warnings for any `[[wiki links|with more than one|pipe character]]`
- They can't be errors, as there is one plugin that has a pipe character in its name, so I added a special case to prevent warnings being issued for that one.


## Checklist

*Not applicable*
