### PR TITLE
Removed embed containing broken link 

### DIFF
--- a/01 - Community/Obsidian Roundup/2021.07.17.md
+++ b/01 - Community/Obsidian Roundup/2021.07.17.md
@@ -85,7 +85,7 @@ Insiders will continue to get access to early beta builds and features.
 
 - The new [[Illusion]] theme (optimized for light mode) is absolutely gorgeous. Its primary benefit is that things are a bit bigger with better contrast.
 - [[California Coast]] theme got some major updates including better mobile support.
-- A couple of people have asked for a “Getting Started” guide for making CSS themes for Obsidian. [Reggie has one](https://publish.obsidian.md/reggienotes/Quickstart+CSS+Guide/010+Obsidian+CSS+Themes) over on Publish. ^594d70
+- A couple of people have asked for a “Getting Started” guide for making CSS themes for Obsidian. [Reggie has one](https://publish.obsidian.md/reggienotes/Quickstart+CSS+Guide/010+Obsidian+CSS+Themes) over on Publish.
 - `@mgmeyers` shared a [method](https://discord.com/channels/686053708261228577/702656734631821413/865318907832172555) to define the shape of icons using css and `web-mask-image` that will work a bit better than `aria-label`s to replace svgs. This lets theme developers swap out icons without needing users to download the icon swapper plugin and download icon files, which should let theme developers do more with icons on mobile too.
 - If you want a custom font on mobile, you can [Base64 encode the font](https://transfonter.org/) into your theme. You can't refer to other files from css snippets directly - relative links won't work there because the files are loaded as a blob instead. Once you’ve encoded the font, copy it into the theme file and change fonts wherever you want either in the theme file itself or through one of the plugins.
 - the [[Everforest]] theme [has been updated](https://forum.obsidian.md/t/theme-everforest-dark-light-theme/20139)

--- a/04 - Guides, Workflows, & Courses/for Beginners.md
+++ b/04 - Guides, Workflows, & Courses/for Beginners.md
@@ -9,7 +9,6 @@ tags:
 
 These guides will help you get started with [[Obsidian]] and related topics.
 
-![[2021.07.17#^594d70]]
 ## Introduction to Basic Concepts
 - [**Sitepoint**: Obsidian Beginner Guide](https://www.sitepoint.com/obsidian-beginner-guide/)
 - [[Obsidian Help]]


### PR DESCRIPTION
## Edited
This was a link to a roundup line linking Reggie's guide to CSS, which was broken. Reggie's publish site seems to be down, or at least I couldn't find it anywhere, so I removed the link.

## Checklist
- [ ] before creating a new note, I searched the vault
- [ ] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
