### PR TITLE
Fixed typo, updated link in 'T - Auxiliary tool.md'

### DIFF
--- a/00 - Contribute to the Obsidian Hub/01 Templates/T - Auxiliary tool.md
+++ b/00 - Contribute to the Obsidian Hub/01 Templates/T - Auxiliary tool.md
@@ -11,8 +11,8 @@ publish: true
 Official website: #placeholder/link
 Documentation: #placeholder/link
 Cost: #placeholder/tool
-Available for: #placeholder/tool %% Uncomment this and remove those that don't apply: [[Windows Tools|Windows]], [[MacOS Tools|MacOS]], [[Linux Tools|Linux]], [[Android Apps|Android]], [[iOS Apps|iOS]], [[iPadOS Apps]] %%
+Available for: #placeholder/tool %% Uncomment this and remove those that don't apply: [[Windows Tools|Windows]], [[MacOS Tools|MacOS]], [[Linux Tools|Linux]], [[Android Apps|Android]], [[iOS Apps|iOS]], [[iPadOS Apps|iPadOS]] %%
 
-%% Add a description below this line. It doesn't need to be long: one or two sentences should be a good start. Mention [[🗂️ Auxiliary Tools]] or [[🗂️ 02.04 Auxiliary Tools by Category]] and any other relevat notes in this vault. %%
+%% Add a description below this line. It doesn't need to be long: one or two sentences should be a good start. Mention [[🗂️ Auxiliary Tools]] or [[🗂️ 02.04 Auxiliary Tools by Category]] and any other relevant notes in this vault. %%
 
 #placeholder/description


### PR DESCRIPTION
## Edited
<!-- Add a brief description here -->
Corrected a typo, and modified a link to appear the same way as the others. 

## Added
<!-- Add a brief description here-->

## Checklist
- [ ] before creating a new note, I searched the vault
- [ ] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
