### PR TITLE
Do not crash update_hub on broken plugins

### DIFF
--- a/.github/scripts/plugins.py
+++ b/.github/scripts/plugins.py
@@ -165,10 +165,8 @@ def get_core_plugins() -> None:
     for plugin in CORE_PLUGINS:
         plugin["slug"] = "Plugins/" + plugin["name"].replace(" ", "+")
 
-    # Needed to stop match[1] giving 'error: Value of type "Optional[Match[str]]" is not indexable'
-    assert match
-    new_contents = contents.replace(
-        match[1], template.render(plugins=CORE_PLUGINS))
+    assert match # Needed to stop match[1] giving 'error: Value of type "Optional[Match[str]]" is not indexable'
+    new_contents = contents.replace(match[1], template.render(plugins=CORE_PLUGINS))
 
     with open(file_path, "w") as md_file:
         md_file.write(new_contents)
@@ -200,7 +198,6 @@ def collect_data_for_plugin(plugin: Plugin, file_groups: FileGroups) -> bool:
 
 def collect_data_for_plugin_and_manifest(plugin: Plugin, manifest: PluginManifest, file_groups: FileGroups) -> bool:
     # the cast to str is to silence: error: Item "None" of "Optional[Any]" has no attribute "split"
-
     repo = str(plugin.get("repo"))
     plugin_is_valid = validate_plugin(plugin, manifest, repo, file_groups)
 

--- a/.github/scripts/plugins.py
+++ b/.github/scripts/plugins.py
@@ -194,6 +194,7 @@ def collect_data_for_plugin(plugin: Plugin, file_groups: FileGroups) -> bool:
     except Exception as err:
         print(f'ERROR processing plugin {current_name}. Error message: {err}')
         plugin_is_valid = False
+        add_file_group(file_groups, "error", f"{current_name}")
         return plugin_is_valid
 
 

--- a/.github/scripts/plugins.py
+++ b/.github/scripts/plugins.py
@@ -185,7 +185,10 @@ def collect_data_for_plugin(plugin: Plugin, file_groups: FileGroups) -> bool:
     """
     repo = plugin.get("repo")
     branch = plugin.get("branch", "master")
-    manifest = get_plugin_manifest(repo, branch)
+    try:
+        manifest = get_plugin_manifest(repo, branch)
+    except Exception as err:
+        print(f'ERROR processing plugin {plugin}. Error message: {err}')
 
     return collect_data_for_plugin_and_manifest(plugin, manifest, file_groups)
 

--- a/.github/scripts/plugins.py
+++ b/.github/scripts/plugins.py
@@ -185,32 +185,32 @@ def collect_data_for_plugin(plugin: Plugin, file_groups: FileGroups) -> bool:
     """
     repo = plugin.get("repo")
     branch = plugin.get("branch", "master")
+    current_name = str(plugin.get("name"))
+
     try:
         manifest = get_plugin_manifest(repo, branch)
-    except Exception as err:
-        print(f'ERROR processing plugin {plugin}. Error message: {err}')
+        return collect_data_for_plugin_and_manifest(plugin, manifest, file_groups)
 
-    return collect_data_for_plugin_and_manifest(plugin, manifest, file_groups)
+    except Exception as err:
+        print(f'ERROR processing plugin {current_name}. Error message: {err}')
+        plugin_is_valid = False
+        return plugin_is_valid
 
 
 def collect_data_for_plugin_and_manifest(plugin: Plugin, manifest: PluginManifest, file_groups: FileGroups) -> bool:
     # the cast to str is to silence: error: Item "None" of "Optional[Any]" has no attribute "split"
-    try:
-        repo = str(plugin.get("repo"))
-        plugin_is_valid = validate_plugin(plugin, manifest, repo, file_groups)
 
-        user = repo.split("/")[0]
-        if manifest.get("isDesktopOnly"):
-            mobile = DESKTOP_ONLY
-        else:
-            mobile = MOBILE_COMPATIBLE
+    repo = str(plugin.get("repo"))
+    plugin_is_valid = validate_plugin(plugin, manifest, repo, file_groups)
 
-        plugin.update(mobile=mobile, user=user, **manifest)
-        update_author_name_for_manual_exceptions(plugin)
+    user = repo.split("/")[0]
+    if manifest.get("isDesktopOnly"):
+        mobile = DESKTOP_ONLY
+    else:
+        mobile = MOBILE_COMPATIBLE
 
-    except Exception as err:
-        print(f'ERROR processing plugin {plugin}. Error message: {err}')
-        add_file_group(file_groups, "error", f"{plugin}")
+    plugin.update(mobile=mobile, user=user, **manifest)
+    update_author_name_for_manual_exceptions(plugin)
 
     return plugin_is_valid
 

--- a/.github/scripts/update_releases.py
+++ b/.github/scripts/update_releases.py
@@ -67,8 +67,7 @@ def process_released_themes(overwrite: bool = False, verbose: bool = False) -> T
     theme_downloads = get_theme_downloads()
 
     for theme in theme_list:
-        current_name, valid = collect_data_for_theme(
-            theme, theme_downloads, template, file_groups)
+        current_name, valid = collect_data_for_theme(theme, theme_downloads, template, file_groups)
         if not valid:
             continue
 
@@ -184,8 +183,7 @@ def update_theme_download_counts(verbose: bool) -> None:
 
     for theme in theme_list:
         current_name = theme.get("name")
-        update_theme_download_count(
-            template, theme_downloads, current_name, verbose)
+        update_theme_download_count(template, theme_downloads, current_name, verbose)
 
 
 def main(argv: Sequence[str] = sys.argv[1:]) -> None:

--- a/.github/scripts/update_releases.py
+++ b/.github/scripts/update_releases.py
@@ -67,7 +67,8 @@ def process_released_themes(overwrite: bool = False, verbose: bool = False) -> T
     theme_downloads = get_theme_downloads()
 
     for theme in theme_list:
-        current_name, valid = collect_data_for_theme(theme, theme_downloads, template, file_groups)
+        current_name, valid = collect_data_for_theme(
+            theme, theme_downloads, template, file_groups)
         if not valid:
             continue
 
@@ -183,7 +184,8 @@ def update_theme_download_counts(verbose: bool) -> None:
 
     for theme in theme_list:
         current_name = theme.get("name")
-        update_theme_download_count(template, theme_downloads, current_name, verbose)
+        update_theme_download_count(
+            template, theme_downloads, current_name, verbose)
 
 
 def main(argv: Sequence[str] = sys.argv[1:]) -> None:


### PR DESCRIPTION
## Issue
Following issue #302, the `update_hub` workflow still crashed due to `update_releases.py --plugins` failing when no `manifest.json` could be found in a plugin's repo. (The Quick Latex plugin's manifest had accidentally been deleted: https://github.com/joeyuping/quick_latex_obsidian/issues/33.)

## Changes
Plugins without a `manifest.json` are now skipped and the errors get logged to the workflow report. The workflow now runs smoothly (see https://github.com/lguenth/obsidian-hub/runs/5259365666) and logs plugins which could not be processed because they don't have a `manifest.json`.

## TODO
- [–] Create test case for incomplete/broken plugin → Moved for now

In the future, we could perhaps also look for a `package.json` and extract the information from there?