### PR TITLE
Adjust add_footer.py to ensure that updated files end with an end-of-line character

### DIFF
--- a/.github/scripts/add_footer.py
+++ b/.github/scripts/add_footer.py
@@ -6,7 +6,7 @@ from utils import get_template
 from re import sub, search
 from urllib.parse import quote
 
-from utils import get_root_of_vault
+from utils import ensure_last_line_has_eol, get_root_of_vault
 
 # These are directories and files to exclude
 # By adding a dir/file, this script will ignore them and never change them!
@@ -103,13 +103,6 @@ def add_footer_to_markdown(relative_path, contents, comment, template, debug):
         print(f"\t=> {debug_message} for '{relative_path}'.")
 
     return replacement
-
-
-def ensure_last_line_has_eol(contents):
-    eol = '\n'
-    if len(contents) == 0 or contents[-1] != eol:
-        contents += eol
-    return contents
 
 
 def main():

--- a/.github/scripts/add_footer.py
+++ b/.github/scripts/add_footer.py
@@ -78,6 +78,7 @@ def add_footer_to_markdown(relative_path, contents, comment, template, debug):
     # Get the rendered template (file => relative path => html encoded)
     render = template.render(
         file_path=quote(relative_path))
+    render = ensure_last_line_has_eol(render)
 
     debug_message = ""
 

--- a/.github/scripts/add_footer.py
+++ b/.github/scripts/add_footer.py
@@ -84,9 +84,7 @@ def add_footer_to_markdown(relative_path, contents, comment, template, debug):
     # If the original file didn't have an end-of-line on the last line,
     # add one here, to ensure that there is a gap between the body of the note
     # and the footer.
-    eol = '\n'
-    if len(contents) == 0 or contents[-1] != eol:
-        contents += eol
+    contents = ensure_last_line_has_eol(contents)
 
     # Check if our particular comment is present
     if search(comment, contents):
@@ -105,6 +103,13 @@ def add_footer_to_markdown(relative_path, contents, comment, template, debug):
         print(f"\t=> {debug_message} for '{relative_path}'.")
 
     return replacement
+
+
+def ensure_last_line_has_eol(contents):
+    eol = '\n'
+    if len(contents) == 0 or contents[-1] != eol:
+        contents += eol
+    return contents
 
 
 def main():

