### PR TITLE
Create `for Vim users.md`

### DIFF
--- a/04 - Guides, Workflows, & Courses/for Vim users.md
+++ b/04 - Guides, Workflows, & Courses/for Vim users.md
@@ -1,0 +1,22 @@
+---
+aliases: 
+- 
+tags:
+- seedling
+---
+
+# for Vim users
+
+This site is for all information valuable to users familiar with vim, that want to use Obsidian's vim mode. 
+
+## Basics
+- You can enable Obsidian's vim mode under the settings under `Editor – Advanced – Vim key bindings`.
+- Obsidian uses the [vim emulation from the CodeMirror Editor](https://github.com/codemirror/codemirror5/blob/master/keymap/vim.js), which does not include all vim commands, but most of them.
+- It is recommended to use the [vimrc Support Plugin](https://obsidian.md/plugins?id=obsidian-vimrc-support) to be able use an obsidian-specific `.vimrc` file.
+
+## Plugins
+- see [[Vim-related Plugins]] for a (non-complete) collection of plugins specifically for vim. 
+
+## Example vimrcs
+- [obsidian.vimrc and usage infos](https://bauer.codes/notes/Obsidian#Obsidian+vim+window+controls) by pmbauer
+- [obsidian.vimrc](https://github.com/chrisgrieser/dotfiles/blob/main/obsidian.vimrc) by [[chrisgrieser|pseudometa]]

--- a/04 - Guides, Workflows, & Courses/for Vim users.md
+++ b/04 - Guides, Workflows, & Courses/for Vim users.md
@@ -11,11 +11,11 @@ This site is for all information valuable to users familiar with vim, that want 
 
 ## Basics
 - You can enable Obsidian's vim mode in the settings under `Editor – Advanced – Vim key bindings`.
-- Obsidian uses the [vim emulation from the CodeMirror Editor](https://github.com/codemirror/codemirror5/blob/master/keymap/vim.js), which does not include all vim commands, but most of them.
+- Obsidian uses the [vim emulation from the CodeMirror Editor](https://github.com/replit/codemirror-vim), which does not include all vim commands, but most of them.
 - It is recommended to use the [vimrc Support Plugin](https://obsidian.md/plugins?id=obsidian-vimrc-support) to be able use an obsidian-specific `.vimrc` file.
 
 ## Plugins
-- see [[Vim-related Plugins]] for a (non-complete) collection of plugins specifically for vim. 
+- see [[Vim-related Plugins]] for a (non-complete) collection of plugins for using Vim in Obsidian.
 
 ## Example vimrcs
 - [obsidian.vimrc and usage infos](https://bauer.codes/notes/Obsidian#Obsidian+vim+window+controls) by pmbauer

--- a/04 - Guides, Workflows, & Courses/for Vim users.md
+++ b/04 - Guides, Workflows, & Courses/for Vim users.md
@@ -10,7 +10,7 @@ tags:
 This site is for all information valuable to users familiar with vim, that want to use Obsidian's vim mode. 
 
 ## Basics
-- You can enable Obsidian's vim mode under the settings under `Editor – Advanced – Vim key bindings`.
+- You can enable Obsidian's vim mode in the settings under `Editor – Advanced – Vim key bindings`.
 - Obsidian uses the [vim emulation from the CodeMirror Editor](https://github.com/codemirror/codemirror5/blob/master/keymap/vim.js), which does not include all vim commands, but most of them.
 - It is recommended to use the [vimrc Support Plugin](https://obsidian.md/plugins?id=obsidian-vimrc-support) to be able use an obsidian-specific `.vimrc` file.
 


### PR DESCRIPTION
## Added
Overview Page for vim users. ([Context](https://discord.com/channels/686053708261228577/716028884885307432/989481680916082698))

## Checklist
- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
- [x] (if applicable) attached images have descriptive file names
- [x] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
