### PR TITLE
Add basic Obsidian ecosystem analysis

### DIFF
--- a/01 - Community/People/Fevol.md
+++ b/01 - Community/People/Fevol.md
@@ -9,7 +9,7 @@ publish: true
 # Fevol
 
 - GitHub: [Fevol](https://github.com/Fevol/) ^github
-- Discord: `@`Fevol#9470 ^discord
+- Discord: `@Fevol#9470` ^discord
 <!-- - Website: <https://> ^website-->
 <!-- - [[Publish sites|Publish site]]: <https://> ^publish-->
 
@@ -21,13 +21,6 @@ CompSci student trying to make plugins for Obsidian, has too many interests for 
 %% Begin Hub: Released contributions %%
 
 
-### Plugins
-- [[obsidian-translate|Obsidian Translate]]
-
-<!--
-### Themes
--->
-
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
@@ -36,9 +29,9 @@ CompSci student trying to make plugins for Obsidian, has too many interests for 
 ### Unlisted plugins
 -->
 
-<!--
+
 ### Others
--->
+- [[Obsidian ecosystem statistics|Brief analysis on Obsidian's ecosystem]]
 
 <!--
 ## Sponsor this author

--- a/01 - Community/People/Fevol.md
+++ b/01 - Community/People/Fevol.md
@@ -1,0 +1,58 @@
+---
+aliases:
+- 
+tags:
+- seedling
+publish: true
+---
+
+# Fevol
+
+- GitHub: [Fevol](https://github.com/Fevol/) ^github
+- Discord: `@`Fevol#9470 ^discord
+<!-- - Website: <https://> ^website-->
+<!-- - [[Publish sites|Publish site]]: <https://> ^publish-->
+
+%% Feel free to add a bio below this comment %%
+CompSci student trying to make plugins for Obsidian, has too many interests for their own good.
+
+## Author of
+
+%% Begin Hub: Released contributions %%
+
+
+### Plugins
+- [[obsidian-translate|Obsidian Translate]]
+
+<!--
+### Themes
+-->
+
+%% End Hub: Released contributions %%
+
+%% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%
+
+<!--
+### Unlisted plugins
+-->
+
+<!--
+### Others
+-->
+
+<!--
+## Sponsor this author
+-->
+
+<!-- - [[GitHub sponsors]]: [Sponsor @Fevol on GitHub Sponsors](https://github.com/sponsors/Fevol) ^github-sponsor-->
+<!-- - [[Buy me a coffee]]: <https://> ^buy-me-a-coffee-->
+<!-- - [[PayPal]]: <https://> ^paypal-->
+<!-- - [[Patreon]]: <https://> ^patreon-->
+
+<!--
+## Follow this author
+-->
+
+<!-- - [[YouTube Channels|On YouTube]]: <https://> ^youtube-->
+<!-- - Twitter: <https://> ^twitter-->
+<!-- - ... -->

--- a/04 - Guides, Workflows, & Courses/Guides/Obsidian ecosystem statistics.md
+++ b/04 - Guides, Workflows, & Courses/Guides/Obsidian ecosystem statistics.md
@@ -1,0 +1,73 @@
+---
+aliases: 
+- 
+tags:
+- seedling
+publish: true
+---
+
+# Obsidian statistics
+*Note written by [[Fevol]]*
+
+This note contains several stats pertaining to the Obsidian ecosystem, specifically the share of users per platform, and the downloads of plugins/themes.
+
+All data and graphs found below have been gathered from either GitHub or Obsidian's API. 
+
+The Python scripts to fetch, process and graph the data, alongside with all raw & processed data, can be found in this GitHub repository: [https://github.com/Fevol/obsidian-data-processing](https://github.com/Fevol/obsidian-data-processing)
+
+Before interpreting the data found below, be aware of the following:
+- The amount of downloads is usually much higher than the actual amount of users who've installed a plugin/Obsidian
+- Flatpak downloads are not included in the platform share, this accounts for 751k installs and updates
+- All data was collected on 2022/09/11
+
+
+## Platform Share
+
+This section contains the %-share of users for every platform Obsidian is available on, excluding iOS and Android.
+
+As of *version 0.15.9*, the share between platforms is divided as follows:
+**Windows** — 53.1%
+ >  64-bit: 98.01%
+>   arm:    1.19%
+>   32-bit: 0.79
+
+**MacOS** — 34.4%
+
+**Linux** — 12.1%
+>  AppImage: 53.92%
+>  Snap: 22.98%
+>  Debian: 17.55%
+>  AppImage(arm): 2.81%
+>  tar.gz: 2.55%
+>  tar.gz(arm): 0.17%
+
+![Releases stats](https://raw.githubusercontent.com/Fevol/obsidian-data-processing/master/images/releases-platform-share.png)
+
+
+## Obsidian Releases Distribution
+
+![Releases stats](https://raw.githubusercontent.com/Fevol/obsidian-data-processing/master/images/releases-full.png)
+
+
+
+## Plugin Downloads
+
+This chart graphs the downloads of community plugins on the y-axis, and the relative age of a plugin on the x-axis (from oldest plugin to newest plugin)
+
+- 21 Plugins have more than 100.000 downloads (3.24%)
+- 155 Plugins have more than 10.000 downloads (23.92%)
+- 449 Plugins have more than 1.000 downloads (69.29%)
+
+![Plugin downloads](https://raw.githubusercontent.com/Fevol/obsidian-data-processing/master/images/plugins-chronological.png)
+
+
+
+## Theme Downloads
+
+This chart graphs the downloads of community themes on the y-axis,  and the relative age of a theme on the x-axis (from oldest theme to newest theme)
+
+- 3 Themes have more than 100.000 downloads (2.13%)
+- 42 Themes have more than 10.000 downloads (29.79%)
+- 135 Themes have more than 1.000 downloads (95.74%)
+
+![Theme downloads](https://raw.githubusercontent.com/Fevol/obsidian-data-processing/master/images/themes-chronological.png)

--- a/04 - Guides, Workflows, & Courses/Guides/Obsidian ecosystem statistics.md
+++ b/04 - Guides, Workflows, & Courses/Guides/Obsidian ecosystem statistics.md
@@ -16,9 +16,9 @@ All data and graphs found below have been gathered from either GitHub or Obsidia
 The Python scripts to fetch, process and graph the data, alongside with all raw & processed data, can be found in this GitHub repository: [https://github.com/Fevol/obsidian-data-processing](https://github.com/Fevol/obsidian-data-processing)
 
 Before interpreting the data found below, be aware of the following:
-- The amount of downloads is usually much higher than the actual amount of users who've installed a plugin/Obsidian
-- Flatpak downloads are not included in the platform share, this accounts for 751k installs and updates
 - All data was collected on 2022/09/11
+- The amount of downloads is usually much higher than the actual amount of users who've installed a plugin/Obsidian
+- Flatpak downloads are not included in the platform share, this accounts for 751k installs and updates in total, spread across all versions of Obsidian
 
 
 ## Platform Share
@@ -27,9 +27,9 @@ This section contains the %-share of users for every platform Obsidian is availa
 
 As of *version 0.15.9*, the share between platforms is divided as follows:
 **Windows** — 53.1%
- >  64-bit: 98.01%
->   arm:    1.19%
->   32-bit: 0.79
+>  64-bit: 98.01%
+>  arm:    1.19%
+>  32-bit: 0.79
 
 **MacOS** — 34.4%
 
@@ -64,7 +64,7 @@ This chart graphs the downloads of community plugins on the y-axis, and the rela
 
 ## Theme Downloads
 
-This chart graphs the downloads of community themes on the y-axis,  and the relative age of a theme on the x-axis (from oldest theme to newest theme)
+This chart graphs the downloads of community themes on the y-axis, and the relative age of a theme on the x-axis (from oldest theme to newest theme)
 
 - 3 Themes have more than 100.000 downloads (2.13%)
 - 42 Themes have more than 10.000 downloads (29.79%)

--- a/04 - Guides, Workflows, & Courses/Guides/Obsidian ecosystem statistics.md
+++ b/04 - Guides, Workflows, & Courses/Guides/Obsidian ecosystem statistics.md
@@ -27,19 +27,19 @@ This section contains the %-share of users for every platform Obsidian is availa
 
 As of *version 0.15.9*, the share between platforms is divided as follows:
 **Windows** — 53.1%
->  64-bit: 98.01%
->  arm:    1.19%
->  32-bit: 0.79
+>64-bit: 98.01%
+>arm:    1.19%
+>32-bit: 0.79
 
 **MacOS** — 34.4%
 
 **Linux** — 12.1%
->  AppImage: 53.92%
->  Snap: 22.98%
->  Debian: 17.55%
->  AppImage(arm): 2.81%
->  tar.gz: 2.55%
->  tar.gz(arm): 0.17%
+>AppImage: 53.92%
+>Snap: 22.98%
+>Debian: 17.55%
+>AppImage(arm): 2.81%
+>tar.gz: 2.55%
+>tar.gz(arm): 0.17%
 
 ![Releases stats](https://raw.githubusercontent.com/Fevol/obsidian-data-processing/master/images/releases-platform-share.png)
 


### PR DESCRIPTION
This PR adds a short note to `04 - Guides` examining the download data of Obsidian, and its themes and plugins. I've also added a short author page.

The note currently only contains some very basic stats and links to graphs hosted on https://github.com/Fevol/obsidian-data-processing. I'm not sure how this note will be used, so any feedback on what data to include would be appreciated!

I avoided making any direct observations/interpretations about the provided data in the note. It would maybe be nice if someone with more experience than me could provide some insight in what the data/graphs actually tell us about the Obsidian ecosystem.

Lastly, the graphs are currently not stored as attachments in 00.02, but instead fetched directly from my repository, as I may update them every once in a while. Is this an issue?

