### PR TITLE
Create Markdown Syntax.md

### DIFF
--- a/04 - Guides, Workflows, & Courses/Guides/Markdown Syntax.md
+++ b/04 - Guides, Workflows, & Courses/Guides/Markdown Syntax.md
@@ -8,24 +8,24 @@ publish: true
 
 # Markdown Syntax
 
+## Introductory Readings
+- [Introduction to Basic Markdown Syntax](https://www.markdownguide.org/basic-syntax/)
+- [John Gruber's Original Documentation](https://daringfireball.net/projects/markdown/)
+
 ## Lesser known Markdown Syntax
-- indenting text with a preceding blank lines is rendered as ==code block== (which is why it changes color, which gets asked quite often)
-- a dash or equal sign below some text turns it into a heading, due to the older (but still supported) *setext-syntax* for Markdown headings. Continuing to write some non-dash-non-equal-sign-character fixes this already.
-- when using the `Strict Line Breaks` setting, a single line break can be created by placing two spaces at the end of a line (["Two Space Rule"](https://daringfireball.net/projects/markdown/syntax#p)) 
+- Indenting text with a preceding blank lines is rendered as ==code block== (which is why it changes color, which gets asked quite often).
+- A dash (`-`) or equal sign (`=`) below some text turns it into a heading, due to the older (but still supported) *setext-syntax* for Markdown headings. Continuing to write some non-dash-non-equal-sign-character fixes this already.
+- When using the `Strict Line Breaks` setting, a single line break can be created by placing two spaces at the end of a line (["Two Space Rule"](https://daringfireball.net/projects/markdown/syntax#p)) 
 	- Since `Strict Line Breaks` makes Obsidian ignore single line breaks, they can be used for  [Semantic Line Breaks](https://sembr.org/)
-- To write special characters like `*` or `$` without them triggering some markup like *italics* or Mathjax, they need to be escaped by putting a backlash in front of it: `\*` or `\$`
-- lists that have single blank lines in between the list items are considered =="loose lists"== and which get extra spacing between each list item. To remove that spacing, simply remove the blank lines between list items. (Note that some themes already disable loose lists by default)
-- to get a line break in a markdown table, use `<br>`
-- To get a code block in a code block, you can use four backticks. (To have a code block in a code block in a code block, you would use five.)
+- To write special characters like `*` or `$` without them triggering some markup like *italics* or Mathjax, they need to be escaped by putting a backlash in front of it: `\*` or `\$`.
+- Lists that have single blank lines in between the list items are considered =="loose lists"== and which get extra spacing between each list item. To remove that spacing, simply remove the blank lines between list items. (Note that some themes already disable loose lists by default.)
+- To get a line break in a Markdown table, use `<br>`.
+- To get a code block in a code block, you can use four backticks. (To have a code block in a code block in a code block, you would use five, etc.)
 	
 `````md
-````
+````md
 	```md
 	fsfsfsf
 	```
 ````
 `````
-
-## Further Readings
-- [Introduction to Basic Markdown Syntax](https://www.markdownguide.org/basic-syntax/)
-- [John Gruber's Original Documentation](https://daringfireball.net/projects/markdown/)

--- a/04 - Guides, Workflows, & Courses/Guides/Markdown Syntax.md
+++ b/04 - Guides, Workflows, & Courses/Guides/Markdown Syntax.md
@@ -1,3 +1,11 @@
+---
+aliases: 
+- 
+tags:
+- seedling
+publish: true
+---
+
 # Markdown Syntax
 
 ## Lesser known Markdown Syntax

--- a/04 - Guides, Workflows, & Courses/Markdown Syntax.md
+++ b/04 - Guides, Workflows, & Courses/Markdown Syntax.md
@@ -1,0 +1,23 @@
+# Markdown Syntax
+
+## Lesser known Markdown Syntax
+- indenting text with a preceding blank lines is rendered as ==code block== (which is why it changes color, which gets asked quite often)
+- a dash or equal sign below some text turns it into a heading, due to the older (but still supported) *setext-syntax* for Markdown headings. Continuing to write some non-dash-non-equal-sign-character fixes this already.
+- when using the `Strict Line Breaks` setting, a single line break can be created by placing two spaces at the end of a line (["Two Space Rule"](https://daringfireball.net/projects/markdown/syntax#p)) 
+	- Since `Strict Line Breaks` makes Obsidian ignore single line breaks, they can be used for  [Semantic Line Breaks](https://sembr.org/)
+- To write special characters like `*` or `$` without them triggering some markup like *italics* or Mathjax, they need to be escaped by putting a backlash in front of it: `\*` or `\$`
+- lists that have single blank lines in between the list items are considered =="loose lists"== and which get extra spacing between each list item. To remove that spacing, simply remove the blank lines between list items. (Note that some themes already disable loose lists by default)
+- to get a line break in a markdown table, use `<br>`
+- To get a code block in a code block, you can use four backticks. (To have a code block in a code block in a code block, you would use five.)
+	
+`````md
+````
+	```md
+	fsfsfsf
+	```
+````
+`````
+
+## Further Readings
+- [Introduction to Basic Markdown Syntax](https://www.markdownguide.org/basic-syntax/)
+- [John Gruber's Original Documentation](https://daringfireball.net/projects/markdown/)

--- a/04 - Guides, Workflows, & Courses/for Beginners.md
+++ b/04 - Guides, Workflows, & Courses/for Beginners.md
@@ -10,10 +10,16 @@ tags:
 These guides will help you get started with [[Obsidian]] and related topics.
 
 ![[2021.07.17#^594d70]]
+## Introduction to Basic Concepts
 - [**Sitepoint**: Obsidian Beginner Guide](https://www.sitepoint.com/obsidian-beginner-guide/)
 - [[Obsidian Help]]
 - [[Obsidian Garden]]
+- [[Markdown Syntax]]
+
+## Video Guides
 - [[YouTube]]
+
+## Courses
 - [[Course for Getting Started with Obsidian]]
 - [[Obsidian Training Course in Russian|For Russian speakers: Obsidian Training Course on YouTube]]
 


### PR DESCRIPTION
## Edited
Guide Overview for Beginners, where the new guide is linked

## Added
Markdown Syntax Guide, mainly for the section "Lesser known markdown Syntax" which regularly comes up at Discord

## Checklist
- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
- [x] (if applicable) attached images have descriptive file names
- [x] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
