### PR TITLE
Fix: typo/duplicate words in Roundup MOC

### DIFF
--- a/01 - Community/Obsidian Roundup/🗂️ Obsidian Roundup.md
+++ b/01 - Community/Obsidian Roundup/🗂️ Obsidian Roundup.md
@@ -8,7 +8,7 @@ publish: true
 
 # 🗂️ Obsidian Roundup
 
-The Obsidian Roundup is a weekly newsletter written by written by moderator [[eleanorkonik|Eleanor Konik]]. It is intended to help Obsidian users stay in the loop about community events, code updates and workflow tips. Each issue represents a summary of potentially relevant information the community engaged with in a particular week. You can [subscribe](https://www.obsidianroundup.org/membership/) via email or RSS. 
+The Obsidian Roundup is a weekly newsletter written by moderator [[eleanorkonik|Eleanor Konik]]. It is intended to help Obsidian users stay in the loop about community events, code updates and workflow tips. Each issue represents a summary of potentially relevant information the community engaged with in a particular week. You can [subscribe](https://www.obsidianroundup.org/membership/) via email or RSS. 
 
 This archive lags slightly behind the one on the [Roundup's website](https://obsidianroundup.org/) but is interlinked with the rest of the Hub thanks to community efforts. You can contribute to that effort [here](https://github.com/obsidian-community/obsidian-hub/contribute).
 


### PR DESCRIPTION
## Edited
<!-- Add a brief description here -->
Found a typo/duplicate "written by" in the Obsidian Roundup MOC.

## Added
<!-- Add a brief description here-->

## Checklist
- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
