### PR TITLE
Added dashboard for sales

### DIFF
--- a/03 - Showcases & Templates/Dashboards/🗂️ Dashboards.md
+++ b/03 - Showcases & Templates/Dashboards/🗂️ Dashboards.md
@@ -10,6 +10,7 @@ tags:
 #placeholder/description
 
 - [@Rainbell's Obsidian Homepage](https://github.com/Rainbell129/Obsidian-Homepage)
+- [Dashboard with tasks, pomodoros and projects](https://forum.obsidian.md/t/dashboard-and-workflow-for-obsidian-at-work-sales/34794)
 
 ## MOC
 

--- a/04 - Guides, Workflows, & Courses/for Specific Professions.md
+++ b/04 - Guides, Workflows, & Courses/for Specific Professions.md
@@ -15,6 +15,9 @@ publish: true
 ## Law
 - [[Breadcrumbs for Comparative Law]]
 
+## Sales
+- [Dashboard for sales](https://forum.obsidian.md/t/dashboard-and-workflow-for-obsidian-at-work-sales/34794)
+
 %% Hub footer: Please don't edit anything below this line %%
 
 # This note in GitHub


### PR DESCRIPTION
## Edited
<!-- Add a brief description here -->

## Added
Added link to dashboard for sales

## Checklist
- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
- [x] (if applicable) attached images have descriptive file names
- [x] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
