### PR TITLE
Add Zettelkasten for Creative Writing Links

### DIFF
--- a/04 - Guides, Workflows, & Courses/for Creative Writing.md
+++ b/04 - Guides, Workflows, & Courses/for Creative Writing.md
@@ -4,6 +4,11 @@
 - [Using Obsidian For Writing Fiction & Notes](https://eleanorkonik.com/obsidian-for-writing/) by [[eleanorkonik|Eleanor Konik]]
 - [9 Must Have Obsidian Plugins for Writers](https://curtismchale.ca/2022/01/10/9-obsidian-writing-plugins/) by Curtis McHale
 
+**Using [[Zettelkasten]] for Creative Writing:**
+- [The Zettelkasten Method for Fiction IV - Creating Stories](https://zettelkasten.de/posts/zettelkasten-fiction-writing-part-4-create-story/) by Sascha on Zettelkasten.de
+- [Zettelkasten For Writers](https://www.eadeverell.com/zettelkasten/) by Eva Deverell
+
+
 %% Hub footer: Please don't edit anything below this line %%
 
 # This note in GitHub


### PR DESCRIPTION
## Edited
for Creative Writing Note

## Added
- Link to site write ups
- Split these links with bolded text for easier legibility

## Checklist
- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
