### PR TITLE
Split author Jinja template into smaller templates

### DIFF
--- a/.github/scripts/templates/author.md.jinja
+++ b/.github/scripts/templates/author.md.jinja
@@ -1,67 +1,22 @@
----
-aliases:
-- {{author}}
-tags:
-- 
-publish: true
----
+{% include "authors/frontmatter.md.jinja" %}
 
-# {{author}}
 
-- GitHub: [{{user}}](https://github.com/{{user}}/) ^github
-<!-- - Discord: `@` ^discord-->
-{% if not website %}<!-- {% endif %}- Website: <{{ website }}> ^website{% if not website %}-->{% endif +%}
-<!-- - [[Publish sites|Publish site]]: ^publish-->
+{% include "authors/author_info.md.jinja" %}
 
-%% Feel free to add a bio below this comment %%
 
 
 ## Author of
 
-%% Begin Hub: Released contributions %%
-{% if plugins %}### Plugins
-{% for plugin in plugins %}
-- {{ plugin }}
-{% endfor %}
-{% endif %}
+{% include "authors/released_contributions.md.jinja" %}
 
-{% if themes %}### Themes
-{% for theme in themes %}
-- {{ theme }}
-{% endfor %}
-{% endif %}
-%% End Hub: Released contributions %%
 
-%% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
+{% include "authors/unreleased_contributions.md.jinja" %}
 
-<!--
-### Unlisted plugins
 
-- 
--->
+{% include "authors/sponsor_author.md.jinja" %}
 
-<!--
-### Others
 
-- 
--->
+{% include "authors/follow_author.md.jinja" %}
 
-<!--
-## Sponsor this author
-
-- [[GitHub sponsors]]: [Sponsor @{{user}} on GitHub Sponsors](https://github.com/sponsors/{{user}}) ^github-sponsor
-- [[Buy me a coffee]]: ^buy-me-a-coffee
-- [[PayPal]]: ^paypal
-- [[Patreon]]: ^patreon
-
--->
-
-<!--
-## Follow this author
-
-- [[YouTube Channels|On YouTube]]: ^youtube
-- Twitter: ^twitter
-- ...
--->
 
 {% include "footer.md.jinja" %}

--- a/.github/scripts/templates/authors/author_info.md.jinja
+++ b/.github/scripts/templates/authors/author_info.md.jinja
@@ -1,0 +1,8 @@
+# {{author}}
+
+- GitHub: [{{user}}](https://github.com/{{user}}/) ^github
+<!-- - Discord: `@` ^discord-->
+{% if not website %}<!-- {% endif %}- Website: <{{ website }}> ^website{% if not website %}-->{% endif +%}
+<!-- - [[Publish sites|Publish site]]: ^publish-->
+
+%% Feel free to add a bio below this comment %%

--- a/.github/scripts/templates/authors/follow_author.md.jinja
+++ b/.github/scripts/templates/authors/follow_author.md.jinja
@@ -1,0 +1,7 @@
+<!--
+## Follow this author
+
+- [[YouTube Channels|On YouTube]]: ^youtube
+- Twitter: ^twitter
+- ...
+-->

--- a/.github/scripts/templates/authors/frontmatter.md.jinja
+++ b/.github/scripts/templates/authors/frontmatter.md.jinja
@@ -1,0 +1,7 @@
+---
+aliases:
+- {{author}}
+tags:
+- 
+publish: true
+---

--- a/.github/scripts/templates/authors/released_contributions.md.jinja
+++ b/.github/scripts/templates/authors/released_contributions.md.jinja
@@ -1,0 +1,13 @@
+%% Begin Hub: Released contributions %%
+{% if plugins %}### Plugins
+{% for plugin in plugins %}
+- {{ plugin }}
+{% endfor %}
+{% endif %}
+
+{% if themes %}### Themes
+{% for theme in themes %}
+- {{ theme }}
+{% endfor %}
+{% endif %}
+%% End Hub: Released contributions %%

--- a/.github/scripts/templates/authors/sponsor_author.md.jinja
+++ b/.github/scripts/templates/authors/sponsor_author.md.jinja
@@ -1,0 +1,9 @@
+<!--
+## Sponsor this author
+
+- [[GitHub sponsors]]: [Sponsor @{{user}} on GitHub Sponsors](https://github.com/sponsors/{{user}}) ^github-sponsor
+- [[Buy me a coffee]]: ^buy-me-a-coffee
+- [[PayPal]]: ^paypal
+- [[Patreon]]: ^patreon
+
+-->

--- a/.github/scripts/templates/authors/unreleased_contributions.md.jinja
+++ b/.github/scripts/templates/authors/unreleased_contributions.md.jinja
@@ -1,0 +1,13 @@
+%% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
+
+<!--
+### Unlisted plugins
+
+- 
+-->
+
+<!--
+### Others
+
+- 
+-->


### PR DESCRIPTION
There is a test of the output of this, which still passes, so the output is guaranteed to be identical.

Note that it is intentional that the component templates do not have an end-of-line - for consistency with the similar files for plugins and themes.

This is part of implementing #156.
