### PR TITLE
Add dy-sh's Obsidian Training Course in Russian (Fixes #264)

### DIFF
--- a/01 - Community/People/dy-sh.md
+++ b/01 - Community/People/dy-sh.md
@@ -36,11 +36,9 @@ publish: true
 - 
 -->
 
-<!--
 ### Others
 
-- 
--->
+- Playlist for [[Obsidian Training Course in Russian]]: https://youtube.com/playlist?list=PLrRc3UisLr6KVOYhzpSnywtHkCi2PEza5
 
 <!--
 ## Sponsor this author
@@ -52,10 +50,11 @@ publish: true
 
 -->
 
-<!--
 ## Follow this author
 
-- [[YouTube Channels|On YouTube]]: ^youtube
+- [[YouTube Channels|On YouTube]]: https://www.youtube.com/c/dysh1 ^youtube
+
+<!--
 - Twitter: ^twitter
 - ...
 -->

--- a/04 - Guides, Workflows, & Courses/Community Talks/YT - An Introduction to Dataview.md
+++ b/04 - Guides, Workflows, & Courses/Community Talks/YT - An Introduction to Dataview.md
@@ -7,7 +7,7 @@ tags:
 
 # An Introduction to [[dataview|Dataview]]
 
-Slides [[An Introduction to Dataview]]
+Slides: [[An Introduction to Dataview Slides]]
 
 This was the very first [[Obsidian Community Talks|Obsidian Community Talk]].  [[SkepticMystic]] gave a great overview of the [[dataview|Dataview]] plugin. 
 

