### PR TITLE
Prevent update_releases.py from removing footers from all files it touches

### DIFF
--- a/.github/scripts/add_footer.py
+++ b/.github/scripts/add_footer.py
@@ -74,6 +74,12 @@ def get_footer_comment_regex() -> str:
     return r"(?sm)%% Hub footer: Please don't edit anything below this line %%.*"
 
 
+def encode_absolute_path_for_footer(absolute_path):
+    relative_path = relpath(absolute_path, get_root_of_vault())
+    encoded_path = quote(relative_path)
+    return encoded_path
+
+
 def add_footer_to_markdown(relative_path, contents, comment, template, debug):
     # Get the rendered template (file => relative path => html encoded)
     render = template.render(

--- a/.github/scripts/templates/author.md.jinja
+++ b/.github/scripts/templates/author.md.jinja
@@ -63,3 +63,5 @@ publish: true
 - Twitter: ^twitter
 - ...
 -->
+
+{% include "footer.md.jinja" %}

--- a/.github/scripts/templates/plugin.md.jinja
+++ b/.github/scripts/templates/plugin.md.jinja
@@ -9,3 +9,4 @@
 
 {% include "funding.md.jinja" %}
 
+{% include "footer.md.jinja" %}

--- a/.github/scripts/templates/theme.md.jinja
+++ b/.github/scripts/templates/theme.md.jinja
@@ -25,3 +25,5 @@
 
 [^1]: Generally, Obsidian themes work with any plugins. That a plugin is not listed here does not mean that it won't work together with the theme. Plugins listed here only received special attention and/or styling by the theme designer.
 {% endif%}
+
+{% include "footer.md.jinja" %}

--- a/.github/scripts/tests/approved_files/test_templates.test_author_from_jinja.approved.md
+++ b/.github/scripts/tests/approved_files/test_templates.test_author_from_jinja.approved.md
@@ -59,3 +59,9 @@ publish: true
 - Twitter: ^twitter
 - ...
 -->
+
+%% Hub footer: Please don't edit anything below this line %%
+
+# This note in GitHub
+
+<span class="git-footer">[Edit In GitHub](https://github.dev/obsidian-community/obsidian-hub/blob/main/Some%20Encoded%20Path.md "git-hub-edit-note") | [Copy this note](https://raw.githubusercontent.com/obsidian-community/obsidian-hub/main/Some%20Encoded%20Path.md "git-hub-copy-note") | [Download this vault](https://github.com/obsidian-community/obsidian-hub/archive/refs/heads/main.zip "git-hub-download-vault") </span>

--- a/.github/scripts/tests/approved_files/test_templates.test_author_from_jinja_minimal.approved.md
+++ b/.github/scripts/tests/approved_files/test_templates.test_author_from_jinja_minimal.approved.md
@@ -53,3 +53,9 @@ publish: true
 - Twitter: ^twitter
 - ...
 -->
+
+%% Hub footer: Please don't edit anything below this line %%
+
+# This note in GitHub
+
+<span class="git-footer">[Edit In GitHub](https://github.dev/obsidian-community/obsidian-hub/blob/main/Some%20Encoded%20Path.md "git-hub-edit-note") | [Copy this note](https://raw.githubusercontent.com/obsidian-community/obsidian-hub/main/Some%20Encoded%20Path.md "git-hub-copy-note") | [Download this vault](https://github.com/obsidian-community/obsidian-hub/archive/refs/heads/main.zip "git-hub-download-vault") </span>

--- a/.github/scripts/tests/test_make_mocs.py
+++ b/.github/scripts/tests/test_make_mocs.py
@@ -75,9 +75,9 @@ def approval_test_options():
     # The supported tool names are listed in:
     #   https://github.com/approvals/ApprovalTests.Python/blob/master/approvaltests/reporters/reporters.json
     #
-    # diff_tool_name = "AraxisMergeMac"
-    # diff_tool = GenericDiffReporterFactory().get(diff_tool_name)
-    # options = options.with_reporter(diff_tool)
+    diff_tool_name = "AraxisMergeMac"
+    diff_tool = GenericDiffReporterFactory().get(diff_tool_name)
+    options = options.with_reporter(diff_tool)
 
     return options
 

--- a/.github/scripts/tests/test_make_mocs.py
+++ b/.github/scripts/tests/test_make_mocs.py
@@ -75,9 +75,9 @@ def approval_test_options():
     # The supported tool names are listed in:
     #   https://github.com/approvals/ApprovalTests.Python/blob/master/approvaltests/reporters/reporters.json
     #
-    diff_tool_name = "AraxisMergeMac"
-    diff_tool = GenericDiffReporterFactory().get(diff_tool_name)
-    options = options.with_reporter(diff_tool)
+    # diff_tool_name = "AraxisMergeMac"
+    # diff_tool = GenericDiffReporterFactory().get(diff_tool_name)
+    # options = options.with_reporter(diff_tool)
 
     return options
 

--- a/.github/scripts/tests/test_templates.py
+++ b/.github/scripts/tests/test_templates.py
@@ -64,14 +64,15 @@ def test_author_from_jinja():
                                   themes=[
                                       "[[my-theme1]]",
                                       "[[my-theme2]]",
-                                  ], )
+                                  ],
+                                  file_path="Some%20Encoded%20Path.md")
 
     verify(new_content, options=approval_test_options())
 
 
 def test_author_from_jinja_minimal():
     template = utils.get_template_from_directory(JINJA_TEMPLATES_DIR, "author.md.jinja")
