### PR TITLE
Add dy-sh's Obsidian Course in Russian (Fix #264)

### DIFF
--- a/01 - Community/People/dy-sh.md
+++ b/01 - Community/People/dy-sh.md
@@ -36,11 +36,11 @@ publish: true
 - 
 -->
 
-<!--
+
 ### Others
 
-- 
--->
+- Playlist for [[Obsidian Training Course in Russian]]: https://youtube.com/playlist?list=PLrRc3UisLr6KVOYhzpSnywtHkCi2PEza5
+
 
 <!--
 ## Sponsor this author
@@ -52,10 +52,10 @@ publish: true
 
 -->
 
-<!--
 ## Follow this author
 
-- [[YouTube Channels|On YouTube]]: ^youtube
+- [[YouTube Channels|On YouTube]]: [dy-sh's YouTube channel](https://www.youtube.com/c/dysh1) ^youtube
+<!--
 - Twitter: ^twitter
 - ...
 -->

--- a/04 - Guides, Workflows, & Courses/Courses/Obsidian Training Course in Russian.md
+++ b/04 - Guides, Workflows, & Courses/Courses/Obsidian Training Course in Russian.md
@@ -1,0 +1,19 @@
+---
+aliases: 
+- 
+tags:
+- seedling
+publish: true
+---
+
+# Obsidian Training Course in Russian
+
+%% Add a description below this line. It doesn't need to be long: one or two sentences should be a good start. %%
+
+This comprehensive [[🗂️ Courses|course]] by [[dy-sh]] is aimed at Russian speakers and covers how to write notes/documentation in [[Markdown]], why you should do it in Markdown and how to use [[Obsidian]] for this purpose.
+
+It goes over how to set up the application, how and which [[🗂️ Plugins|plugins]] to install, how to organize your library of files and even how to [[for Plugin Developers|write your own plugin]].
+
+All 8 parts of the course are available on [YouTube](https://youtube.com/playlist?list=PLrRc3UisLr6KVOYhzpSnywtHkCi2PEza5):
+
+<iframe width="100%" height="400px" src="https://www.youtube.com/embed/aeebp25l9Gg?list=PLrRc3UisLr6KVOYhzpSnywtHkCi2PEza5" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/04 - Guides, Workflows, & Courses/for Beginners.md
+++ b/04 - Guides, Workflows, & Courses/for Beginners.md
@@ -15,6 +15,7 @@ These guides will help you get started with [[Obsidian]] and related topics.
 - [[Obsidian Garden]]
 - [[YouTube]]
 - [[Course for Getting Started with Obsidian]]
+- [[Obsidian Training Course in Russian|For Russian speakers: Obsidian Training Course on YouTube]]
 
 %% Hub footer: Please don't edit anything below this line %%
 


### PR DESCRIPTION
Okay, hopefully this time everything worked.

## Edited
- Changed dy-sh's People page to include a link to the course playlist and the YouTube channel
<!-- Add a brief description here -->

## Added
- Added dy-sh's Obsidian Course in Russian as a new note (which should close #264)
- Linked to new note in "for Beginners"
<!-- Add a brief description here-->

## Checklist
- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
- [x] (if applicable) attached images have descriptive file names
- [x] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