--- a/04 - Guides, Workflows, & Courses/Courses/Obsidian Training Course in Russian.md
+++ b/04 - Guides, Workflows, & Courses/Courses/Obsidian Training Course in Russian.md
@@ -1,0 +1,19 @@
+---
+aliases: 
+- 
+tags:
+- seedling
+publish: true
+---
+
+# Obsidian Training Course in Russian
+
+%% Add a description below this line. It doesn't need to be long: one or two sentences should be a good start. %%
+
+This comprehensive [[🗂️ Courses|course]] by [[dy-sh]] is aimed at Russian speakers and covers how to write notes/documentation in [[Markdown]], why you should do it in Markdown and how to use [[Obsidian]] for this purpose.
+
+It goes over how to set up the application, how and which [[🗂️ Plugins|plugins]] to install, how to organize your library of files and even how to [[for Plugin Developers|write your own plugin]].
+
+All 8 parts of the course are available on [YouTube](https://youtube.com/playlist?list=PLrRc3UisLr6KVOYhzpSnywtHkCi2PEza5):
+
+<iframe width="100%" height="400px" src="https://www.youtube.com/embed/aeebp25l9Gg?list=PLrRc3UisLr6KVOYhzpSnywtHkCi2PEza5" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/04 - Guides, Workflows, & Courses/Guides/An Introduction to Dataview Slides.md
+++ b/04 - Guides, Workflows, & Courses/Guides/An Introduction to Dataview Slides.md
@@ -11,66 +11,99 @@ publish: true
 
 %% Add a description below this line. It doesn't need to be long: one or two sentences should be a good start. %%
 
-This is a reformatted, web-compatible version of the very first [[Obsidian Community Talks|Obsidian Community Talk]], an overview of the [[dataview|Dataview]] plugin, held by [[SkepticMystic]]. 
+These are the original markdown slides from my [[Obsidian Community Talks|Community Talk]] on [[YT - An Introduction to Dataview|An Introduction to Dataview]].
+You can convert these slides to [[revealjs]] by [[Using Pandoc inside Obsidian|using Pandoc]].
 
-The original slides can be found [[An Introduction to Dataview Slides|here]] and are best viewed with Obsidian and the [[obsidian-advanced-slides|Advanced Slides]] plugin or converted to [[revealjs]] with [[YT - Pandoc and Obsidian - Create slideshows, PDFs and Word documents|Pandoc]]. Make sure to also take a look at the [[YT - An Introduction to Dataview|YouTube video]] for in-depth explanations.
+For a better reading experience on the web version of the hub, these notes have been reformatted and provided in [[An Introduction to Dataview|condensed form]].
 
 By [[SkepticMystic]]
 
-## Overview
-1. [[An Introduction to Dataview#Introduction|Broad Intro to Dataview]]
-2. [[An Introduction to Dataview#Metadata|Metadata]]
-3. [[An Introduction to Dataview#Dataview Queries|Dataview Queries]]
-    - [[An Introduction to Dataview#List|List]]
-    - [[An Introduction to Dataview#From|From]]
-    - [[An Introduction to Dataview#Where|Where]]
-    - [[An Introduction to Dataview#Task|Task]]
-    - [[An Introduction to Dataview#Table|Table]]
-    - [[An Introduction to Dataview#Sort|Sort]]
-    - [[An Introduction to Dataview#Flatten|Flatten]]
-    - [[An Introduction to Dataview#Group by|Group by]]
-    
-## Introduction
-The *official documentation* for [[dataview|Dataview]] is available here:
-https://blacksmithgu.github.io/obsidian-dataview
+# Overview
 
-## Metadata
+---
 
-### What is it?
+1.  Broad Intro to Dataview
 
-Metadata provides information _about_ your data. 
+. . .
+
+2.  Metadata
+
+::: incremental
+
+3.  Dataview Queries
+    - `List`
+    - `From`
+    - `Where`
+    - `Task`
+    - `Table`
+    - `Sort`
+    - `Flatten`
+    - `Group by`
+
+:::
+
+# Introduction
+
+## {data-background-iframe="https://blacksmithgu.github.io/obsidian-dataview/#/README"}
+
+# Metadata
+
+## What is it?
+
+Metadata provides information _about_ your data.
+
+. . .
+
 It is _extra_ info that is either already _inherent_ in your data, or info that you **manually add**.
 
-### Examples of Metadata 💡
+## Examples of Metadata 💡
 
-#### Photographs
+---
+
+### Photographs
+
+::: incremental
+
 - Date & time ⏰
 - Location 🌍
 - People 🧑‍🤝‍🧑
 
+:::
+
+---
+
 My display picture has the following _inherent_ metadata:
 
-![SkepticMystic Mandala dp|400](https://i.imgur.com/UrwAWzI.jpg)
+:::::::::::::: {.columns}
+::: {.column width="60%"}
+![|SkepticMystic Mandala dp](https://i.imgur.com/UrwAWzI.jpg)
+:::
+::: {.column width="40%"}
+![|Image metadata](https://i.imgur.com/dWmowLU.png)
+:::
+::::::::::::::
 
-![Image metadata|400](https://i.imgur.com/dWmowLU.png)
+---
 
 But it could also be given other properties:
 
-![Edit image metadata|400](https://i.imgur.com/YPT6Gzb.png)
+![|Edit image metadata](https://i.imgur.com/YPT6Gzb.png){ height=400px }
 
-#### Markdown Notes
+---
+
+### Markdown Notes
 
 We can also add metadata to **Markdown notes** using a language called <abbr title="Yaml Ain't Markup Language"><em>YAML</em></abbr>.
 
 - YAML is a **structured** way of adding _arbitrary_ metadata to a file.
 
-### Adding YAML Metadata
+---
+
+#### Adding YAML Metadata
 
 1.  At the **top** of your note, add 3 dashes `---`
 2.  Underneath that, you can start adding key-value pairs in the form `key: value`
-3.  To finish the metadata block, close it off with 3 dashes again `---`.
-
-In the photo example, this would look as follows:
+    - In the photo example, this would look as follows:
 
 ```yaml
 ---
@@ -81,7 +114,20 @@ rating: 5
 ---
 ```
 
-#### YAML Lists
+3.  To finish the metadata block, close it off with 3 dashes again `---`.
+
+---
+
+```yaml
+---
+dimensions: 1200x1200
+bit depth: 24
+title: "Mandala Display Picture"
+rating: 5
+---
+```
+
+## YAML Lists
 
 You can add more than one `value` to each `key` using _lists_.
 
@@ -93,6 +139,8 @@ There are two notations you can use:
 foods: [apples, pears, oranges]
 ```
 
+---
+
 ##### 2. Indented
 
 ```yaml
@@ -102,11 +150,11 @@ foods:
   - oranges
 ```
 
-**Note the spacing!**
+==Note the spacing==
 
-### Types of Metadata
+## Types of Metadata
 
-You can find this information on the [Dataview reference page](https://blacksmithgu.github.io/obsidian-dataview/#/README).
+You can find this information on the [Dataview reference page](https://blacksmithgu.github.io/obsidian-dataview/#/README)
 
 ```yaml
 number: 3.6
@@ -125,6 +173,8 @@ date:
 link: [[2021-04-09 Daily Note]]
 ```
 
+---
+
 ### Implicit Metadata in all notes
 
 | Property     | Value                                    | Type     |
@@ -136,23 +186,36 @@ link: [[2021-04-09 Daily Note]]
 | `file.ctime` | Date that the file was **created**       | `date`   |
 | `file.mtime` | Date that the file was last **modified** | `date`   |
 | `file.day`   | The **date** contained in the note title | `date`   |
-| `file.tags`  | An `array` of all **tags** in the note.  | `array`  |
 
-Subtags are broken down by each level, so `#Tag/1/A` will be stored in the array as `[#Tag, #Tag/1, #Tag/1/A]`
+---
 
-## Dataview Queries
-### `List`
+`file.tags` - An `array` of all **tags** in the note.
+
+. . .
+
+- Subtags are broken down by each level, so `#Tag/1/A` will be stored in the array as
+
+<br>
+
+`[#Tag, #Tag/1, #Tag/1/A]`
+
+# Dataview Queries
+
+## `List`
+
 Creates a _list_ of the specified notes
 
 ```dataview
 list
 ```
 
-### `From`
+## `From`
 
 Determines **where** to get notes _from_.
 
-#### From \#Tag
+---
+
+### From \#Tag
 
 You can get all notes _from_ a specified **tag**:
 
@@ -161,7 +224,9 @@ list
 from #MOC
 ```
 
-#### From "Folder"
+---
+
+### From "Folder"
 
 All notes from a **folder**:
 
@@ -170,7 +235,9 @@ list
 from "1. Projects"
 ```
 
-#### From \[\[Links\]\]
+---
+
+### From \[\[Links\]\]
 
 And even all notes with links coming _into_ a note:
 
@@ -188,16 +255,24 @@ from outgoing([[yoga MOC]])
 
 - This syntax may change in an upcoming release.
 
-#### Combining Sources
+---
+
+### Combining Sources
 
 You can use the 3 basic logical operators to create more complex `from` queries:
+
+::: incremental
 
 - `list from #A and #B`
 - `list from "University" or "Work"`
 - `list from -#Personal`
 - `list from [[CSS]] and -#HTML`
 
-#### String Concatenation
+:::
+
+---
+
+### String Concatenation
 
 In the results of a `list`, you can include metadata fields joined with strings
 
@@ -206,7 +281,9 @@ list "File Path: " + file.path + " :)"
 from #SN
 ```
 
-#### Lists of lists
+---
+
+### Lists of lists
 
 A `list` can also display indented sublists of metadata:
 
@@ -215,7 +292,7 @@ list authors
 from #SN/Blog
 ```
 
-### `Task`
+## `Task`
 
 `Task` searches for all checkboxes `- [ ] ` in your vault.
 
@@ -225,16 +302,25 @@ It returns a list of all tasks, grouped by their parent note
 task from #MOC
 ```
 
-### `Where`
+# `Where`
+
+---
 
 After choosing _which_ notes to use, you can narrow down the list further using a `where` block.
+
+. . .
+
 This lets you use the various _comparison operators_ on the metadata fields in your notes.
 
 `>`, `>=`, `<`, `<=`, `=`, `!=`
 
-`where {condition}`
+. . .
 
-#### Examples
+<center>`where {condition}`</center>
+
+## Examples
+
+::: incremental
 
 - `where file.size > 1000`
 
@@ -244,13 +330,17 @@ This lets you use the various _comparison operators_ on the metadata fields in y
 
 - `where !complete`
 
-### `Table`
+:::
+
+# `Table`
+
+---
 
 `Table` can show you a _table_ of various metadata fields linked to each note.
 
 `Table {field 1}, {field 2}, ...`
 
-#### Examples
+## Examples
 
 ```dataview
 table intensity
@@ -259,61 +349,77 @@ from #Uni/2021/Asg
 
 ![|Dataview table](https://i.imgur.com/OnEoP7J.png)
 
+---
+
 ```dataview
 table title, type
 from #SN
 ```
+
+---
 
 ```dataview
 table file.tags
 from Kw/Yoga
 ```
 
-### `Sort`
+## `Sort`
 
 You can use `sort` to define which order to list the results in, and which `field` to sort by:
 
 `sort field asc/desc`
 
+. . .
+
 Give multiple fields to decide ties
 
 `sort field1 asc/desc, field2 asc/desc, ...`
 
-### `Flatten`
+## `Flatten`
 
 Use `flatten` to "unroll" lists into their own rows.
 
 ```dataview
 table authors from #SN
 ```
-<center>versus</center>
+
+Versus
+
 ```dataview
 table authors from #SN
 flatten authors
 ```
 
-### `Group by`
+## `Group by`
 
 `Group by` lets do gather together results based on the value of a field.
 
-You may group:
-- tasks by `completed`
-- games by `rating`
-- assignments by `intensity`
+Examples:
+
+- Group tasks by `completed`
+- Group games by `rating`
+- Group assignments by `intensity`
+
+---
 
 First, gather all the assignments:
 
-`from #Uni/2021/Asg`
+<center>`from #Uni/2021/Asg `</center>
 
-Then, group by `intensity`: 
+Then, group by `intensity`:
 
-`group by intensity`
+<center>`group by intensity`</center>
+
+---
 
 ### `rows` Object
 
 By grouping the notes, we've created a **new object**.
 
-This is a **nested list** of all the assignments grouped by intensity. 
+This is a **nested list** of all the assignments grouped by intensity.
+
+. . .
+
 Something like:
 
 ```js
@@ -324,10 +430,14 @@ Something like:
 ];
 ```
 
+---
+
 To access this new list, we use the `rows` object.
 
 - Get the file name of every note in the array: `rows.file.name`
 - Get the due date of every note: `rows.dueDate`
+
+---
 
 ```dataview
 table intensity, rows.title
@@ -335,7 +445,7 @@ from #Uni/2021/Asg
 group by intensity
 ```
 
-### Group by tags
+## Group by tags
 
 ```dataview
 table rows.file.tags, rows.file.link
@@ -343,49 +453,60 @@ from #Fi/Yoga
 group by file.tags
 ```
 
-#### Limitations
+. . .
+
+### Limitations
 
 It will only consider two notes to be in the same group if they have **exactly the same tags**.
 
 - So even if two notes have `#Note/Author`, if the one has a tag that the other doesn't, they won't be grouped together.
 
-## Functions
+# Functions
 
-### `Contains()`
+## `Contains()`
 
 Used to see if:
 
 - a `string` _contains_ a substring
 - a `list` _contains_ a value
 
+. . .
+
 `where contains(file.name, "Daily Note")`
+
+. . .
+
 `where contains(authors, "Robert Lamb")`
 
-### `Length()`
+## `Length()`
 
 Returns the _length_ of a `string` or `list`
 
+. . .
+
 `where length(file.name) > 10`
 
-### `Sum()`
+## `Sum()`
 
 Returns the _sum_ of the numbers in a `list`
 
+. . .
+
 `where sum(minutesStudied) < 60`
 
-### Many other Functions
-For further info on implemented functions, head over to [the official documentation](https://blacksmithgu.github.io/obsidian-dataview/#/functions).
+## Many other Functions
 
-## Neat Examples
-People have come up with a lot of interesting ways of leveraging Dataview. Lots of them have been shared in the central [Snippet Showcase](https://forum.obsidian.md/t/dataview-plugin-snippet-showcase/13673) on the Obsidian Forum. 
+[Further reading](https://blacksmithgu.github.io/obsidian-dataview/#/functions)
 
-#### Untagged Notes
-For example, finding all untagged notes in your vault is as simple as:
+# Neat Examples
 
-`list where length(file.tags) = 0`
+## [Snippet Showcase](https://forum.obsidian.md/t/dataview-plugin-snippet-showcase/13673) {data-background-iframe="https://forum.obsidian.md/t/dataview-plugin-snippet-showcase/13673"}
 
-#### Birthdays
-If you track \#People in separate notes and add their Birthday as a dataview property, you could compile a list of everyone whose birthday is today like this:
+## Untagged Notes
+
+<center>`list where length(file.tags) = 0`</center>
+
+## Birthdays
 
 ```dataview
 list from #People

--- a/04 - Guides, Workflows, & Courses/for Beginners.md
+++ b/04 - Guides, Workflows, & Courses/for Beginners.md
@@ -15,6 +15,7 @@ These guides will help you get started with [[Obsidian]] and related topics.
 - [[Obsidian Garden]]
 - [[YouTube]]
 - [[Course for Getting Started with Obsidian]]
+- [[Obsidian Training Course in Russian|For Russian speakers: Obsidian Training Course on YouTube]]
 
 %% Hub footer: Please don't edit anything below this line %%
 


### PR DESCRIPTION
Fix for #264 as mentioned in #262 

## Edited
- Made some additions to dy-sh's author page, such as their YouTube link and the course playlist
- Added course to Guides for Beginners with a note that it's specifically for Russian speakers
<!-- Add a brief description here -->

## Added
<!-- Add a brief description here-->
A new note for the Obsidian Training Course in Russian, incl. a link to the playlist + the embed of the first part, with the description adapted from what dy-sh added in the renaming PR. I also cross-referenced some of the other guides.

## Checklist
- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
- [x] (if applicable) attached images have descriptive file names
- [x] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
