### PR TITLE
Add note for "Open in Obsidian" tool

### DIFF
--- a/02 - Community Expansions/02.05 All Community Expansions/Auxiliary Tools/Open in Obsidian.md
+++ b/02 - Community Expansions/02.05 All Community Expansions/Auxiliary Tools/Open in Obsidian.md
@@ -16,7 +16,7 @@ Available for: [[iOS Apps|iOS]], [[iPadOS Apps|iPadOS]], [[MacOS Tools|MacOS]]
 
 To download: Visit the “official website” linked above, and tap the “Get Shortcut” button. The Shortcuts app will open and offer to import the shortcut (if nothing happens after Shortcuts opens, go back and tap “Get Shortcut” again).
 
-To use: In the Share menu (<img src="https://help.apple.com/assets/61800C7E6EA4632586448084/61800C896EA463258644809A/en_US/01f5a9889bbecc202d8cbb3067a261ad.png" alt="" height="30" width="23" originalImageName="GlobalArt/IL_Share.png">) or “Share…” item in the [edit menu](https://developer.apple.com/design/human-interface-guidelines/ios/controls/edit-menus/), select “Save to Obsidian,” and the content should then magically appear in Obsidian.
+To use: In the Share menu, select “Save to Obsidian,” and the content should then magically appear in Obsidian.
 
 In principle, it will accept any input. In practice, some formats will work better than others. 
 

--- a/02 - Community Expansions/02.05 All Community Expansions/Auxiliary Tools/Open in Obsidian.md
+++ b/02 - Community Expansions/02.05 All Community Expansions/Auxiliary Tools/Open in Obsidian.md
@@ -1,0 +1,23 @@
+---
+aliases:
+  -
+tags:
+  -  evergreen
+publish: true
+---
+
+# Open in Obsidian
+
+Official website: https://routinehub.co/shortcut/11156/
+Cost: Free
+Available for:  [[MacOS Tools|MacOS]], [[iOS Apps|iOS]], [[iPadOS Apps|iPadOS]] 
+
+%% Add a description below this line. It doesn't need to be long: one or two sentences should be a good start. Mention [[🗂️ Auxiliary Tools]] or [[🗂️ 02.04 Auxiliary Tools by Category]] and any other relevat notes in this vault. %%
+
+“Open in Obsidian” is a iOS/iPadOS/MacOS [[iOS Shortcuts|Shortcut]] which takes input from the share sheet and imports it into the Obsidian app.
+
+In principle, it will accept any input. In practice, some formats will work better than others. 
+
+If you run into formats it handles poorly, or any other problems, please leave feedback on Open in Obsidian’s [Routinehub page](https://routinehub.co/shortcut/11156/).
+
+If this shortcut has been helpful to you, feel free to [buy me a coffee!](https://www.buymeacoffee.com/calion)


### PR DESCRIPTION
## Edited
<!-- Add a brief description here -->

## Added
<!-- Add a brief description here-->

Added a page for my shortcut. Hopefully it's in the right place. It says to Mention [[🗂️ Auxiliary Tools]] or [[🗂️ 02.04 Auxiliary Tools by Category]], but I'm not quite sure what to do with that. 

## Checklist
- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
