### PR TITLE
Add schedule to run update_hub GitHub Workflow every Wednesday

### DIFF
--- a/.github/workflows/update_hub.yml
+++ b/.github/workflows/update_hub.yml
@@ -1,8 +1,11 @@
 name: update_hub
 
 on:
-  # This workflow is only ever be triggered manually.
+  # This workflow is run every Wednesday.
+  # It can also be triggered manually.
   # It only runs on the main branch.
+  schedule:
+    - cron: "0 0 * * 3" 
   workflow_dispatch:
     # Inputs the workflow accepts.
     inputs:


### PR DESCRIPTION
## Edited
This PR is the result of discussions on issue #274. It implements a weekly schedule, namely every Wednesday on midnight, for the GitHub workflow `update_hub`. This allows us to get new releases and incorporate them into the hub before Eleanor works on the Roundup on Fridays.

I hope the time is okay? If it fails, I/someone could still kick it off Thursday morning.