### PR TITLE
added templates, vault template and SRD conversion script

### DIFF
--- a/04 - Guides, Workflows, & Courses/for TTRPG.md
+++ b/04 - Guides, Workflows, & Courses/for TTRPG.md
@@ -29,6 +29,7 @@ This note collects resources for those using Obsidian for tabletop role-playing 
 - From [[nvanderhoevan]]'s Publish site:
 	- [Forgotten Realms - World - Fork My Brain](https://notes.nicolevanderhoeven.com/ForgottenRealms/World)
 	- [Exandria - World - Fork My Brain](https://notes.nicolevanderhoeven.com/Exandria/World)
+- [Obsidian Table Top Templates](https://github.com/mProjectsCode/Obsidian-Table-Top-Templates) Templates and a Vault structure for TTRPG campaigns and worldbuilding
 
 ## CSS Snippets
 
@@ -41,6 +42,7 @@ This note collects resources for those using Obsidian for tabletop role-playing 
 - [OldManUmby/OGL-SRD5: D&D 5E SRD converted line-by-line to Markdown and many other publishing formats.](https://github.com/OldManUmby/OGL-SRD5)
 - [twisterghost/5e-obsidian](https://github.com/twisterghost/5e-obsidian) - A script to break down the excellent compiled [D&D SRD Remastered](https://github.com/Umbyology/OGL-SRD5) into a workable reference directory for use in Obsidian.
 - [WychWitch/Obsidian-Dice-Roller-Tables: This is a collection of Dice Roller Tables that I use to run my DND campaigns](https://github.com/WychWitch/Obsidian-Dice-Roller-Tables). Formatted for use with the [[obsidian-dice-roller|Dice Roller]] plugin.
+- [SRD Obsidian Importer](https://github.com/mProjectsCode/d20pfsrd_obsidian_importer) - A script to scrape and import the excelent [d20pfsrd](https://www.d20pfsrd.com/) and [5esrd](https://www.5esrd.com/) into Obsidian.
 
 
 ## Community Plugins


### PR DESCRIPTION
## Edited
`for TTRPG` to add one of my repos containing TTRPG campaign and worldbuilding templates
`for TTRPG` to add one of my repos containing a script to scrape and convert [d20pfsrd](https://www.d20pfsrd.com/) and [5esrd](https://www.5esrd.com/) into an obsidian vault

## Added
no file was added

## Checklist
- [ ] before creating a new note, I searched the vault
- [ ] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
