### PR TITLE
Use workflow-specific branch names for PRs.

### DIFF
--- a/.github/workflows/update_hub.yml
+++ b/.github/workflows/update_hub.yml
@@ -85,6 +85,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           title: Scripted update of Hub content
+          branch: create-pull-request/${{ github.workflow }}
           labels: |
             scripted update
 

--- a/.github/workflows/update_issues.yml
+++ b/.github/workflows/update_issues.yml
@@ -41,6 +41,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           title: Update 'Plugins seeking help'
+          branch: create-pull-request/${{ github.workflow }}
           labels: |
             scripted update
 


### PR DESCRIPTION
This fixes #384: see that issue for details.