-    new_content = template.render(user="test-user", author="test-user")
+    new_content = template.render(user="test-user", author="test-user", file_path="Some%20Encoded%20Path.md")
 
     verify(new_content, options=approval_test_options())
 

--- a/.github/scripts/utils.py
+++ b/.github/scripts/utils.py
@@ -60,8 +60,8 @@ def get_output_dir(template, file_name):
 
 def write_file(template, file_name, overwrite=False, verbose=False, **kwargs):
     file_path = get_output_dir(template, file_name)
-
     encoded_path = encode_absolute_path_for_footer(os.path.abspath(file_path))
+
     file_content = template.render(file_path=encoded_path, **kwargs)
     file_content = ensure_last_line_has_eol(file_content)
 

--- a/.github/scripts/utils.py
+++ b/.github/scripts/utils.py
@@ -1,7 +1,6 @@
 import os
 import json
 import glob
-import urllib
 
 import requests
 

--- a/.github/scripts/utils.py
+++ b/.github/scripts/utils.py
@@ -62,8 +62,7 @@ def write_file(template, file_name, overwrite=False, verbose=False, **kwargs):
     file_path = get_output_dir(template, file_name)
 
     absolute_path = os.path.abspath(file_path)
-    relative_path = os.path.relpath(absolute_path, get_root_of_vault())
-    encoded_path = urllib.parse.quote(relative_path)
+    encoded_path = encode_absolute_path_for_footer(absolute_path)
     file_content = template.render(file_path=encoded_path, **kwargs)
     file_content = ensure_last_line_has_eol(file_content)
 
@@ -94,6 +93,12 @@ def write_file(template, file_name, overwrite=False, verbose=False, **kwargs):
         group = "new"
 
     return group
+
+
+def encode_absolute_path_for_footer(absolute_path):
+    relative_path = os.path.relpath(absolute_path, get_root_of_vault())
+    encoded_path = urllib.parse.quote(relative_path)
+    return encoded_path
 
 
 def have_same_contents(file_path, rendered_template):

--- a/.github/scripts/utils.py
+++ b/.github/scripts/utils.py
@@ -1,6 +1,8 @@
 import os
 import json
 import glob
+import urllib
+
 import requests
 
 from urllib.request import urlopen
@@ -58,7 +60,12 @@ def get_output_dir(template, file_name):
 
 def write_file(template, file_name, overwrite=False, verbose=False, **kwargs):
     file_path = get_output_dir(template, file_name)
