### PR TITLE
Change Plugin URI to `obsidian://show-plugin?`

### DIFF
--- a/.github/scripts/templates/plugins/plugin_info.md.jinja
+++ b/.github/scripts/templates/plugins/plugin_info.md.jinja
@@ -3,7 +3,7 @@
 # {{name}}
 
 Plugin ID: `{{id}}`
-Links: [GitHub repository](https://github.com/{{repo}}) or [<button id=HH>Open in Obsidian</button>](obsidian://goto-plugin?id={{id}})
+Links: [GitHub repository](https://github.com/{{repo}}) or [<button id=HH>Open in Obsidian</button>](obsidian://show-plugin?id={{id}})
 Developed by: [[{{user}}]]
 Mobile compatible: {{mobile}}
 

--- a/publish.css
+++ b/publish.css
@@ -25,28 +25,6 @@
     }    
 }
 
-
-/* Buttons */
-button#HH:hover:before {
-	content: "Only works with Hotkey Helper Installed";
-	color: var(--text-on-accent);
-	background: black;
-	font-weight: 800;
-	font-size: 16px;
-    
-	position: absolute;
-	margin-top: -72px;
-	margin-left: -12vh;
-	border-radius: 5px;
-	padding: 20px;
-	z-index: 5;
-}
-body:not(.popover.is-loaded) button#HH:hover:before { margin-left: -2vh; }
-
-.external-link[href^="obsidian://goto-plugin?"] { background-image: none; }
-.tooltip { --layer-tooltip: 1; }
-
-
 /* Embed Adjustments */
 .internal-embed[alt*="clean"] .markdown-embed,
 .markdown-preview-view .internal-embed[alt*="clean"]:not(.image-embed),


### PR DESCRIPTION
## Edited
- change `obsidian://goto-plugin?` to `obsidian://show-plugin?` in the plugin info template
- publish.css: removed hover-tooltip that informs that the button only works with the Hotkey Helper Plugin

This PR addresses #108, and enables users to open the plugins in Obsidian without having the Hotkey Helper Plugin installed. Since it has been almost two months since the 0.13 release, I think it now okay to switch to the 0.13 URI.