### PR TITLE
Add Obsidian syntax cheatsheet and commonmark tutorials

### DIFF
--- a/04 - Guides, Workflows, & Courses/Guides/Markdown Syntax.md
+++ b/04 - Guides, Workflows, & Courses/Guides/Markdown Syntax.md
@@ -10,7 +10,63 @@ publish: true
 
 ## Introductory Readings
 - [Introduction to Basic Markdown Syntax](https://www.markdownguide.org/basic-syntax/)
+	- There are many markdown variations. Obsidian's syntax is based on commonmark. Here are two good places to start:
+		- [Markdown Reference](https://commonmark.org/help/)
+		- [Markdown Tutorial - Introduction](https://commonmark.org/help/tutorial/index.html)
 - [John Gruber's Original Documentation](https://daringfireball.net/projects/markdown/)
+- The full syntax used by Obsidian (including its [[#Obsidian's Custom markdown syntax|custom syntax]] ) is described here: [Format your notes - Obsidian Help](https://help.obsidian.md/How+to/Format+your+notes)
+
+### Obsidian's Custom markdown syntax
+
+- Links use the `[[wikilink]]` format, but you can switch to markdown links in the settings if you want. 
+	- `[[wikilink#]]` to link to headers
+	- `[[wikilink#^]]` to link to individual "blocks"
+- You can use a `|` to modify the text being displayed, e.g. `[[wikilink|display text]]`.
+- Adding `!` before a link, e.g. `![[wikilink]]` will embed the file, but you can also embed headers (anything starting with `#`) or blocks (using `^`).
+	- `![[wikilink]]` for the full note
+	- `![[wikilink#Header]]` for headers
+	- `![[wikilink#^blockid]]` for individual "blocks"
+- It recognizes tags, e.g. #tutorial and clicking on them will open a search
+- You can add highlights by surrounding text with `==`, e.g. `==highlight==`, and strikethrough with `~~`, e.g.`~~strikethrough~~`
+- It supports [MathJax](https://www.mathjax.org/) to write formulas/equations: `$x^2 + y^2 = z^2$` looks like $x^2 + y^2 = z^2$
+- Text enclosed in `%%` are considered comments and won't be rendered `%% Comments %%`
+
+#### Callouts
+
+Callouts were recently added to highlight information, e.g. 
+
+```markdown
+> [!info] Callout title
+> Content of callout
+```
+
+results in: 
+
+> [!info] Callout title
+> Content of the callout
+
+#### Mermaid diagrams
+
+Supports rendering [mermaid](https://mermaid-js.github.io/mermaid/#/) diagrams, e.g. 
+
+````markdown
+```mermaid
+flowchart TB  
+	A --> C  
+	A --> D  
+	B --> C  
+	B --> D
+```
+````
+
+results in:
+```mermaid
+flowchart TB  
+	A --> C  
+	A --> D  
+	B --> C  
+	B --> D
+```
 
 ## Lesser known Markdown Syntax
 - Indenting text with a preceding blank lines is rendered as ==code block== (which is why it changes color, which gets asked quite often).

--- a/04 - Guides, Workflows, & Courses/Guides/Markdown Syntax.md
+++ b/04 - Guides, Workflows, & Courses/Guides/Markdown Syntax.md
@@ -14,7 +14,7 @@ publish: true
 		- [Markdown Reference](https://commonmark.org/help/)
 		- [Markdown Tutorial - Introduction](https://commonmark.org/help/tutorial/index.html)
 - [John Gruber's Original Documentation](https://daringfireball.net/projects/markdown/)
-- The full syntax used by Obsidian (including its [[#Obsidian's Custom markdown syntax|custom syntax]] ) is described here: [Format your notes - Obsidian Help](https://help.obsidian.md/How+to/Format+your+notes)
+- The full syntax used by Obsidian (including its [[#Obsidian's Custom markdown syntax|custom syntax]]) is described here: [Format your notes - Obsidian Help](https://help.obsidian.md/How+to/Format+your+notes)
 
 ### Obsidian's Custom markdown syntax
 


### PR DESCRIPTION
## Edited
<!-- Add a brief description here -->

## Added
<!-- Add a brief description here-->

## Checklist
- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
