### PR TITLE
Add new overview page: Obsidian for Religious Uses

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "python.formatting.provider": "none",
-    "editor.formatOnSaveMode": "modifications"
-}

--- a/01 - Community/People/Chris Wilson.md
+++ b/01 - Community/People/Chris Wilson.md
@@ -1,0 +1,44 @@
+---
+aliases:
+- cjwilson
+tags:
+- 
+publish: true
+---
+
+# Chris Wilson
+
+<!-- - GitHub: []() ^github -->
+<!-- - Discord: `@` ^discord-->
+- Website: <https://www.cjwilson.co.uk/> ^website
+<!-- - [[Publish sites|Publish site]]: <https://> ^publish-->
+ 
+Chris Wilson creates resources [[for Religious Uses|for Bible Study]] and shares how he uses [[Obsidian]] on his YouTube channel.
+
+## Author of
+
+%% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
+
+<!--
+### Unlisted plugins
+-->
+
+### Others
+- Chris has a playlist on his Obsidian setup: [Biblekasten Playlist](https://www.youtube.com/playlist?list=PLykefMsqC1neImu5aISN9ByTOKLaXgigk)
+
+<!--
+## Sponsor this author
+-->
+
+<!-- - [[GitHub sponsors]]: [Sponsor @sonarAIT on GitHub Sponsors](https://github.com/sponsors/sonarAIT) ^github-sponsor-->
+<!-- - [[Buy me a coffee]]: <https://> ^buy-me-a-coffee-->
+<!-- - [[PayPal]]: <https://> ^paypal-->
+<!-- - [[Patreon]]: <https://> ^patreon-->
+
+## Follow this author
+
+- [[YouTube Channels|On YouTube]]: <https://www.youtube.com/c/ChrisWilsonUK> ^youtube
+<!-- - Twitter: <https://> ^twitter-->
+<!-- - ... -->
+
+%% Hub footer: Please don't edit anything below this line %%

--- a/01 - Community/People/Chris Wilson.md
+++ b/01 - Community/People/Chris Wilson.md
@@ -30,7 +30,7 @@ Chris Wilson creates resources [[for Religious Uses|for Bible Study]] and shares
 ## Sponsor this author
 -->
 
-<!-- - [[GitHub sponsors]]: [Sponsor @sonarAIT on GitHub Sponsors](https://github.com/sponsors/sonarAIT) ^github-sponsor-->
+<!-- - [[GitHub sponsors]]: []() ^github-sponsor-->
 <!-- - [[Buy me a coffee]]: <https://> ^buy-me-a-coffee-->
 <!-- - [[PayPal]]: <https://> ^paypal-->
 <!-- - [[Patreon]]: <https://> ^patreon-->

--- a/01 - Community/People/Mark McElroy.md
+++ b/01 - Community/People/Mark McElroy.md
@@ -1,0 +1,45 @@
+---
+aliases:
+- 
+tags:
+- 
+publish: true
+---
+
+# Mark McElroy
+
+<!-- - GitHub: []() ^github -->
+<!-- - Discord: `@` ^discord-->
+- Website: <https://markmcelroy.com/> ^website
+<!-- - [[Publish sites|Publish site]]: <https://> ^publish-->
+ 
+Mark McElroy is a writer and adviser who helps people find their creative path.
+
+## Author of
+
+%% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
+
+<!--
+### Unlisted plugins
+-->
+
+### Others
+- Marc McElroy has written multiple blog posts on how he uses Obsidian on a daily basis to process his readings and thoughts as a knowledge worker: [All Roads Lead to… Obsidian?](https://markmcelroy.com/all-roads-lead-to-obsidian/)
+
+<!--
+## Sponsor this author
+-->
+
+<!-- - [[GitHub sponsors]]: [Sponsor @sonarAIT on GitHub Sponsors](https://github.com/sponsors/sonarAIT) ^github-sponsor-->
+<!-- - [[Buy me a coffee]]: <https://> ^buy-me-a-coffee-->
+<!-- - [[PayPal]]: <https://> ^paypal-->
+<!-- - [[Patreon]]: <https://> ^patreon-->
+
+## Follow this author
+
+<!-- [[YouTube Channels|On YouTube]]: <> ^youtube -->
+- Twitter: <https://twitter.com/markmcelroy> ^twitter
+- Instagram: <https://www.instagram.com/markmcelroydotcom/>
+- Facebook: <https://www.facebook.com/mark.mcelroy.378537>
+
+%% Hub footer: Please don't edit anything below this line %%

--- a/01 - Community/People/Mark McElroy.md
+++ b/01 - Community/People/Mark McElroy.md
@@ -30,7 +30,7 @@ Mark McElroy is a writer and adviser who helps people find their creative path.
 ## Sponsor this author
 -->
 
-<!-- - [[GitHub sponsors]]: [Sponsor @sonarAIT on GitHub Sponsors](https://github.com/sponsors/sonarAIT) ^github-sponsor-->
+<!-- - [[GitHub sponsors]]: []() ^github-sponsor-->
 <!-- - [[Buy me a coffee]]: <https://> ^buy-me-a-coffee-->
 <!-- - [[PayPal]]: <https://> ^paypal-->
 <!-- - [[Patreon]]: <https://> ^patreon-->

--- a/01 - Community/People/lguenth.md
+++ b/01 - Community/People/lguenth.md
@@ -1,0 +1,44 @@
+---
+aliases:
+- Luke
+- apfelstrudelig
+tags:
+- 
+publish: true
+---
+
+# Luke
+
+- GitHub: [lguenth](https://github.com/lguenth/) ^github
+- Discord: `@apfelstrudelig` ^discord
+<!-- - Website: <https://> ^website-->
+<!-- - [[Publish sites|Publish site]]: <https://> ^publish-->
+
+%% Feel free to add a bio below this comment %%
+Luke is a maintainer of the Hub and he tries to be an active member of the community. Feel free to ask him questions whenever you see him around on the [[🗂️ 01 - Community|Discord server]].
+
+## Author of
+
+%% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
+
+<!--
+### Unlisted plugins
+-->
+
+### Others
+- [mdbible](https://github.com/lguenth/mdbible): A JSON-to-Markdown converter for [Javascripture's](https://javascripture.org/) ESV Bible.
+
+## Sponsor this author
+
+<!-- - [[GitHub sponsors]]: [Sponsor @selfire1 on GitHub Sponsors](https://github.com/sponsors/selfire1) ^github-sponsor-->
+- [[Buy me a coffee]]: <https://ko-fi.com/lguenth> ^buy-me-a-coffee
+<!-- - [[PayPal]]: <https://> ^paypal-->
+<!-- - [[Patreon]]: <https://> ^patreon-->
+
+<!--
+## Follow this author
+-->
+
+<!-- - [[YouTube Channels|On YouTube]]: <https://> ^youtube-->
+<!-- - Twitter: <https://> ^twitter-->
+<!-- - ... -->

--- a/01 - Community/People/lguenth.md
+++ b/01 - Community/People/lguenth.md
@@ -30,7 +30,7 @@ Luke is a maintainer of the Hub and he tries to be an active member of the commu
 
 ## Sponsor this author
 
-<!-- - [[GitHub sponsors]]: [Sponsor @selfire1 on GitHub Sponsors](https://github.com/sponsors/selfire1) ^github-sponsor-->
+<!-- - [[GitHub sponsors]]: []() ^github-sponsor-->
 - [[Buy me a coffee]]: <https://ko-fi.com/lguenth> ^buy-me-a-coffee
 <!-- - [[PayPal]]: <https://> ^paypal-->
 <!-- - [[Patreon]]: <https://> ^patreon-->

--- a/01 - Community/People/nickmilo.md
+++ b/01 - Community/People/nickmilo.md
@@ -1,6 +1,7 @@
 ---
 aliases:
 - nickmilo
+- Nick Milo
 tags:
 - 
 publish: true
@@ -14,7 +15,7 @@ publish: true
 <!-- - [[Publish sites|Publish site]]: <https://> ^publish-->
 
 %% Feel free to add a bio below this comment %%
-
+Nick Milo is the creator of [[Linking Your Thinking]] and the corresponding theme ([[LYT Mode]]) and vault starter kit ([[LYT Kit]]).
 
 ## Author of
 
@@ -31,9 +32,10 @@ publish: true
 ### Unlisted plugins
 -->
 
-<!--
 ### Others
--->
+- [[LYT Kit]] is a starter vault for Obsidian.
+- [LYT Notes](https://lyt.ck.page/e552e5b39e) is a weekly newsletter with tips on how to make, retrieve and link notes.
+- In 2022, Nick held the first [[Linking Your Thinking]] [conference](https://www.linkingyourthinking.com/conference).
 
 <!--
 ## Sponsor this author
@@ -48,8 +50,8 @@ publish: true
 ## Follow this author
 -->
 
-<!-- - [[YouTube Channels|On YouTube]]: <https://> ^youtube-->
-<!-- - Twitter: <https://> ^twitter-->
+- [[YouTube Channels|On YouTube]]: [Linking Your Thinking](https://www.youtube.com/channel/UC85D7ERwhke7wVqskV_DZUA) ^youtube
+- Twitter: <https://twitter.com/NickMilo> ^twitter
 <!-- - ... -->
 
 %% Hub footer: Please don't edit anything below this line %%

--- a/01 - Community/People/selfire1.md
+++ b/01 - Community/People/selfire1.md
@@ -11,7 +11,7 @@ publish: true
 - GitHub: [selfire1](https://github.com/selfire1/) ^github
 <!-- - Discord: `@` ^discord-->
 <!-- - Website: <https://> ^website-->
-<!-- - [[Publish sites|Publish site]]: <https://> ^publish-->
+- [[Publish sites|Publish site]]: <https://joschuasgarden.com/> ^publish-
 
 %% Feel free to add a bio below this comment %%
 
@@ -34,14 +34,12 @@ publish: true
 ### Others
 -->
 
-<!--
 ## Sponsor this author
--->
 
 <!-- - [[GitHub sponsors]]: [Sponsor @selfire1 on GitHub Sponsors](https://github.com/sponsors/selfire1) ^github-sponsor-->
-<!-- - [[Buy me a coffee]]: <https://> ^buy-me-a-coffee-->
+- [[Buy me a coffee]]: <https://www.buymeacoffee.com/joschua> ^buy-me-a-coffee
 <!-- - [[PayPal]]: <https://> ^paypal-->
-<!-- - [[Patreon]]: <https://> ^patreon-->
+- [[Patreon]]: <https://www.patreon.com/joschua> ^patreon
 
 <!--
 ## Follow this author

--- a/04 - Guides, Workflows, & Courses/for Religious Uses.md
+++ b/04 - Guides, Workflows, & Courses/for Religious Uses.md
@@ -1,0 +1,30 @@
+---
+aliases:
+- for Bible Studies
+tags:
+- seedling
+- MOC
+publish: true
+---
+
+# for Religious Uses
+The [[🗂️ 01 - Community|Obsidian Community]] has created plenty of resources on *Bible Studies*.
+
+## Plugins
+- The [[obsidian-bible-reference|Bible Reference Plugin]] will let you "fetch" a particular passage of the Bible from [ESV.org](https://www.esv.org/).
+- With [[obsidian-bible-linker|Bible Linker]], you can quickly copy bible verses and create links to them.
+
+## Media Resources
+- [[Chris Wilson]] has multiple YouTube video about how he uses Obsidian to take notes on the Bible. Here is an introduction to his "Biblekasten": [How to set up Obsidian to take digital Bible notes](https://www.youtube.com/watch?v=kT4g59YCbd0)
+- In the video [Jeff Cavins' CRAZY Note Taking System](https://www.youtube.com/watch?v=3TeRR9KnLDg), Jeff Cavins talks about how he links together theological and philosophical ideas from books and other sources.
+- [[selfire1|Joschua]] shared how he uses the [[Linking Your Thinking]] framework by [[nickmilo|Nick Milo]] to integrate his religious learnings into a PKM system.
+- There is also [this Meta Post on organising the Bible](https://forum.obsidian.md/t/organising-the-bible-in-obsidian/1490) that Joschua compiled.
+- [[Mark McElroy]] wrote [a useful blog post](https://markmcelroy.com/spatial-models-for-relating-ideas/) on effectively capturing information, creating spatial relationships between ideas and keeping track of supporting and differing viewpoints.
+
+## Kits and Converters
+- Joschua is a rich source for inspiration if you want to try digital Bible Studies:
+	- He published the [Bible Study in Obsidian Kit](https://forum.obsidian.md/t/bible-study-in-obsidian-kit-including-the-bible-in-markdown/12503) and also wrote [BibleGateway-to-Obsidian](https://github.com/selfire1/BibleGateway-to-Obsidian), a script to import various versions of the Bible. 
+	- The tool is also available in French and German. If you need help using it, take a look at the help thread in the Obsidian Forum.
+- [[lguenth|Luke]] wrote a JSON-to-[[Markdown]] converter for [Javascripture's online bible](https://javascripture.org/). Currently, only the ESV is provided but he is taking requests for other versions and formats.
+
+If you have come across other resources for working with religious content inside Obsidian, feel free to add them to this page!


### PR DESCRIPTION
## Edited
- Nick Milo's and Joschua's notes in `01 Community/People` to include up-to-date info.

## Added
- New note `for Religious Uses` which @eleanorkonik requested in #449 :)
- New manually created People pages for a blog writer, a Obsidian YouTube channel... and me (because I wrote a tool a few months ago that fit into the note :see_no_evil:)

## Checklist
- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
~~- [ ] (if applicable) attached images have descriptive file names~~
~~- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses~~
