### PR TITLE
Streamline GitHub actions

### DIFF
--- a/.github/workflows/update_hub.yml
+++ b/.github/workflows/update_hub.yml
@@ -5,7 +5,7 @@ on:
   # It can also be triggered manually.
   # It only runs on the main branch.
   schedule:
-    - cron: "59 23 * * 3" 
+    - cron: "59 21 * * 3" 
   workflow_dispatch:
     # Inputs the workflow accepts.
     inputs:

--- a/.github/workflows/update_issues.yml
+++ b/.github/workflows/update_issues.yml
@@ -1,7 +1,7 @@
 name: update_community_plugin_issue_list
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "59 23 * * 3"
   workflow_dispatch:
     # Inputs the workflow accepts.
     inputs:


### PR DESCRIPTION
## Edited
<!-- Add a brief description here -->

1.  Only run update_issues.yml once per week

The Hub is only published once a week, so there's no benefit     in the environmental impact of running this action more often.

2. Run update_hub.yml 2 hours before update_issues.yml

This means that we are less likely to exceed API usage limits,     but if we do, we prioritise update_hub.yml over update_issues.yml.
