### PR TITLE
Add API class diagram

### DIFF
--- a/04 - Guides, Workflows, & Courses/for Plugin Developers.md
+++ b/04 - Guides, Workflows, & Courses/for Plugin Developers.md
@@ -41,6 +41,7 @@ This note collects resources and guides for beginner and expert plugin developer
 - [obsidian-tools:](https://github.com/obsidian-tools/obsidian-tools) an unofficial collection of tools that helps devs build plugins for obsidian.
 - [obsidian-rust-plugin:](https://github.com/trashhalo/obsidian-rust-plugin) boilerplate needed to write obsidian plugins in rust!
 - [obsidian-api-docs:](https://github.com/HEmile/obsidian-api-docs/blob/main/docs/00_Home.md) community-provided documentation of the Obsidian API.
+- [API class diagram](https://i.joethei.space/obsidian-api.png): structure and relationships between API classes([svg version](https://i.joethei.space/obsidian-api.svg))
 - [obsidian-dev-tools:](https://github.com/KjellConnelly/obsidian-dev-tools)  allows for a modified console (useful for debugging on mobile), and viewing all Obsidian icons/strings.
 - [obsidian-daily-notes-interface:](https://github.com/liamcain/obsidian-daily-notes-interface) a collection of utility functions for working with dates and daily notes in Obsidian plugins.
 - [obsidian-calendar-ui:](https://github.com/liamcain/obsidian-calendar-ui) provides an out-of-the-box calendar view for Obsidian plugins.


### PR DESCRIPTION
## Added
Links to automatically generated class diagrams of the obsidian API to the developer documentation.

(This one: https://i.joethei.space/obsidian-api.png)

## Checklist
- [X] before creating a new note, I searched the vault
- [X] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
