### PR TITLE
Add obsidianki4 to Auxiliary Tools

### DIFF
--- a/02 - Community Expansions/02.05 All Community Expansions/Auxiliary Tools/Anki.md
+++ b/02 - Community Expansions/02.05 All Community Expansions/Auxiliary Tools/Anki.md
@@ -17,7 +17,7 @@ Available for: [[Windows Tools|Windows]], [[MacOS Tools|MacOS]], [[Linux Tools|L
 
 Anki is a free and open-source [[🗂️ Auxiliary Tools|tool]] to create digital flashcards. It uses a [[Spaced repetition]] algorithm to help you prevent forgetting what you have learned. It lets you review information over a long period of time as revisions are spaced out based on your confidence to recall the learned content.
 
-There are several community-developed plugins to integrate Obsidian into an Anki workflow. See: [[Spaced Repetition Plugins]]
+To integrate Obsidian into your Anki workflow, you may want to take a look at several community-developed plugins over at [[Spaced Repetition Plugins]] or consider third-party tools such as [[obsidianki4]].
 
 %% Hub footer: Please don't edit anything below this line %%
 

--- a/02 - Community Expansions/02.05 All Community Expansions/Auxiliary Tools/obsidianki4.md
+++ b/02 - Community Expansions/02.05 All Community Expansions/Auxiliary Tools/obsidianki4.md
@@ -1,0 +1,28 @@
+---
+aliases:
+  - obsidianki 4
+  - Obsidianki 4
+tags:
+  - seedling
+publish: true
+---
+
+# obsidianki4
+
+Official website: [GitHub repository](https://github.com/wxxedu/obsidianki4), [Addon page – Ankiweb](https://ankiweb.net/shared/info/620260832)
+Documentation: [README](https://github.com/wxxedu/obsidianki4/blob/main/README.md)
+Cost: Free
+Available for: [[Windows Tools|Windows]], [[MacOS Tools|MacOS]], [[Linux Tools|Linux]]
+
+%% Add a description below this line. It doesn't need to be long: one or two sentences should be a good start. Mention [[🗂️ Auxiliary Tools]] or [[🗂️ 02.04 Auxiliary Tools by Category]] and any other relevant notes in this vault. %%
+
+obsidianki4 is an add-on for the digital flashcard app [[Anki]]. It enables you to import notes from your [[Obsidian]] vault into Anki to be used as flashcards for revision in a [[Spaced repetition]] workflow. It preserves both wiki-links and hierarchical tag structures.
+
+**Note:** The development of this [[🗂️ Auxiliary Tools|third-party tool]] is currently paused, meaning the code is unmaintained for the foreseeable future. (Status: 2022-03-15)
+
+## Installation
+Download the `Obsidianki 4.ankiaddon` file as well as the card deck template `Obsidianki 4.0.apkg` from the [GitHub releases page](https://github.com/wxxedu/obsidianki4/releases) or the official [Anki Addon page](https://ankiweb.net/shared/info/620260832).
+
+Open Anki, navigate to *Tools > Add-ons > Install from file* and choose the `.ankiaddon` file you downloaded. Restart Anki and import the `.apkg` deck template via *File > Import*.
+
+For further explanations, please take a look at the official documentation which is linked above.


### PR DESCRIPTION
**Note:** *This PR effectively replaces #345.*

## Edited
- Mention third-party tool [obsidianki4](https://github.com/wxxedu/obsidianki4) in Anki note
 
## Added
- Add new note for obsidanki4 in Auxiliary Tools with the appropriate template

## Checklist
- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
