### PR TITLE
add graph view customization note

### DIFF
--- a/04 - Guides, Workflows, & Courses/Guides/Graph view customization.md
+++ b/04 - Guides, Workflows, & Courses/Guides/Graph view customization.md
@@ -1,6 +1,6 @@
 # Graph view customization
 
-Since the graph is rendered using `<canvas>` and WebGL, CSS is unable to affect things like nodes and links. To customize graph view, we have provided a way to convert CSS colors into WebGL commands.
+Since the graph is rendered using `<canvas>` and WebGL, CSS is unable to affect things like nodes and links. To customize graph view, we have provided a bridge to use CSS colors for customizing WebGL.
 
 ## The following CSS classes are supported:
 

--- a/04 - Guides, Workflows, & Courses/Guides/Graph view customization.md
+++ b/04 - Guides, Workflows, & Courses/Guides/Graph view customization.md
@@ -1,0 +1,54 @@
+# Graph view customization
+
+Since the graph is rendered using `<canvas>` and WebGL, [[Customizing CSS|CSS]] is unable to affect things like nodes and links. To customize graph view, we have provided a way to convert CSS colors into WebGL commands.
+
+## The following CSS classes are supported:
+
+```
+.graph-view.color-fill
+.graph-view.color-fill-focused (use transparent to disable)
+.graph-view.color-fill-tag (theme-dependent)
+.graph-view.color-fill-attachment (theme-dependent)
+.graph-view.color-arrow
+.graph-view.color-circle
+.graph-view.color-line
+.graph-view.color-text
+.graph-view.color-fill-highlight
+.graph-view.color-line-highlight
+.graph-view.color-fill-unresolved
+```
+
+\* theme-dependent means you may have to add `.theme-dark` or `.theme-light` to style it for different themes. See [[#Defaults]] for explanation.
+
+## The following CSS rules are supported:
+
+```css
+ .graph-view.color-class {
+	/* Supports all CSS color directives, like #HEX, rgb and rgba */
+	color:   #FFF;
+	color:   #FFFFFF;
+	color:   rgb(0, 0, 0);
+	color:   rgba(0, 0, 0, 1);
+	/* Opacity (similar to rgba) will make the color transparent */
+	opacity: 0.5;
+}
+```
+
+## Defaults
+
+These CSS rules are the ones Obsidian uses by default. You may override any of them using an identical or [more specific](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity) CSS rule. This applies especially to `.color-fill-tag` and `.color-fill-attachment` As a last resort, add `!important` to the end of your rule.
+
+```css
+.graph-view.color-fill,
+.theme-dark .graph-view.color-fill-tag,
+.theme-light .graph-view.color-fill-tag,
+.theme-dark .graph-view.color-fill-attachment,
+.theme-light .graph-view.color-fill-attachment,
+.graph-view.color-arrow,
+.graph-view.color-circle,
+.graph-view.color-line,
+.graph-view.color-text,
+.graph-view.color-fill-highlight,
+.graph-view.color-line-highlight,
+.graph-view.color-fill-unresolved {}
+```

--- a/04 - Guides, Workflows, & Courses/Guides/Graph view customization.md
+++ b/04 - Guides, Workflows, & Courses/Guides/Graph view customization.md
@@ -1,6 +1,6 @@
 # Graph view customization
 
-Since the graph is rendered using `<canvas>` and WebGL, [[Customizing CSS|CSS]] is unable to affect things like nodes and links. To customize graph view, we have provided a way to convert CSS colors into WebGL commands.
+Since the graph is rendered using `<canvas>` and WebGL, CSS is unable to affect things like nodes and links. To customize graph view, we have provided a way to convert CSS colors into WebGL commands.
 
 ## The following CSS classes are supported:
 

--- a/04 - Guides, Workflows, & Courses/for Theme Designers.md
+++ b/04 - Guides, Workflows, & Courses/for Theme Designers.md
@@ -29,6 +29,7 @@ This note collects resources and guides for beginner and expert theme designers 
   - [Getting comfortable with Obsidian CSS](https://forum.obsidian.md/t/getting-comfortable-with-obsidian-css/133)
   - [Common Selectors for Custom CSS](https://forum.obsidian.md/t/common-selectors-for-custom-css/1984)
 - [[Using Visual Studio Code for Theme Development]] by [[damiankorcz|Damian Korcz]]
+- [[Graph view customization|Styling the graph view]] 
 
 ## Community Talks
 


### PR DESCRIPTION
It used to be part of the Obsidian help docs.

Co-Authored-By: lishid <lishid@gmail.com>

## Edited
<!-- Add a brief description here -->

Add link to Theme designer guide note.

## Added
<!-- Add a brief description here-->

Add graph view customization note.

## Checklist
- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [x] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
