### PR TITLE
Add more blank lines, before and in footer.

### DIFF
--- a/.github/scripts/add_footer.py
+++ b/.github/scripts/add_footer.py
@@ -81,6 +81,13 @@ def add_footer_to_markdown(relative_path, contents, comment, template, debug):
 
     debug_message = ""
 
+    # If the original file didn't have an end-of-line on the last line,
+    # add one here, to ensure that there is a gap between the body of the note
+    # and the footer.
+    eol = '\n'
+    if len(contents) == 0 or contents[-1] != eol:
+        contents += eol
+
     # Check if our particular comment is present
     if search(comment, contents):
         replacement = sub(comment, render, contents)

--- a/.github/scripts/templates/footer.md.jinja
+++ b/.github/scripts/templates/footer.md.jinja
@@ -1,4 +1,5 @@
 %% Hub footer: Please don't edit anything below this line %%
+
 # This note in GitHub
 
 <span class="git-footer">[Edit In GitHub](https://github.dev/obsidian-community/obsidian-hub/blob/main/{{ file_path }} "git-hub-edit-note") | [Copy this note](https://raw.githubusercontent.com/obsidian-community/obsidian-hub/main/{{ file_path }} "git-hub-copy-note") | [Download this vault](https://github.com/obsidian-community/obsidian-hub/archive/refs/heads/main.zip "git-hub-download-vault") </span>

--- a/.github/scripts/tests/approved_files/test_add_footer.test_end_of_line_added_if_missing.approved.md
+++ b/.github/scripts/tests/approved_files/test_add_footer.test_end_of_line_added_if_missing.approved.md
@@ -1,0 +1,20 @@
+
+INPUT:
+
+---
+# Sample note content.
+Path used for this test: `04 - Guides, Workflows, & Courses/for Plugin Developers.md`
+I do not have a line-ending at end of file. A blank line should be added.
+---
+
+OUTPUT:
+
+---
+# Sample note content.
+Path used for this test: `04 - Guides, Workflows, & Courses/for Plugin Developers.md`
+I do not have a line-ending at end of file. A blank line should be added.
+
+%% Hub footer: Please don't edit anything below this line %%
+# This note in GitHub
+
+<span class="git-footer">[Edit In GitHub](https://github.dev/obsidian-community/obsidian-hub/blob/main/04%20-%20Guides%2C%20Workflows%2C%20%26%20Courses/for%20Plugin%20Developers.md "git-hub-edit-note") | [Copy this note](https://raw.githubusercontent.com/obsidian-community/obsidian-hub/main/04%20-%20Guides%2C%20Workflows%2C%20%26%20Courses/for%20Plugin%20Developers.md "git-hub-copy-note") | [Download this vault](https://github.com/obsidian-community/obsidian-hub/archive/refs/heads/main.zip "git-hub-download-vault") </span>

--- a/.github/scripts/tests/approved_files/test_add_footer.test_end_of_line_added_if_missing.approved.md
+++ b/.github/scripts/tests/approved_files/test_add_footer.test_end_of_line_added_if_missing.approved.md
@@ -15,6 +15,7 @@ Path used for this test: `04 - Guides, Workflows, & Courses/for Plugin Developer
 I do not have a line-ending at end of file. A blank line should be added.
 
 %% Hub footer: Please don't edit anything below this line %%
+
 # This note in GitHub
 
 <span class="git-footer">[Edit In GitHub](https://github.dev/obsidian-community/obsidian-hub/blob/main/04%20-%20Guides%2C%20Workflows%2C%20%26%20Courses/for%20Plugin%20Developers.md "git-hub-edit-note") | [Copy this note](https://raw.githubusercontent.com/obsidian-community/obsidian-hub/main/04%20-%20Guides%2C%20Workflows%2C%20%26%20Courses/for%20Plugin%20Developers.md "git-hub-copy-note") | [Download this vault](https://github.com/obsidian-community/obsidian-hub/archive/refs/heads/main.zip "git-hub-download-vault") </span>

--- a/.github/scripts/tests/approved_files/test_add_footer.test_footer_added_if_missing.approved.md
+++ b/.github/scripts/tests/approved_files/test_add_footer.test_footer_added_if_missing.approved.md
@@ -20,6 +20,7 @@ should still work.
 CHECK that path in URLs has been encoded.
 
 %% Hub footer: Please don't edit anything below this line %%
+
 # This note in GitHub
 
 <span class="git-footer">[Edit In GitHub](https://github.dev/obsidian-community/obsidian-hub/blob/main/04%20-%20Guides%2C%20Workflows%2C%20%26%20Courses/for%20Plugin%20Developers.md "git-hub-edit-note") | [Copy this note](https://raw.githubusercontent.com/obsidian-community/obsidian-hub/main/04%20-%20Guides%2C%20Workflows%2C%20%26%20Courses/for%20Plugin%20Developers.md "git-hub-copy-note") | [Download this vault](https://github.com/obsidian-community/obsidian-hub/archive/refs/heads/main.zip "git-hub-download-vault") </span>

--- a/.github/scripts/tests/approved_files/test_add_footer.test_footer_updated_if_present.approved.md
+++ b/.github/scripts/tests/approved_files/test_add_footer.test_footer_updated_if_present.approved.md
@@ -8,6 +8,7 @@ CHECK that the footer is only present once in the output.
 CHECK that UPPER-CASE of this text is not present: 'check that i am not present in final output'
 
 %% Hub footer: Please don't edit anything below this line %%
+
 # This note in GitHub
 
 <span class="git-footer">[Edit In GitHub](https://github.dev/obsidian-community/obsidian-hub/blob/main/04%20-%20Guides%2C%20Workflows%2C%20%26%20Courses/for%20Plugin%20Developers.md "git-hub-edit-note") | [Copy this note](https://raw.githubusercontent.com/obsidian-community/obsidian-hub/main/04%20-%20Guides%2C%20Workflows%2C%20%26%20Courses/for%20Plugin%20Developers.md "git-hub-copy-note") | [Download this vault](https://github.com/obsidian-community/obsidian-hub/archive/refs/heads/main.zip "git-hub-download-vault") </span>
@@ -23,6 +24,7 @@ CHECK that the footer is only present once in the output.
 CHECK that UPPER-CASE of this text is not present: 'check that i am not present in final output'
 
 %% Hub footer: Please don't edit anything below this line %%
+
 # This note in GitHub
 
 <span class="git-footer">[Edit In GitHub](https://github.dev/obsidian-community/obsidian-hub/blob/main/04%20-%20Guides%2C%20Workflows%2C%20%26%20Courses/for%20Plugin%20Developers.md "git-hub-edit-note") | [Copy this note](https://raw.githubusercontent.com/obsidian-community/obsidian-hub/main/04%20-%20Guides%2C%20Workflows%2C%20%26%20Courses/for%20Plugin%20Developers.md "git-hub-copy-note") | [Download this vault](https://github.com/obsidian-community/obsidian-hub/archive/refs/heads/main.zip "git-hub-download-vault") </span>

--- a/.github/scripts/tests/test_add_footer.py
+++ b/.github/scripts/tests/test_add_footer.py
@@ -37,6 +37,16 @@ CHECK that path in URLs has been encoded.
     output = add_footer_to_markdown_test(input, relative_path)
     verify_footer_addition(input, output)
 
+# Ensure eol is added before footer, if missing from input file
+def test_end_of_line_added_if_missing():
+    relative_path = '04 - Guides, Workflows, & Courses/for Plugin Developers.md'
+    input = \
+        f"""# Sample note content.
+Path used for this test: `{relative_path}`
+I do not have a line-ending at end of file. A blank line should be added."""
+    output = add_footer_to_markdown_test(input, relative_path)
+    verify_footer_addition(input, output)
+
 
 # Test that footer is not added twice
 # Test that footer is updated if content differs


### PR DESCRIPTION
## Edited

- Ensure eol is added before footer, if missing from input file - as discussed in Discord
- Also put a blank line between `%% Hub footer: ... %%` and `# This note in GitHub` - for consistency with 7c1483f6f5f3da29e0b19f7ee83666baaa8ddbd0
