### PR TITLE
Fix: Run update_hub before Wednesday midnight

### DIFF
--- a/.github/workflows/update_hub.yml
+++ b/.github/workflows/update_hub.yml
@@ -5,7 +5,7 @@ on:
   # It can also be triggered manually.
   # It only runs on the main branch.
   schedule:
-    - cron: "0 0 * * 3" 
+    - cron: "59 23 * * 3" 
   workflow_dispatch:
     # Inputs the workflow accepts.
     inputs:


### PR DESCRIPTION
## Changes
The `update_hub` workflow should run on midnight between Wednesday/Thursday, not Tuesday/Wednesday.
And as @chrisgrieser pointed out: Changing the time to 23:59 UTC makes it less ambiguous. ;)