### PR TITLE
Fix update_issues.yml's failure to create a PR

### DIFF
--- a/.github/workflows/update_issues.yml
+++ b/.github/workflows/update_issues.yml
@@ -1,4 +1,4 @@
-name: update community plugin issue list
+name: update_community_plugin_issue_list
 on:
   schedule:
     - cron: "0 1 * * *"


### PR DESCRIPTION
## Edited

Remove spaces from the workflow's name.

When I made the job use the workflow name in the branch in #385, I didn't spot there were spaces in the name of this one.
