### PR TITLE
Remove stray line from mochi-cards-exporter.md

### DIFF
--- a/02 - Community Expansions/02.05 All Community Expansions/Plugins/mochi-cards-exporter.md
+++ b/02 - Community Expansions/02.05 All Community Expansions/Plugins/mochi-cards-exporter.md
@@ -1,4 +1,4 @@
- ￼￼￼￼￼Mochi Cards Exporter￼￼ exports markdown notes to Mochi flashcards. Cards are designated via tags.---
+---
 plugin-id: mochi-cards-exporter
 aliases:
 - Mochi Cards Exporter


### PR DESCRIPTION
## Edited
Remove what looks to have been a stray line added to the YAML of `02 - Community Expansions/02.05 All Community Expansions/Plugins/mochi-cards-exporter.md` in 9845b770312c613765793e1a01952040b81e63d2

