### PR TITLE
Add guide for historical research

### DIFF
--- a/04 - Guides, Workflows, & Courses/for Academic Writing.md
+++ b/04 - Guides, Workflows, & Courses/for Academic Writing.md
@@ -15,7 +15,7 @@ tags:
 - [An Integrated Qualitative Analysis Environment with Obsidian - Axle](https://axle.design/an-integrated-qualitative-analysis-environment-with-obsidian) by [[ryanjamurphy|Ryan Murphy]]
 - [An Academic Workflow: Zotero & Obsidian | by Alexandra Phelan](https://medium.com/@alexandraphelan/an-academic-workflow-zotero-obsidian-56bf918d51ab) by @lexanka
 - [[YT - Pandoc and Obsidian - Create slideshows, PDFs and Word documents|Community Talk: Using Pandoc and Obsidian]] by [[SkepticMystic]]
-- [Doing History with Zotero and Obsidian: 01 Notetaking for Historians](https://publish.obsidian.md/history-notes/01+Notetaking+for+Historians) by [[Elena Razlogova|erazlogo]]*
+- [Doing History with Zotero and Obsidian: 01 Notetaking for Historians](https://publish.obsidian.md/history-notes/01+Notetaking+for+Historians) by [[Elena Razlogova|erazlogo]]
 
 
 %% Hub footer: Please don't edit anything below this line %%

--- a/04 - Guides, Workflows, & Courses/for Academic Writing.md
+++ b/04 - Guides, Workflows, & Courses/for Academic Writing.md
@@ -15,7 +15,7 @@ tags:
 - [An Integrated Qualitative Analysis Environment with Obsidian - Axle](https://axle.design/an-integrated-qualitative-analysis-environment-with-obsidian) by [[ryanjamurphy|Ryan Murphy]]
 - [An Academic Workflow: Zotero & Obsidian | by Alexandra Phelan](https://medium.com/@alexandraphelan/an-academic-workflow-zotero-obsidian-56bf918d51ab) by @lexanka
 - [[YT - Pandoc and Obsidian - Create slideshows, PDFs and Word documents|Community Talk: Using Pandoc and Obsidian]] by [[SkepticMystic]]
-- [Doing History with Zotero and Obsidian: 01 Notetaking for Historians](https://publish.obsidian.md/history-notes/01+Notetaking+for+Historians) by [[Elena Razlogova|erazlogo]]
+- [Doing History with Zotero and Obsidian: 01 Notetaking for Historians](https://publish.obsidian.md/history-notes/01+Notetaking+for+Historians) by @erazlogo
 
 
 %% Hub footer: Please don't edit anything below this line %%

--- a/04 - Guides, Workflows, & Courses/for Academic Writing.md
+++ b/04 - Guides, Workflows, & Courses/for Academic Writing.md
@@ -15,6 +15,7 @@ tags:
 - [An Integrated Qualitative Analysis Environment with Obsidian - Axle](https://axle.design/an-integrated-qualitative-analysis-environment-with-obsidian) by [[ryanjamurphy|Ryan Murphy]]
 - [An Academic Workflow: Zotero & Obsidian | by Alexandra Phelan](https://medium.com/@alexandraphelan/an-academic-workflow-zotero-obsidian-56bf918d51ab) by @lexanka
 - [[YT - Pandoc and Obsidian - Create slideshows, PDFs and Word documents|Community Talk: Using Pandoc and Obsidian]] by [[SkepticMystic]]
+- [Doing History with Zotero and Obsidian: 01 Notetaking for Historians](https://publish.obsidian.md/history-notes/01+Notetaking+for+Historians) by [[Elena Razlogova|erazlogo]]*
 
 
 %% Hub footer: Please don't edit anything below this line %%


### PR DESCRIPTION
## Edited
I edited `04 - Guides, Workflows, & Courses/for Academic Writing.md` -- added a link to my workflow for historians.

## Added
I did not add any pages.

## Checklist
- [ ] before creating a new note, I searched the vault
- [ ] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
