### PR TITLE
Add new overview page: Obsidian for Religious Uses (2nd try)

### DIFF
--- a/01 - Community/People/Chris Wilson.md
+++ b/01 - Community/People/Chris Wilson.md
@@ -1,0 +1,44 @@
+---
+aliases:
+- cjwilson
+tags:
+- 
+publish: true
+---
+
+# Chris Wilson
+
+<!-- - GitHub: []() ^github -->
+<!-- - Discord: `@` ^discord-->
+- Website: <https://www.cjwilson.co.uk/> ^website
+<!-- - [[Publish sites|Publish site]]: <https://> ^publish-->
+ 
+Chris Wilson creates resources [[for Religious Uses|for Bible Study]] and shares how he uses [[Obsidian]] on his YouTube channel.
+
+## Author of
+
+%% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
+
+<!--
+### Unlisted plugins
+-->
+
+### Others
+- Chris has a playlist on his Obsidian setup: [Biblekasten Playlist](https://www.youtube.com/playlist?list=PLykefMsqC1neImu5aISN9ByTOKLaXgigk)
+
+<!--
+## Sponsor this author
+-->
+
+<!-- - [[GitHub sponsors]]: []() ^github-sponsor-->
+<!-- - [[Buy me a coffee]]: <https://> ^buy-me-a-coffee-->
+<!-- - [[PayPal]]: <https://> ^paypal-->
+<!-- - [[Patreon]]: <https://> ^patreon-->
+
+## Follow this author
+
+- [[YouTube Channels|On YouTube]]: <https://www.youtube.com/c/ChrisWilsonUK> ^youtube
+<!-- - Twitter: <https://> ^twitter-->
+<!-- - ... -->
+
+%% Hub footer: Please don't edit anything below this line %%

--- a/01 - Community/People/Mark McElroy.md
+++ b/01 - Community/People/Mark McElroy.md
@@ -1,0 +1,45 @@
+---
+aliases:
+- 
+tags:
+- 
+publish: true
+---
+
+# Mark McElroy
+
+<!-- - GitHub: []() ^github -->
+<!-- - Discord: `@` ^discord-->
+- Website: <https://markmcelroy.com/> ^website
+<!-- - [[Publish sites|Publish site]]: <https://> ^publish-->
+ 
+Mark McElroy is a writer and adviser who helps people find their creative path.
+
+## Author of
+
+%% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
+
+<!--
+### Unlisted plugins
+-->
+
+### Others
+- Marc McElroy has written multiple blog posts on how he uses Obsidian on a daily basis to process his readings and thoughts as a knowledge worker: [All Roads Lead to… Obsidian?](https://markmcelroy.com/all-roads-lead-to-obsidian/)
+
+<!--
+## Sponsor this author
+-->
+
+<!-- - [[GitHub sponsors]]: []() ^github-sponsor-->
+<!-- - [[Buy me a coffee]]: <https://> ^buy-me-a-coffee-->
+<!-- - [[PayPal]]: <https://> ^paypal-->
+<!-- - [[Patreon]]: <https://> ^patreon-->
+
+## Follow this author
+
+<!-- [[YouTube Channels|On YouTube]]: <> ^youtube -->
+- Twitter: <https://twitter.com/markmcelroy> ^twitter
+- Instagram: <https://www.instagram.com/markmcelroydotcom/>
+- Facebook: <https://www.facebook.com/mark.mcelroy.378537>
+
+%% Hub footer: Please don't edit anything below this line %%

--- a/01 - Community/People/lguenth.md
+++ b/01 - Community/People/lguenth.md
@@ -1,0 +1,44 @@
+---
+aliases:
+- Luke
+- apfelstrudelig
+tags:
+- 
+publish: true
+---
+
+# Luke
+
+- GitHub: [lguenth](https://github.com/lguenth/) ^github
+- Discord: `@apfelstrudelig#1337` ^discord
+<!-- - Website: <https://> ^website-->
+<!-- - [[Publish sites|Publish site]]: <https://> ^publish-->
+
+%% Feel free to add a bio below this comment %%
+Luke is a maintainer of the Hub. Feel free to ask him questions regarding Obsidian or anything else that's on your mind whenever you see him around on the [[🗂️ 01 - Community|Discord server]].
+
+## Author of
+
+%% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
+
+<!--
+### Unlisted plugins
+-->
+
+### Others
+- [mdbible](https://github.com/lguenth/mdbible): A JSON-to-Markdown converter for [Javascripture's](https://javascripture.org/) ESV Bible.
+
+## Sponsor this author
+
+<!-- - [[GitHub sponsors]]: []() ^github-sponsor-->
+- [[Buy me a coffee]]: <https://ko-fi.com/lguenth> ^buy-me-a-coffee
+<!-- - [[PayPal]]: <https://> ^paypal-->
+<!-- - [[Patreon]]: <https://> ^patreon-->
+
+<!--
+## Follow this author
+-->
+
+<!-- - [[YouTube Channels|On YouTube]]: <https://> ^youtube-->
+<!-- - Twitter: <https://> ^twitter-->
+<!-- - ... -->

--- a/01 - Community/People/nickmilo.md
+++ b/01 - Community/People/nickmilo.md
@@ -1,6 +1,7 @@
 ---
 aliases:
 - nickmilo
+- Nick Milo
 tags:
 - 
 publish: true
@@ -9,12 +10,12 @@ publish: true
 # nickmilo
 
 - GitHub: [nickmilo](https://github.com/nickmilo/) ^github
-<!-- - Discord: `@` ^discord-->
+- Discord: `@nickmilo#6327` ^discord
 <!-- - Website: <https://> ^website-->
 <!-- - [[Publish sites|Publish site]]: <https://> ^publish-->
 
 %% Feel free to add a bio below this comment %%
-
+Nick Milo is the creator of [[Linking Your Thinking]] and the corresponding theme ([[LYT Mode]]) and vault starter kit ([[LYT Kit]]).
 
 ## Author of
 
@@ -31,9 +32,10 @@ publish: true
 ### Unlisted plugins
 -->
 
-<!--
 ### Others
--->
+- [[LYT Kit]] is a starter vault for Obsidian.
+- [LYT Notes](https://lyt.ck.page/e552e5b39e) is a weekly newsletter with tips on how to make, retrieve and link notes.
+- In 2022, Nick held the first [[Linking Your Thinking]] [conference](https://www.linkingyourthinking.com/conference).
 
 <!--
 ## Sponsor this author
@@ -44,12 +46,10 @@ publish: true
 <!-- - [[PayPal]]: <https://> ^paypal-->
 <!-- - [[Patreon]]: <https://> ^patreon-->
 
-<!--
 ## Follow this author
--->
 
-<!-- - [[YouTube Channels|On YouTube]]: <https://> ^youtube-->
-<!-- - Twitter: <https://> ^twitter-->
+- [[YouTube Channels|On YouTube]]: [Linking Your Thinking](https://www.youtube.com/channel/UC85D7ERwhke7wVqskV_DZUA) ^youtube
+- Twitter: <https://twitter.com/NickMilo> ^twitter
 <!-- - ... -->
 
 %% Hub footer: Please don't edit anything below this line %%

--- a/01 - Community/People/pmbauer.md
+++ b/01 - Community/People/pmbauer.md
@@ -1,0 +1,44 @@
+---
+aliases:
+- Paul Bauer
+tags:
+- 
+publish: true
+---
+
+# Paul Bauer
+
+- GitHub: [pmbauer](https://github.com/pmbauer) ^github
+- Discord: `@Paul Bauer#0067` ^discord
+
+%% Feel free to add a bio below this comment %%
+
+## Author of
+
+%% Begin Hub: Released contributions %%
+
+%% End Hub: Released contributions %%
+
+%% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
+
+<!--
+### Unlisted plugins
+-->
+
+### Others
+- [av-obsidian](https://github.com/pmbauer/av-obsidian): A converter for the King James Bible, formatted for use in Obsidian.
+
+## Sponsor this author
+
+<!-- - [[GitHub sponsors]]: [Sponsor @pmbauer on GitHub Sponsors](https://github.com/sponsors/pmbauer) ^github-sponsor-->
+<!-- - [[Buy me a coffee]]: <https://> ^buy-me-a-coffee-->
+<!-- - [[PayPal]]: <https://> ^paypal-->
+<!-- - [[Patreon]]: <https://> ^patreon-->
+
+<!--
+## Follow this author
+-->
+
+<!-- - [[YouTube Channels|On YouTube]]: <https://> ^youtube-->
+<!-- - Twitter: <https://> ^twitter-->
+<!-- - ... -->

--- a/01 - Community/People/selfire1.md
+++ b/01 - Community/People/selfire1.md
@@ -9,12 +9,11 @@ publish: true
 # Joschua
 
 - GitHub: [selfire1](https://github.com/selfire1/) ^github
-<!-- - Discord: `@` ^discord-->
-<!-- - Website: <https://> ^website-->
-<!-- - [[Publish sites|Publish site]]: <https://> ^publish-->
+- Discord: `@selfire#3095` ^discord
+- [[Publish sites|Publish site]]: <https://joschuasgarden.com/> ^publish
 
 %% Feel free to add a bio below this comment %%
-
+Joschua is the creator of many well-known [[for Religious Uses|Bible resources for Obsidian]].
 
 ## Author of
 
@@ -34,14 +33,12 @@ publish: true
 ### Others
 -->
 
-<!--
 ## Sponsor this author
--->
 
 <!-- - [[GitHub sponsors]]: [Sponsor @selfire1 on GitHub Sponsors](https://github.com/sponsors/selfire1) ^github-sponsor-->
-<!-- - [[Buy me a coffee]]: <https://> ^buy-me-a-coffee-->
+- [[Buy me a coffee]]: <https://www.buymeacoffee.com/joschua> ^buy-me-a-coffee
 <!-- - [[PayPal]]: <https://> ^paypal-->
-<!-- - [[Patreon]]: <https://> ^patreon-->
+- [[Patreon]]: <https://www.patreon.com/joschua> ^patreon
 
 <!--
 ## Follow this author

--- a/04 - Guides, Workflows, & Courses/for Religious Uses.md
+++ b/04 - Guides, Workflows, & Courses/for Religious Uses.md
@@ -1,0 +1,36 @@
+---
+aliases:
+- for Bible Studies
+tags:
+- seedling
+- MOC
+publish: true
+---
+
+# for Religious Uses
+The [[🗂️ 01 - Community|Obsidian Community]] has created plenty of resources for studying religious texts.
+
+## Plugins
+- The [[obsidian-bible-reference|Bible Reference Plugin]] will let you "fetch" a particular passage of the Bible from [ESV.org](https://www.esv.org/).
+- With [[obsidian-bible-linker|Bible Linker]], you can quickly copy bible verses and create links to them.
+- [[obsidian-daf-yomi|Daf Yomi]] helps you prepare for the [daily practice of learning the Oral Torah](https://en.wikipedia.org/wiki/Daf_Yomi) by downloading the day's PDF (one page of the [Talmud](https://en.wikipedia.org/wiki/Talmud)) and links to commentary and other resources.
+
+## Media Resources
+- [[Chris Wilson]] has multiple YouTube videos about how he uses Obsidian to take notes on the Bible. Here is an introduction to his "Biblekasten": [How to set up Obsidian to take digital Bible notes](https://www.youtube.com/watch?v=kT4g59YCbd0)
+- In the video [Jeff Cavins' CRAZY Note Taking System](https://www.youtube.com/watch?v=3TeRR9KnLDg), Jeff Cavins talks about how he links together theological and philosophical ideas from books and other sources.
+- [[selfire1|Joschua]] shared how he uses the [[Linking Your Thinking]] framework by [[nickmilo|Nick Milo]] to integrate his religious learnings into a PKM system.
+- There is also [this Meta Post on organising the Bible](https://forum.obsidian.md/t/organising-the-bible-in-obsidian/1490) that Joschua compiled.
+- [[Mark McElroy]] wrote [a useful blog post](https://markmcelroy.com/spatial-models-for-relating-ideas/) on effectively capturing information, creating spatial relationships between ideas and keeping track of supporting and differing viewpoints.
+
+## Vaults, Kits and Converters
+- [av-obsidian](https://github.com/pmbauer/av-obsidian) is a script by [[pmbauer]] which creates a formatted version of the [King James Bible/Authorized Version](https://en.wikipedia.org/wiki/King_James_Version).
+- Joschua is a rich source for inspiration if you want to try digital Bible Studies:
+	- He published the [Bible Study in Obsidian Kit](https://forum.obsidian.md/t/bible-study-in-obsidian-kit-including-the-bible-in-markdown/12503) and also wrote [BibleGateway-to-Obsidian](https://github.com/selfire1/BibleGateway-to-Obsidian), a script to import various versions of the Bible. 
+	- The tool is also available in French and German.
+- [mdbible](https://github.com/lguenth/mdbible) is a JSON-to-[[Markdown]] converter for [Javascripture's online bible](https://javascripture.org/), written by [[lguenth|Luke]]. Currently, only the ESV is provided but he is taking requests for other versions and formats.
+
+If you have come across other resources for working with religious content inside Obsidian, feel free to add them to this page! In the discussions leading up to the creation of this note, [some people chimed in on GitHub to share their workflows](https://github.com/obsidian-community/obsidian-hub/issues/449). 
+
+Or let yourself be inspired by this wonderful (and very pretty!) [showcase of someone's setup](https://forum.obsidian.md/t/my-bible-study-workflow/39044) inside Obsidian:
+
+![forum-bible-study-workflow-showcase](https://web.archive.org/web/20220621231316if_/https://forum.obsidian.md/uploads/default/original/3X/8/6/864dac12a1a08ef7dff7af0718137f589011a9e5.jpeg)


### PR DESCRIPTION
This is the second try of PR #450. Now without git oopsies. Hopefully.

Edited
- Nick Milo's and Joschua's notes in 01 Community/People to include up-to-date info

Added
- New note for Religious Uses which @eleanorkonik requested in https://github.com/obsidian-community/obsidian-hub/issues/449
- New manually created People pages for Paul Bauer, a blog writer, a Obsidian YouTube channel and me

Checklist

- [x] before creating a new note, I searched the vault
- [x] new notes have the .md extension
- [x] (if applicable) attached images have descriptive file names