### PR TITLE
Prevent empty issues prs & lost footer on uncategorised plugins

### DIFF
--- a/.github/scripts/templates/category.md.jinja
+++ b/.github/scripts/templates/category.md.jinja
@@ -24,3 +24,5 @@ publish: true
 
 #placeholder/notes
 {% endif %}
+
+{% include "footer.md.jinja" %}

--- a/.github/scripts/templates/plugin_issues.md.jinja
+++ b/.github/scripts/templates/plugin_issues.md.jinja
@@ -36,3 +36,5 @@ See also [[Volunteer Plugin Doc Writers]] for some more developers that want hel
 {% for issue in documentation %}
 - [[{{ issue.pluginID }}|{{ issue.plugin }}]] - [{{ issue.title }}]({{ issue.url }})
 {% endfor %}
+
+{% include "footer.md.jinja" %}

--- a/.github/workflows/update_issues.yml
+++ b/.github/workflows/update_issues.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           cd .github/scripts
           python3 ./update_issues.py --apikey ${{ secrets.TOKEN }}
-          git commit -m "Update Issues" -a  || echo "nothing to commit"
+          git commit -m "Update 'Plugins seeking help'" -a  || echo "nothing to commit"
           
       # ----------------------------------------------------------------------------------
       # Finalisation
@@ -37,9 +37,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v3
         with:
-          title: Scripted update of Hub content
-          body: |
-            Updating list of plugin issues with labels.
+          title: Update 'Plugins seeking help'
           labels: |
             scripted update
 

--- a/.github/workflows/update_issues.yml
+++ b/.github/workflows/update_issues.yml
@@ -29,17 +29,6 @@ jobs:
           python3 ./update_issues.py --apikey ${{ secrets.TOKEN }}
           git commit -m "Update Issues" -a  || echo "nothing to commit"
           
-
-      # This must be the last edit, to ensure that no later steps accidentally
-      # overwrite the footer.
-      - name: Add Footer
-        run: |
-          cd .github/scripts
-          python3 ./add_footer.py
-          cd ../..
-          git add .
-          git commit -m "Add 'This note in GitHub' footers" || echo "nothing to commit"
-
       # ----------------------------------------------------------------------------------
       # Finalisation
       # ----------------------------------------------------------------------------------


### PR DESCRIPTION
### Preventing footers being deleted

I noticed in #372 that the `Plugins seeking help.md` file hadn't changed, but other files missing their footers had changed, causing a PR to be created.

Also the history of [Uncategorized plugins.md](https://github.com/obsidian-community/obsidian-hub/commits/main/02%20-%20Community%20Expansions/02.01%20Plugins%20by%20Category/Uncategorized%20plugins.md) shows loads of pairs of commits where the file is updated but that removes its footer, and then the footer gets re-added...

So I had a look at how the footer was added when new plugins notes are created, and it turns out that `render_template_for_file()` in `utils.py` has code that takes care of that:

https://github.com/obsidian-community/obsidian-hub/blob/f3b971847fe2c604ccb7b09ed8dc304058da0737/.github/scripts/utils.py#L111-L119

This meant that adding the following to the end of Jinja templates then includes the footer in the generated file automatically:

```jinja

{% include "footer.md.jinja" %}
```

### Simplifying `update_issues.yml`

This removed the need for `update_issues.yml` to run `add_footer.py`.

Whilst there, because `update_issues.yml` only changes one file, I changed its commit message and PR name to be more specific about what it does - and so that its PRs have different titles from `update_hub.yml` which was harder to give a specific title to, because it does so much...
