### PR TITLE
Prevent cron job from triggering on forks (see #381)

### DIFF
--- a/.github/workflows/update_hub.yml
+++ b/.github/workflows/update_hub.yml
@@ -14,6 +14,9 @@ jobs:
   update_hub_content:
     runs-on: ubuntu-latest
 
+    # Prevent cron job from triggering on forks
+    if: github.repository_owner == 'obsidian-community'
+
     steps:
       # ----------------------------------------------------------------------------------
       # Setup

--- a/.github/workflows/update_issues.yml
+++ b/.github/workflows/update_issues.yml
@@ -10,6 +10,9 @@ jobs:
   update_issues:
     runs-on: ubuntu-latest
 
+    # Prevent cron job from triggering on forks
+    if: github.repository_owner == 'obsidian-community'
+
     steps:
       # ----------------------------------------------------------------------------------
       # Setup


### PR DESCRIPTION
This fixes #381: see that issue for details.

This unfortunately prevents testing via manual trigger on forks too, but that will happen much less often that authors forking to edit content on the Hub, and I think it's better to avoid confusing email messages to new contributors.
