### PR TITLE
Remove theme download count assertion

### DIFF
--- a/.github/scripts/themes.py
+++ b/.github/scripts/themes.py
@@ -275,7 +275,7 @@ class ThemeDownloadCount:
             return
 
         # If the download count has decreased, there is something gone fundamentally wrong:
-        assert new_download_count >= previous_download_count
+        # assert new_download_count >= previous_download_count
 
         if new_download_count == previous_download_count:
             if verbose:


### PR DESCRIPTION
## Changes

After theme developers noticed that their download counts were skyrocketing for no apparent reason, Licat updated the method which estimates a theme's growth. This meant that download counts suddenly dropped a lot which caused `update_releases.py` to fail a test in `themes.py`. See this run: https://github.com/obsidian-community/obsidian-hub/runs/5953784145?check_suite_focus=true

This PR comments out the assertion that theme download counts have grown instead of decreased since the last update, so that the `update_hub` workflow can be run again. This change may be reverted at some point.
