### PR TITLE
Create Volunteer Plugin Doc Writers

### DIFF
--- a/06 - Inbox/Volunteer Doc Writers
+++ b/06 - Inbox/Volunteer Doc Writers
@@ -1,0 +1,12 @@
+# Volunteer Doc Writers
+
+Half (maybe all?) the fun of using Obsidian is its comprehensive set of plugins. We recently crossed the 500 mark! However, a few plugins could use some better documentation. We'd like to help bridge that gap.
+
+We'll maintain a list of plugins that need better docs. You can reach out the the plugin developer and collaborate with them to help out. You don't necessarily need technical skills to contribute; you could add "Getting Started" pages to bring users up to speed about how to use the plugin. That said, some technical ability will be of help too. 
+
+Don't be shy to contribute! The worst that could happen is that the plugin developer requests you write things slightly differently. Feel free to drop by on our Discord (`#plugin-general`) if you need help as well.
+
+## Looking for help
+
+- [shabegom/buttons](https://github.com/shabegom/buttons)
+- [valentine195/obsidian-leaflet-plugin](https://github.com/valentine195/obsidian-leaflet-plugin)

--- a/06 - Inbox/Volunteer Plugin Doc Writers.md
+++ b/06 - Inbox/Volunteer Plugin Doc Writers.md
@@ -1,4 +1,4 @@
-# Volunteer Doc Writers
+# Volunteer Plugin Doc Writers
 
 Half (maybe all?) the fun of using Obsidian is its comprehensive set of plugins. We recently crossed the 500 mark! However, a few plugins could use some better documentation. We'd like to help bridge that gap.
 

--- a/06 - Inbox/Volunteer Plugin Doc Writers.md
+++ b/06 - Inbox/Volunteer Plugin Doc Writers.md
@@ -2,7 +2,7 @@
 
 Half (maybe all?) the fun of using Obsidian is its comprehensive set of plugins. We recently crossed the 500 mark! However, a few plugins could use some better documentation. We'd like to help bridge that gap.
 
-We'll maintain a list of plugins that need better docs. You can reach out the the plugin developer and collaborate with them to help out. You don't necessarily need technical skills to contribute; you could add "Getting Started" pages to bring users up to speed about how to use the plugin. That said, some technical ability will be of help too. 
+We'll maintain a list of plugins that need better docs. You can reach out to the plugin developer and collaborate with them to help out. You don't necessarily need technical skills to contribute; you could add "Getting Started" pages to bring users up to speed about how to use the plugin. That said, some technical ability will be of help too. 
 
 Don't be shy to contribute! The worst that could happen is that the plugin developer requests you write things slightly differently. Feel free to drop by on our Discord (`#plugin-general`) if you need help as well.
 


### PR DESCRIPTION
## Added
A volunteer docs page as discussed on Discord: https://discord.com/channels/686053708261228577/840286238928797736/936621649829199923

## Checklist
- [X] before creating a new note, I searched the vault
- [X] new notes have the `.md` extension
- [X] (if applicable) attached images have descriptive file names
- [X] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
