### PR TITLE
always add footer to issue list

### DIFF
--- a/.github/workflows/update_issues.yml
+++ b/.github/workflows/update_issues.yml
@@ -28,6 +28,17 @@ jobs:
           cd .github/scripts
           python3 ./update_issues.py --apikey ${{ secrets.TOKEN }}
           git commit -m "Update Issues" -a  || echo "nothing to commit"
+          
+
+      # This must be the last edit, to ensure that no later steps accidentally
+      # overwrite the footer.
+      - name: Add Footer
+        run: |
+          cd .github/scripts
+          python3 ./add_footer.py
+          cd ../..
+          git add .
+          git commit -m "Add 'This note in GitHub' footers" || echo "nothing to commit"
 
       # ----------------------------------------------------------------------------------
       # Finalisation
@@ -38,6 +49,8 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           title: Scripted update of Hub content
+          body: |
+            Updating list of plugin issues with labels.
           labels: |
             scripted update
 


### PR DESCRIPTION
## Edited
Always add the footer to the issue list,
otherwise the daily PR would often only contain the removal the footer.
(like in #367) 

## Added
<!-- Add a brief description here-->

## Checklist
- [ ] before creating a new note, I searched the vault
- [ ] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