-    file_content = template.render(**kwargs)
+
+    absolute_path = os.path.abspath(file_path)
+    relative_path = os.path.relpath(absolute_path, get_root_of_vault())
+    encoded_path = urllib.parse.quote(relative_path)
+    file_content = template.render(file_path=encoded_path, **kwargs)
+    file_content = ensure_last_line_has_eol(file_content)
 
     # Check if file exists
     if os.path.exists(file_path) and not overwrite:

--- a/.github/scripts/utils.py
+++ b/.github/scripts/utils.py
@@ -59,6 +59,10 @@ def get_output_dir(template, file_name):
 
 
 def write_file(template, file_name, overwrite=False, verbose=False, **kwargs):
+    # This add_footer function cannot be imported at top of this file,
+    # as this would cause a cyclic reference:
+    from add_footer import encode_absolute_path_for_footer 
+
     file_path = get_output_dir(template, file_name)
     encoded_path = encode_absolute_path_for_footer(os.path.abspath(file_path))
 
@@ -92,12 +96,6 @@ def write_file(template, file_name, overwrite=False, verbose=False, **kwargs):
         group = "new"
 
     return group
-
-
-def encode_absolute_path_for_footer(absolute_path):
-    relative_path = os.path.relpath(absolute_path, get_root_of_vault())
-    encoded_path = urllib.parse.quote(relative_path)
-    return encoded_path
 
 
 def have_same_contents(file_path, rendered_template):

--- a/.github/scripts/utils.py
+++ b/.github/scripts/utils.py
@@ -58,21 +58,22 @@ def get_output_dir(template, file_name):
 
 def write_file(template, file_name, overwrite=False, verbose=False, **kwargs):
     file_path = get_output_dir(template, file_name)
+    file_content = template.render(**kwargs)
 
     # Check if file exists
     if os.path.exists(file_path) and not overwrite:
         group = "modified"
         modified = "File contents don't match template."
 
-        if have_same_contents(file_path, template.render(**kwargs)):
+        if have_same_contents(file_path, file_content):
             modified = ""
             group = "exists"
 
         if verbose:
             print("{} exists. {}".format(file_name, modified))
     elif os.path.exists(file_path) and overwrite:
-        if not have_same_contents(file_path, template.render(**kwargs)):
-            template.stream(**kwargs).dump(file_path)
+        if not have_same_contents(file_path, file_content):
+            open(file_path, 'w').write(file_content)
             group = "overwritten"
             if verbose:
                 print("Overwriting {}".format(file_name))
@@ -82,7 +83,7 @@ def write_file(template, file_name, overwrite=False, verbose=False, **kwargs):
         # Create file
         if verbose:
             print("Creating {}".format(file_name))
-        template.stream(**kwargs).dump(file_path)
+        open(file_path, 'w').write(file_content)
         group = "new"
 
     return group

--- a/.github/scripts/utils.py
+++ b/.github/scripts/utils.py
@@ -61,8 +61,7 @@ def get_output_dir(template, file_name):
 def write_file(template, file_name, overwrite=False, verbose=False, **kwargs):
     file_path = get_output_dir(template, file_name)
 
-    absolute_path = os.path.abspath(file_path)
-    encoded_path = encode_absolute_path_for_footer(absolute_path)
+    encoded_path = encode_absolute_path_for_footer(os.path.abspath(file_path))
     file_content = template.render(file_path=encoded_path, **kwargs)
     file_content = ensure_last_line_has_eol(file_content)
 


### PR DESCRIPTION
See issue #250  (not 240, which is the wrongly-named branch I did this work on)

This change means that files written by `update_releases.py` will now have the footer, from the moment that they are written

## Edited

- `write_file()` in `utils.py` now passes `file_path` to the templates for new author, plugin and theme
    - for this to be manageable, I refactored its implementation so that there is only 1 template-rendering call, where previously there were several.
-  `test_templates.py` updated to also pass in a simulated `file_path` variable

**Note:** The code in `update_releases.py` still strips the footer from `Uncategorized plugins.md` - that can be fixed in a later PR.