### PR TITLE
Add links to my obsidian-repos-downloader tool

### DIFF
--- a/01 - Community/People/claremacrae.md
+++ b/01 - Community/People/claremacrae.md
@@ -33,6 +33,7 @@ publish: true
 ### Others
 
 - [[Plugin Testing for Developers]]
+- [obsidian-repos-downloader](https://github.com/claremacrae/obsidian-repos-downloader) - Download every approved Obsidian.md community Plugin and Theme
 
 <!--
 ## Sponsor this author

--- a/04 - Guides, Workflows, & Courses/for Plugin Developers.md
+++ b/04 - Guides, Workflows, & Courses/for Plugin Developers.md
@@ -53,8 +53,9 @@ See also [[for Plugin Developers to Automate Tests|Resources and Guides for Plug
 - [obsidian-md at GitHub](https://github.com/topics/obsidian-md)
 - [What tools and libraries are used in Obsidian?](https://konhi.me/obsidian-stack.html)
 - Ways to download all of Obsidian's plugin source codes to learn from and search through:
-  - [Repoistories Downloader](https://github.com/konhi/obsidian-repositories-downloader)
+  - [Repositories Downloader](https://github.com/konhi/obsidian-repositories-downloader)
   - [Plugin Downloader](https://github.com/luckman212/obsidian-plugin-downloader)
+  - [obsidian-repos-downloader](https://github.com/claremacrae/obsidian-repos-downloader) - Download every approved Obsidian.md community Plugin and Theme
 
   
 %% Hub footer: Please don't edit anything below this line %%

--- a/04 - Guides, Workflows, & Courses/for Theme Designers.md
+++ b/04 - Guides, Workflows, & Courses/for Theme Designers.md
@@ -43,6 +43,8 @@ This note collects resources and guides for beginner and expert theme designers 
 - [**Iconify Icon Sets**](https://icon-sets.iconify.design/) Website to search and find icons from multiple icon sets
 - [**URL-encoder for SVG**](https://yoksel.github.io/url-encoder/) Encodes icon's svg code into useful `background-image` url
 - [obsidian-style-settings:](https://github.com/mgmeyers/obsidian-style-settings) allows snippet, theme, and plugin CSS files to define a set of configuration options. It then allows users to see all the tweakable settings in one settings pane.
+- Ways to download all of Obsidian's theme source codes to learn from and search through:
+  - [obsidian-repos-downloader](https://github.com/claremacrae/obsidian-repos-downloader) - Download every approved Obsidian.md community Plugin and Theme
 
 %% Hub footer: Please don't edit anything below this line %%
 


### PR DESCRIPTION
## Edited

Been meaning to add a link to https://github.com/claremacrae/obsidian-repos-downloader for some tome, and then was prompted today by @chrisgrieser ...

Have added it to the pages for Plugin authors and Theme designers... and to my own note.

## Added
<!-- Add a brief description here-->

## Checklist
- [ ] before creating a new note, I searched the vault
- [ ] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
