### PR TITLE
Add obsidianki4 to spaced repetition plugins

### DIFF
--- a/02 - Community Expansions/02.05 All Community Expansions/Plugins/obsidianki4
+++ b/02 - Community Expansions/02.05 All Community Expansions/Plugins/obsidianki4
@@ -1,0 +1,38 @@
+---
+plugin-id: obsidianki4
+aliases:
+- obsidianki 4
+tags: 
+- 
+publish: true
+---
+
+%% ----- Badges ----- %%
+
+![GitHub all releases](https://img.shields.io/github/downloads/wxxedu/obsidianki4/total?color=573E7A&logo=github&style=for-the-badge)   
+![GitHub manifest version](https://img.shields.io/github/manifest-json/v/wxxedu/obsidianki4?color=573E7A&logo=github&style=for-the-badge)   
+![GitHub issues by-label](https://img.shields.io/github/issues/wxxedu/obsidianki4/help%20wanted?color=573E7A&logo=github&style=for-the-badge)   
+![GitHub Repo stars](https://img.shields.io/github/stars/wxxedu/obsidianki4?color=573E7A&logo=github&style=for-the-badge)
+
+%% ----- Badges ----- %%
+
+%% ----- Do not edit this section ----- %%
+
+# obsidianki 4
+
+Plugin ID: `obsidianki4`
+Links: [GitHub repository](https://github.com/wxxedu/obsidianki4) or [<button id=HH>Open in Obsidian</button>](obsidian://show-plugin?id=wxxedu/obsidianki4)
+Developed by: wxxedu
+Mobile compatible: [[Desktop-only plugins|No]]
+
+Yet Another Obsidianki 4
+
+%% ----- Do not edit anything above this line ----- %% 
+
+%% Does the repository or author have any sponsoring links? Uncomment the next line and add them to the author's note. If they don't, please delete the placeholder tag: #placeholder/author %%
+%% ![[wxxedu#Sponsor this author]] %%
+
+%% Hub footer: Please don't edit anything below this line %%
+
+# This note in GitHub
+ [Edit In GitHub](https://github.dev/obsidian-community/obsidian-hub/blob/main/02%20-%20Community%20Expansions/02.05%20All%20Community%20Expansions/Plugins/obsidianki4.md "git-hub-edit-note") | [Copy this note](https://raw.githubusercontent.com/obsidian-community/obsidian-hub/main/02%20-%20Community%20Expansions/02.05%20All%20Community%20Expansions/Plugins/obsidianki4.md "git-hub-copy-note") | [Download this vault](https://github.com/obsidian-community/obsidian-hub/archive/refs/heads/main.zip "git-hub-download-vault") </span>


### PR DESCRIPTION
## Edited
obsidianki 4 in Spaced Repetition Plugins.md.

## Added
obsidianki4.md  in Plugins folder.

## Checklist
- [x ] before creating a new note, I searched the vault
- [x ] new notes have the `.md` extension
- [x ] (if applicable) attached images have descriptive file names
- [x ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
