### PR TITLE
Add new publish site showcase

### DIFF
--- a/03 - Showcases & Templates/Publish Sites/Data Engineering Wiki.md
+++ b/03 - Showcases & Templates/Publish Sites/Data Engineering Wiki.md
@@ -1,0 +1,17 @@
+---
+aliases: 
+- 
+tags:
+- seedling
+publish: true
+---
+
+# Data Engineering Wiki
+
+Link: https://dataengineering.wiki/Index 
+Author: Jonathan Porter and [Data Engineering Community Contributors](https://github.com/data-engineering-community/data-engineering-wiki/graphs/contributors)
+Tool: [[Obsidian Publish]]
+
+%% Add a description about the publish site below this line. It doesn't need to be long: one or two sentences should be a good start. %%
+
+The Data Engineering Wiki is an open-source collection of notes and resources around Data Engineering. It's the official site of the [r/DataEngineering](https://www.reddit.com/r/dataengineering) community which is the largest Data Engineering community in the world.


### PR DESCRIPTION
## Edited


## Added
Added a new note for a publish site showcase

## Checklist
- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
