### PR TITLE
Obsidian2MKdocs fix 404 embedded images

### DIFF
--- a/06 - Inbox/Obsidian2Mkdocs.md
+++ b/06 - Inbox/Obsidian2Mkdocs.md
@@ -1,4 +1,4 @@
----
+---https://github.com/Mara-Li/mkdocs_obsidian_template/raw/main/screenshot/image_1.png
 aliases: 
 - Mkdocs Publish
 - Material Publish
@@ -62,10 +62,7 @@ options:
 ```
 
 # Showcase
-![](https://github.com/Mara-Li/mkdocs_obsidian_template/raw/main/screenshot/image_1.png)
-![](https://github.com/Mara-Li/mkdocs_obsidian_template/raw/main/screenshot/image_2.png)
-![](https://github.com/Mara-Li/mkdocs_obsidian_publish/raw/main/screenshot/image_3.png)
-![](https://github.com/Mara-Li/mkdocs_obsidian_publish/raw/main/screenshot/image_4.png)
+![](https://github.com/Mara-Li/mkdocs_embed_file_plugins/raw/main/docs/demo.gif)
 ![](https://github.com/Mara-Li/mkdocs_embed_file_plugins/raw/main/docs/note3.png)
 
 %% Hub footer: Please don't edit anything below this line %%

--- a/06 - Inbox/Obsidian2Mkdocs.md
+++ b/06 - Inbox/Obsidian2Mkdocs.md
@@ -1,4 +1,4 @@
----https://github.com/Mara-Li/mkdocs_obsidian_template/raw/main/screenshot/image_1.png
+---
 aliases: 
 - Mkdocs Publish
 - Material Publish


### PR DESCRIPTION
## Edited
In the Showcase heading of Obsidian to Mkdocs page (`Obsidian2Mkdocs.md`) there are 4 embedded images missing. 

![image](https://user-images.githubusercontent.com/7347034/161428017-10732f11-2ecd-4a58-b5ca-3051e1147455.png)

They used to be screenshots from [mkdocs_obsidian_publish](https://github.com/Mara-Li/mkdocs_obsidian_publish) repository, but today they are not available anymore.

Since there is an already embedded image from [mkdocs_embed_file_plugins](https://github.com/Mara-Li/mkdocs_embed_file_plugins), `note3.png`, I propose  to add its `demo.gif` to replace the removed embeds.