### PR TITLE
Styelint guide: Fix a bunch of grammar and bad phrasing

### DIFF
--- a/04 - Guides, Workflows, & Courses/Guides/Why and How to use Stylelint for your Obsidian Theme.md
+++ b/04 - Guides, Workflows, & Courses/Guides/Why and How to use Stylelint for your Obsidian Theme.md
@@ -84,7 +84,7 @@ While there are far more things `stylelint` can do, this should suffice to get s
 ## Usage
 
 ### In the Terminal
-The most basic usage is done via the command line. The two most common commands are the one to report all issues and the one to auto-fix issues (and report the ones that cannot be auto-fixed).[^2]
+The most basic usage is done via the command line. The two most common commands are the one to report all issues and the one to auto-fix issues (and report those that cannot be auto-fixed).[^2]
 
 ```shell
 # Report all issues

--- a/04 - Guides, Workflows, & Courses/Guides/Why and How to use Stylelint for your Obsidian Theme.md
+++ b/04 - Guides, Workflows, & Courses/Guides/Why and How to use Stylelint for your Obsidian Theme.md
@@ -13,7 +13,7 @@ publish: true
 This guide explains why it is beneficial for theme designers to use a linter and how to get started with [Stylelint](https://stylelint.io/), the most popular linter for CSS.
 
 ## What is Linting, and what is its purpose?
-[Linters](https://w3.wikiwand.com/en/Lint_(software)) are tools that analyze code to report bugs and stylistic problems. There are linters for pretty much every programming language,[^1] and [Stylelint](https://stylelint.io/) is regarded as the state-of-the-art linter for CSS.
+[Linters](https://www.wikiwand.com/en/Lint_(software)) are tools that analyze code to report bugs and stylistic problems. There are linters for pretty much every programming language,[^1] and [Stylelint](https://stylelint.io/) is regarded as the state-of-the-art linter for CSS.
 
 __Using linters has several advantages:__
 1. They point out *invalid code*, e.g., using `//comments` which are invalid in CSS.
@@ -26,7 +26,7 @@ As the rules regarding styling are quite subjective, they are all opt-in and con
 ## Getting Started
 
 ### Requirements
-`stylelint,` as most linters, is installed via `npm`. To check whether you have `npm` installed, you can run this command in your Terminal:
+`stylelint`, as most linters, is installed via `npm`. To check whether you have `npm` installed, you can run this command in your Terminal:
 
 ```shell
 # Check whether npm is installed
@@ -44,14 +44,14 @@ npm install -g stylelint postcss
 ```
 
 ### Stylelint Configuration File
-In contrast to most other linters, `stylelint` will not work without a configuration file. This means you have to create such a configuration file (`.styelintrc.json`) before you can use `styelint`.
+In contrast to most other linters, `stylelint` will not work without a configuration file. This means you have to create such a configuration file (`.stylelintrc.json`) before you can use `stylelint`.
 
 ```shell
 # Create a stylelint configuration file in your home directory
 touch ${HOME}/.stylelintrc.json
 ```
 