--- a/.github/scripts/tests/approved_files/test_add_footer.test_end_of_line_added_if_missing.approved.md
+++ b/.github/scripts/tests/approved_files/test_add_footer.test_end_of_line_added_if_missing.approved.md
@@ -19,3 +19,4 @@ I do not have a line-ending at end of file. A blank line should be added.
 # This note in GitHub
 
 <span class="git-footer">[Edit In GitHub](https://github.dev/obsidian-community/obsidian-hub/blob/main/04%20-%20Guides%2C%20Workflows%2C%20%26%20Courses/for%20Plugin%20Developers.md "git-hub-edit-note") | [Copy this note](https://raw.githubusercontent.com/obsidian-community/obsidian-hub/main/04%20-%20Guides%2C%20Workflows%2C%20%26%20Courses/for%20Plugin%20Developers.md "git-hub-copy-note") | [Download this vault](https://github.com/obsidian-community/obsidian-hub/archive/refs/heads/main.zip "git-hub-download-vault") </span>
+

--- a/.github/scripts/tests/approved_files/test_add_footer.test_footer_added_if_missing.approved.md
+++ b/.github/scripts/tests/approved_files/test_add_footer.test_footer_added_if_missing.approved.md
@@ -24,3 +24,4 @@ CHECK that path in URLs has been encoded.
 # This note in GitHub
 
 <span class="git-footer">[Edit In GitHub](https://github.dev/obsidian-community/obsidian-hub/blob/main/04%20-%20Guides%2C%20Workflows%2C%20%26%20Courses/for%20Plugin%20Developers.md "git-hub-edit-note") | [Copy this note](https://raw.githubusercontent.com/obsidian-community/obsidian-hub/main/04%20-%20Guides%2C%20Workflows%2C%20%26%20Courses/for%20Plugin%20Developers.md "git-hub-copy-note") | [Download this vault](https://github.com/obsidian-community/obsidian-hub/archive/refs/heads/main.zip "git-hub-download-vault") </span>
+

--- a/.github/scripts/tests/approved_files/test_add_footer.test_footer_updated_if_present.approved.md
+++ b/.github/scripts/tests/approved_files/test_add_footer.test_footer_updated_if_present.approved.md
@@ -12,6 +12,7 @@ CHECK that UPPER-CASE of this text is not present: 'check that i am not present 
 # This note in GitHub
 
 <span class="git-footer">[Edit In GitHub](https://github.dev/obsidian-community/obsidian-hub/blob/main/04%20-%20Guides%2C%20Workflows%2C%20%26%20Courses/for%20Plugin%20Developers.md "git-hub-edit-note") | [Copy this note](https://raw.githubusercontent.com/obsidian-community/obsidian-hub/main/04%20-%20Guides%2C%20Workflows%2C%20%26%20Courses/for%20Plugin%20Developers.md "git-hub-copy-note") | [Download this vault](https://github.com/obsidian-community/obsidian-hub/archive/refs/heads/main.zip "git-hub-download-vault") </span>
+
 CHECK THAT I AM NOT PRESENT IN FINAL OUTPUT
 ---
 
@@ -28,3 +29,4 @@ CHECK that UPPER-CASE of this text is not present: 'check that i am not present 
 # This note in GitHub
 
 <span class="git-footer">[Edit In GitHub](https://github.dev/obsidian-community/obsidian-hub/blob/main/04%20-%20Guides%2C%20Workflows%2C%20%26%20Courses/for%20Plugin%20Developers.md "git-hub-edit-note") | [Copy this note](https://raw.githubusercontent.com/obsidian-community/obsidian-hub/main/04%20-%20Guides%2C%20Workflows%2C%20%26%20Courses/for%20Plugin%20Developers.md "git-hub-copy-note") | [Download this vault](https://github.com/obsidian-community/obsidian-hub/archive/refs/heads/main.zip "git-hub-download-vault") </span>
+

--- a/.github/scripts/tests/test_add_footer.py
+++ b/.github/scripts/tests/test_add_footer.py
@@ -85,6 +85,14 @@ def add_footer_to_markdown_test(input: str, relative_path:str) -> str:
 
 
 def verify_footer_addition(input, output):
+
+    # First make sure that the output has a finely end-of-line character.
+    explanation = """
+    ERROR.
+    The generated footer does not have an end-of-line character on the last line.
+    """
+    assert output[-1] == '\n', explanation
+
     text_to_verify = f"""
 INPUT:
 

--- a/.github/scripts/tests/test_add_footer.py
+++ b/.github/scripts/tests/test_add_footer.py
@@ -86,12 +86,7 @@ def add_footer_to_markdown_test(input: str, relative_path:str) -> str:
 
 def verify_footer_addition(input, output):
 
-    # First make sure that the output has a finely end-of-line character.
-    explanation = """
-    ERROR.
-    The generated footer does not have an end-of-line character on the last line.
-    """
-    assert output[-1] == '\n', explanation
+    check_output_has_eol_on_last_line(output)
 
     text_to_verify = f"""
 INPUT:
@@ -106,3 +101,12 @@ OUTPUT:
 {output}
 """
     verify(text_to_verify, options=approval_test_options())
+
+
+def check_output_has_eol_on_last_line(output):
+    # First make sure that the output has a finely end-of-line character.
+    explanation = """
+    ERROR.
+    The generated footer does not have an end-of-line character on the last line.
+    """
+    assert output[-1] == '\n', explanation

--- a/.github/scripts/utils.py
+++ b/.github/scripts/utils.py
@@ -195,7 +195,12 @@ def get_root_of_vault() -> str:
     return up2
 
 
-def ensure_last_line_has_eol(contents):
+def ensure_last_line_has_eol(contents) -> str:
+    """
+    Ensure that the given string ends with an end-of-line character.
+    :param contents: The string to check
+    :return: The supplied string, with a `\n` added, if needed
+    """
     eol = '\n'
     if len(contents) == 0 or contents[-1] != eol:
         contents += eol

--- a/.github/scripts/utils.py
+++ b/.github/scripts/utils.py
@@ -193,3 +193,10 @@ def get_root_of_vault() -> str:
     up1 = os.path.dirname(dir_path)
     up2 = os.path.dirname(up1)
     return up2
+
+
+def ensure_last_line_has_eol(contents):
+    eol = '\n'
+    if len(contents) == 0 or contents[-1] != eol:
+        contents += eol
+    return contents


### PR DESCRIPTION
## Edited

- `utils.py` has new function `ensure_last_line_has_eol()`
- `add_footer.py` now ensures that any updated `.md` files end with an end-of-line character
- `test_add_footer.py` checks that added footers have this EOL. (This failed before the above changes were made)

This is the code half of #244