### PR TITLE
Run actions on branch names including slash

### DIFF
--- a/.github/workflows/check_content.yml
+++ b/.github/workflows/check_content.yml
@@ -3,9 +3,9 @@ name: check_content
 on:
   # Intentionally check on all branches, to detect any issues as early as possible
   push:
-    branches: [ '*' ]
+    branches: [ '**' ]
   pull_request:
-    branches: [ '*' ]
+    branches: [ '**' ]
 
 jobs:
   check_hub_content:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -2,9 +2,9 @@ name: python
 
 on:
   push:
-    branches: [ '*' ]
+    branches: [ '**' ]
   pull_request:
-    branches: [ '*' ]
+    branches: [ '**' ]
 
 jobs:
   python_tests:


### PR DESCRIPTION
I noticed that in the recent branches `refactor/Theme-class` and `refactor/Theme-methods`, CI wasn't running on pushes whilst the branches were being developed.

The solution was spotted by @kometenstaub - also found in: https://github.com/actions/runner/issues/1183
