### PR TITLE
Catalogue discontinued plugins

### DIFF
--- a/02 - Community Expansions/02.01 Plugins by Category/Discontinued plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Discontinued plugins.md
@@ -1,0 +1,27 @@
+---
+aliases:
+- 
+tags: 
+- seedling 
+publish: true
+---
+
+
+# Discontinued plugins
+
+These plugins were once published, but have have since been withdrawn, or are no longer supported. These plugins may no longer work well with newer versions of Obsidian. These plugins should be installed only at your own risk and without placing any expectations on their authors. 
+
+## Plugins in this category
+
+%% Add a bullet here and link to the plugins you'd like to categorize - and sort them alphabetically! %%
+
+- [[obsidian-advanced-appearance|Advanced Appearance]]
+- [[pdf-to-markdown-plugin|PDF to Markdown]]
+- [[obsidian-stenography-plugin|Stenography]]
+- [[todo-txt|Todo.txt support]]
+
+## Related categories
+
+%% Add links to other 02.02 - Category notes %%
+
+- [[Unlisted plugins]]

--- a/02 - Community Expansions/02.01 Plugins by Category/Unlisted plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Unlisted plugins.md
@@ -30,6 +30,7 @@ These plugins are not listed in Obsidian's plugin store. Keep in mind that the a
 %% Add links to other 02.02 - Category notes %%
 
 - [[Plugins in Beta]]
+- [[Discontinued plugins]]
 
 %% Hub footer: Please don't edit anything below this line %%
 

--- a/02 - Community Expansions/02.01 Plugins by Category/🗂️ 02.01 Plugins by Category.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/🗂️ 02.01 Plugins by Category.md
@@ -95,6 +95,7 @@ tags:
 
 - [[Plugins in Beta]]
 - [[Unlisted plugins]]
+- [[Discontinued plugins]]
 
 ## MOC
 

--- a/02 - Community Expansions/02.01 Plugins by Category/🗂️ 02.01 Plugins by Category.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/🗂️ 02.01 Plugins by Category.md
@@ -106,6 +106,7 @@ tags:
 -  [[02 - Community Expansions/02.01 Plugins by Category/Date and calendar plugins|Date and calendar plugins]]
 -  [[02 - Community Expansions/02.01 Plugins by Category/Desktop-only plugins|Desktop-only plugins]]
 -  [[02 - Community Expansions/02.01 Plugins by Category/Dictionary and Spellchecking Plugins|Dictionary and Spellchecking Plugins]]
+-  [[02 - Community Expansions/02.01 Plugins by Category/Discontinued plugins|Discontinued plugins]]
 -  [[02 - Community Expansions/02.01 Plugins by Category/Finance plugins|Finance plugins]]
 -  [[02 - Community Expansions/02.01 Plugins by Category/Folder management plugins|Folder management plugins]]
 -  [[02 - Community Expansions/02.01 Plugins by Category/Graph plugins|Graph plugins]]


### PR DESCRIPTION
## Added
- Add new plugin category 'Discontinued plugins'
- Its description is mostly cribbed from 'Unlisted plugins'
- Add the 4 plugins that are no longer listed in obsidian releases catalogue

## Edited
- Add new file to curated list of categories
- Add links between 'Discontinued plugins' and 'Unlisted plugins'
- Update MOCs

Note that this is a partial, manual implementation of #162. At some point we will also automatically detect plugins whose repos have been archived.

I'm doing this manual step now to speed up other work.