-By default, all `stylint` rules are turned off, meaning you have to add some basic configuration before you can use `stylelint.` Luckily, there is the `npm` package `stylelint-config-recommended` which activates all linting rules regarding ["possible errors"](https://stylelint.io/user-guide/rules/list/#possible-errors). You can install it via:
+By default, all `stylelint` rules are turned off, meaning you have to add some basic configuration before you can use `stylelint`. Luckily, there is the `npm` package `stylelint-config-recommended` which activates all linting rules regarding ["possible errors"](https://stylelint.io/user-guide/rules/list/#possible-errors). You can install it via:
 
 ```shell
 # Install recommended configurations
@@ -102,7 +102,7 @@ There is a plugin for [Sublime Text](https://packagecontrol.io/packages/SublimeL
 ## Further Configuration
 
 ### Rules for Best Practices and Code Formatting
-With the current configuration, `stylelint` will only report clear and likely errors in your CSS. You can, however, also set up `stylelint`  to check consistency, best practices, and increased readability.
+With the current configuration, `stylelint` will only report clear and likely errors in your CSS. You can, however, also set up `stylelint` to check consistency, best practices, and increased readability.
 
 The `stylelint` documentation [lists a total of 170 rules](https://stylelint.io/user-guide/rules/list/) from which you can choose. (Remember that all rules under the section "Possible Errors" are already enabled by `stylelint-config-recommended`, so you do not need to add them.)
 

--- a/04 - Guides, Workflows, & Courses/Guides/Why and How to use Stylelint for your Obsidian Theme.md
+++ b/04 - Guides, Workflows, & Courses/Guides/Why and How to use Stylelint for your Obsidian Theme.md
@@ -10,32 +10,33 @@ publish: true
 # Why and How to use Stylelint for your Obsidian Theme
 *written by [[chrisgrieser|pseudometa]]*
 
-This guide explains why it is beneficial for theme designers to use a linter and how to get started with [Stylelint](https://stylelint.io/) , the most popular linter for CSS.
+This guide explains why it is beneficial for theme designers to use a linter and how to get started with [Stylelint](https://stylelint.io/), the most popular linter for CSS.
 
 ## What is Linting, and what is its purpose?
-[Linters](https://www.wikiwand.com/en/Lint_(software)) are basically tools that analyze code and report bugs as well as stylistic problems. There are linters for every programming language,[^1] and [Stylelint](https://stylelint.io/) is regarded as the state-of-the-art linter for CSS code.
+[Linters](https://w3.wikiwand.com/en/Lint_(software)) are tools that analyze code to report bugs and stylistic problems. There are linters for pretty much every programming language,[^1] and [Stylelint](https://stylelint.io/) is regarded as the state-of-the-art linter for CSS.
 
-__Using a linter has several advantages:__
-1. They report *errors* and best-practice-violations in your code, e.g., using `//comments` which are invalid in CSS.
-2. They enforce *consistent* styling, which increases the readability of your code, e.g., to always have exactly one line break after between two blocks.
-3. For the simpler rules, linters usually also offer an option to *autofix* the code, *saving you tons of time* to clean your code.
+__Using linters has several advantages:__
+1. They point out *invalid code*, e.g., using `//comments` which are invalid in CSS.
+2. Linters also encourage best practices in your code, like avoiding duplicate selectors.
+3. They enforce *consistent* styling, which increases the readability of your code, e.g., to always have exactly one line break after between two blocks.
+4. For the simpler rules, linters usually offer an option to *auto-fix* the code, saving you a lot of time.
 
-As styling rules are of course subjective, they are opt-in and configurable. Error reports, however, are mostly unambiguous and in my view the reason *everyone* should use a linter, regardless of the value one puts on code consistency.
+As the rules regarding styling are quite subjective, they are all opt-in and configurable. Error reports, however, are unambiguous and, in my view, the reason why *everyone* should use a linter, regardless of the value one puts on nicely formatted code.
 
 ## Getting Started
 
 ### Requirements
-Stylelint, as most linters, are installed via `npm`. To check whether you have `npm` installed, you can run this command in your Terminal:
+`stylelint,` as most linters, is installed via `npm`. To check whether you have `npm` installed, you can run this command in your Terminal:
 
 ```shell
 # Check whether npm is installed
 npm -v
 ```
 
-If the command returns a version number, you are good to go. If it doesn't, you need to [install Node on your machine](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm). (Homebrew users on Mac can easily do that via `brew install node`.)
+If the command returns a version number, you are good to go. If it doesn't, you need to [install Node on your machine](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm). (Homebrew users on Mac can do that via `brew install node`.)
 
 ### Installing Stylelint
-When you have `npm` installed, you just need to run the following code in your Terminal to install `stylelint` and its dependency, `postcss`. 
+After installing `npm`, you can run the following code in your Terminal to install `stylelint` and its dependency, `postcss`. 
 
 ```shell
 # Install stylelint & dependency
@@ -43,28 +44,30 @@ npm install -g stylelint postcss
 ```
 
 ### Stylelint Configuration File
-In contrast to other linters, `stylelint` will not work without a configuration file. So you have to create a configuration file (`.styelintrc.json`) before you are able to use `styelint`.
+In contrast to most other linters, `stylelint` will not work without a configuration file. This means you have to create such a configuration file (`.styelintrc.json`) before you can use `styelint`.
 
 ```shell
 # Create a stylelint configuration file in your home directory
 touch ${HOME}/.stylelintrc.json
 ```
 
-Now creating the configuration isn't enough, since `stylelint` has *turned off all rules by default*. This means you have to set up some basic configuration, too, before you can use stylelint. Luckily, there is the `npm` package `stylelint-config-recommended` which activates all linting rules regarding ["possible errors"](https://stylelint.io/user-guide/rules/list/#possible-errors).
+By default, all `stylint` rules are turned off, meaning you have to add some basic configuration before you can use `stylelint.` Luckily, there is the `npm` package `stylelint-config-recommended` which activates all linting rules regarding ["possible errors"](https://stylelint.io/user-guide/rules/list/#possible-errors). You can install it via:
 
 ```shell
 # Install recommended configurations
 npm install -g stylelint-config-recommended
 ```
 
-Then, you open the `.stylelintrc.json` in your home directory. Note that files that begin with `.` (so-called "dot files") are hidden by default on macOS. So you either have to make hidden files visible (by pressing `cmd + shift + .` in Finder) or you by using this command in the Terminal:
+Then, open the `.stylelintrc.json` in your home directory. 
+
+Note that files beginning with `.` (so-called "dotfiles") are hidden by default on macOS. So if you are on macOS, you either have to make hidden files visible by pressing `cmd + shift + .` in Finder, or you can open the configuration file via this Terminal command:
 
 ```bash
 # open config file via Terminal
 open ${HOME}/.stylelintrc.json
 ```
 
-For getting started more easily, __I recommend to simply copypaste the following basic configuration__. This will activate `stylelint-config-recommended`, but disable two rules that mostly create false positives in the specific context of Obsidian theme development.
+To keep things simple, __I recommend you simply copy-paste the following basic configuration__ into that file. This will activate `stylelint-config-recommended`, but disable two rules that mostly create false positives in the specific context of Obsidian theme development.
 
 ```json
 {
@@ -76,37 +79,37 @@ For getting started more easily, __I recommend to simply copypaste the following
 }
 ```
 
-While there are far more things stylelint can do, this should suffice as a basic setup to get started. (At the end of this guide, I explain how to do further configurations.)
+While there are far more things `stylelint` can do, this should suffice to get started. (At the end of this guide, I explain how to do further configurations.)
 
 ## Usage
 
 ### In the Terminal
-The most basic usage is done via the command line. The two most common commands are the one to report all issues and the one to autofix issues (and report the ones that cannot be autofixed).[^2]
+The most basic usage is done via the command line. The two most common commands are the one to report all issues and the one to auto-fix issues (and report the ones that cannot be auto-fixed).[^2]
 
 ```shell
 # Report all issues
 stylelint "/path/to/my/css/file/theme.css"
 
-# Autofix issues and report the non-fixable issues remaining
+# Auto-fix issues and report the remaining non-fixable issues
 stylelint --fix "/path/to/my/css/file/theme.css"
 ```
 
 ### In the Code Editor
-More convenient than using `stylelint` in the Terminal is to install an integration for your code editor. With those editor integrations, you can get live feedback on linting rule violations as soon as you type them.
+More convenient than using `stylelint` in the Terminal is to install an integration for your code editor. With those editor integrations, you can get live feedback on rule violations as soon as you type them.
 
-There is a plugin for [Sublime Text](https://packagecontrol.io/packages/SublimeLinter-stylelint) (also requires the [SublimeLinter Plugin](https://packagecontrol.io/packages/SublimeLinter)), a plugin for [VS Code](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint), and a bunch of plugins for [other common code editors](https://stylelint.io/user-guide/integrations/editor/).
+There is a plugin for [Sublime Text](https://packagecontrol.io/packages/SublimeLinter-stylelint), a plugin for [VS Code](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint), and various plugins for [other common code editors](https://stylelint.io/user-guide/integrations/editor/).
 
 ## Further Configuration
 
-### Rules for Styling and Best Practices
-The configuration set up in the sections before only covers linting rules *reporting errors in CSS*. However, you can also set up rules for consistent code, best practices, and increased readability of code.
+### Rules for Best Practices and Code Formatting
+With the current configuration, `stylelint` will only report clear and likely errors in your CSS. You can, however, also set up `stylelint`  to check consistency, best practices, and increased readability.
 
-You can take a look at the [list of all stylelint rules](https://stylelint.io/user-guide/rules/list/) featuring a total of 170 rules and add choose any of them as you like. Remember that all rules under the section "Possible Errors" are already enabled by `stylelint-config-recommended`, so you not need to add them.[^3]
+The `stylelint` documentation [lists a total of 170 rules](https://stylelint.io/user-guide/rules/list/) from which you can choose. (Remember that all rules under the section "Possible Errors" are already enabled by `stylelint-config-recommended`, so you do not need to add them.)
 
-To add the custom rules, open the `.stylelintrc.json` again and simply add any rules in plain text. If you are not familiar with it, the configuration file is formatted as `json`, and you need to follow the [JSON Syntax](https://www.w3schools.com/js/js_json_syntax.asp), otherwise `styelint` won't work. (If you cannot find the error in your configuration, you can use a [JSON validator](https://jsonformatter.curiousconcept.com/) to locate your syntax error.)
+To include more rules, open the `.stylelintrc.json` again and simply add any rules in plain text. The configuration file is formatted as `json`, meaning you have to follow the [JSON Syntax](https://www.w3schools.com/js/js_json_syntax.asp). (If you cannot find the error in your configuration, you can use a [JSON validator](https://jsonformatter.curiousconcept.com/) to locate your syntax error.)
 
 ### Plugins for Stylelint
-On top of all that, there are even [dozens of plugins for stylelint](https://github.com/hudochenkov/stylelint-order), too. The most relevant one should be [stylelint-order](https://github.com/hudochenkov/stylelint-order), which automatically orders declarations inside blocks, I personally also like [a small plugin that reports ignored properties](https://www.npmjs.com/package/stylelint-declaration-block-no-ignored-properties). You install the plugins as you did install everything else before:
+On top of all that, there are [dozens and dozens of plugins for stylelint](https://github.com/hudochenkov/stylelint-order), too. The most important one is [stylelint-order](https://github.com/hudochenkov/stylelint-order), which enables `styelint` to automatically order declarations inside blocks. I personally also like [a small plugin that reports ignored properties](https://www.npmjs.com/package/stylelint-declaration-block-no-ignored-properties). You install the plugins as you did install everything else before:
 
 ```shell
 # Install plugins
@@ -114,14 +117,13 @@ npm install -g stylelint-order
 npm install -g stylelint-declaration-block-no-ignored-properties
 ```
 
-Plugins and their rules *both* need to be activated in your `.stylelintrc.json`. The details on to do that what the plugins do exactly can be found in the READMEs of the respective plugin.
+Plugins and their rules *both* need to be activated in your `.stylelintrc.json`. The details on how to do that can be found in the READMEs of the respective plugin.
 
 ### Example Configuration
-You can take a look at the [stylelint configuration of *Shimmering Focus*](https://github.com/chrisgrieser/shimmering-focus/blob/main/.stylelintrc.json) for an example of how far you can fine-tune stylelint.
+You can take a look at the [stylelint configuration of the theme *Shimmering Focus*](https://github.com/chrisgrieser/shimmering-focus/blob/main/.stylelintrc.json) as an example of a very extensive configuration.
 
-[^1]: There is also [[obsidian-linter|Linter specifically for Obsidian]].
-[^2]: You can find out which rules can be autofixed by checking the [documentation of the specific rules](https://stylelint.io/user-guide/rules/list/#possible-errors).
-[^3]: You can, however, add them to apply some manual changes, like [changing the severity of a rule](https://stylelint.io/user-guide/configure#severity) from `error` to `warning`.
+[^1]: There is also a [[obsidian-linter|Linter specifically for Obsidian]].
+[^2]: You can find out which rules can be auto-fixed by checking the [documentation of the specific rules](https://stylelint.io/user-guide/rules/list/#possible-errors).
 
 %% Hub footer: Please don't edit anything below this line %%
 


### PR DESCRIPTION
## Edited
Fix a bunch of grammar and bad phrasing in my stylelint guide.

## Checklist
- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
- [x] (if applicable) attached images have descriptive file names
- [x] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
