### PR TITLE
Add missing closing parentheses on 3 external links

### DIFF
--- a/01 - Community/Obsidian Roundup/2021.06.19.md
+++ b/01 - Community/Obsidian Roundup/2021.06.19.md
@@ -14,8 +14,7 @@
 * The [Adjacency Matrix Maker](https://github.com/SkepticMystic/adjacency-matrix-maker) can now show folders on the matrix up to any depth. 
 *  [Templater](https://github.com/SilentVoid13/Templater) (1.8.0) has new internal functions in the tp.file module and syntax highlighting in edit mode. 
 ### Scripts
-* `@Nick_At_Day` shared this [[templater-obsidian|Templater]] [script](http://discordapp.com/channels/686053708261228577/840286238928797736/853274331135606814
-) intended for folks who use "ABC" lists to try to come up with tags. It will allow you to select the table and return only the tags.
+* `@Nick_At_Day` shared this [[templater-obsidian|Templater]] [script](http://discordapp.com/channels/686053708261228577/840286238928797736/853274331135606814) intended for folks who use "ABC" lists to try to come up with tags. It will allow you to select the table and return only the tags.
 * `@Witt` shared a nice, simple, straightforward example of how to use inline [[dataview|Dataview]] queries that act as formulas manipulating a variable. 
 * `@Christian` created a [[quickadd|QuickAdd]] [script to move all notes with a tag to any folder](https://github.com/chhoumann/quickadd#macro-move-notes-with-a-tag-to-a-folder). 
 ### Under The Radar

--- a/01 - Community/Obsidian Roundup/2021.08.14.md
+++ b/01 - Community/Obsidian Roundup/2021.08.14.md
@@ -54,7 +54,7 @@
 
 ## Knowledge Management
 
-- `@joshduffney` has a nice video about [how to categorize and manage fleeting notes](https://www.youtube.com/watch?v=cvYitBS1yOY.
+- `@joshduffney` has a nice video about [how to categorize and manage fleeting notes](https://www.youtube.com/watch?v=cvYitBS1yOY).
 - `@ryanjamurphy` shared a new [framework for understanding Integrated Thinking Environments](https://axle.design/obsidian-roam-and-the-rise-of-integrated-thinking-environments%E2%80%94what-they-are-what-they-do-and-what-s) like Obsidian.
 
 ## [[🗂️ 02.04 Auxiliary Tools by Category|Ancillary tools]]

--- a/01 - Community/Obsidian Roundup/2021.08.21.md
+++ b/01 - Community/Obsidian Roundup/2021.08.21.md
@@ -34,7 +34,7 @@ _Remember, you can manually install any plugin by copying the `main.js`, `manife
 
 ## Workflow Stuff
 
-- `@bianca_oli_per` has a holistic [academic workflow](https://www.youtube.com/watch?v=fGJv6hiXPmk up over on [[Linking Your Thinking]]. It covers MOCs, [[LaTeX]] equations, [[Obsidian queries]], PDF extraction and more.
+- `@bianca_oli_per` has a holistic [academic workflow](https://www.youtube.com/watch?v=fGJv6hiXPmk) up over on [[Linking Your Thinking]]. It covers MOCs, [[LaTeX]] equations, [[Obsidian queries]], PDF extraction and more.
 - `@ASRenner1` shared how she uses Obsidian to provide a [minimalist but organized workspace](https://www.youtube.com/watch?v=OX_UKIzRALs) for her fiction and nonfiction writing process.
 - Remember, you can search for any heading or paragraph in your vault without knowing the file: `[[##` for headings, `[[^^` for blocks.
 - This [guide](https://publish.obsidian.md/arun/Tech/Obsidian/Using+Obsidian+with+Dragon+Dictation+-+Edit+Your+Notes+With+Full+Voice+Control) serves as a quick how-to for switching between editing notes in Obsidian and [[Dragon speech recognition|Dragon]]-friendly word processors with full text control and without reaching for the mouse or keyboard.


### PR DESCRIPTION
## Edited

- Add missing `)` after 3 URLs

Found with:

`find . -name \*.md -print0 | xargs -0 grep '](' | grep -v ')'`

Which gave this output:

```
./01 - Community/Obsidian Roundup/2021.08.14.md:
... [how to categorize and manage fleeting notes](https://www.youtube.com/watch?v=cvYitBS1yOY.

./01 - Community/Obsidian Roundup/2021.08.21.md:
...  [academic workflow](https://www.youtube.com/watch?v=fGJv6hiXPmk 

./01 - Community/Obsidian Roundup/2021.06.19.md:
... [script](http://discordapp.com/channels/686053708261228577/840286238928797736/853274331135606814
```
