### PR TITLE
Added links, updated tag in 'How to add content through GitHub.md'

### DIFF
--- a/04 - Guides, Workflows, & Courses/Guides/How to add content through GitHub.md
+++ b/04 - Guides, Workflows, & Courses/Guides/How to add content through GitHub.md
@@ -3,7 +3,7 @@ aliases:
 - Submit to GitHub
 - Submit your changes to GitHub
 tags:
-- seedling
+-  evergreen
 publish: true
 ---
 
@@ -11,9 +11,9 @@ publish: true
 
 If you're familiar with git, you can skip this guide and directly make a *pull request*. If you don't know what that is, don't worry! This guide explains how to submit changes to this vault through GitHub's web interface. 
 
-We assume you have a GitHub account, and you've downloaded and edited the contents of this vault as described in [[CONTRIBUTING|how to contribute]].
+We assume you have a [GitHub account](https://github.com/), and you've downloaded and edited the contents of this vault as described in [[CONTRIBUTING|how to contribute]].
 
-1. Find the file you want to edit on our GitHub repository
+1. Find the file you want to edit on our [GitHub repository](https://github.com/obsidian-community/obsidian-hub)
 2. To edit a file, click on the little pencil on the top-right corner
 	![[github-edit-file.png]]
 	To create a new file, navigate to the folder you want to add the file to, and then click on `Add file`. There you can upload the note you just created or create it using the editor (more about that on step 3):


### PR DESCRIPTION
## Edited
<!-- Add a brief description here -->
Added some hopefully useful links, and changed the tag to Evergreen, as this looks complete.

## Added
<!-- Add a brief description here-->

## Checklist
- [ ] before creating a new note, I searched the vault
- [ ] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
