### PR TITLE
Remove link to unmaintained plugin docs

### DIFF
--- a/04 - Guides, Workflows, & Courses/for Plugin Developers.md
+++ b/04 - Guides, Workflows, & Courses/for Plugin Developers.md
@@ -42,7 +42,6 @@ See also [[for Plugin Developers to Automate Tests|Resources and Guides for Plug
   - [Obsidian Sample Plugin](https://github.com/obsidianmd/obsidian-sample-plugin)
 - [obsidian-tools:](https://github.com/obsidian-tools/obsidian-tools) an unofficial collection of tools that helps devs build plugins for obsidian.
 - [obsidian-rust-plugin:](https://github.com/trashhalo/obsidian-rust-plugin) boilerplate needed to write obsidian plugins in rust!
-- [obsidian-api-docs:](https://github.com/HEmile/obsidian-api-docs/blob/main/docs/00_Home.md) community-provided documentation of the Obsidian API.
 - [API class diagram](https://i.joethei.space/obsidian-api.png): structure and relationships between API classes([svg version](https://i.joethei.space/obsidian-api.svg))
 - [obsidian-dev-tools:](https://github.com/KjellConnelly/obsidian-dev-tools)  allows for a modified console (useful for debugging on mobile), and viewing all Obsidian icons/strings.
 - [obsidian-daily-notes-interface:](https://github.com/liamcain/obsidian-daily-notes-interface) a collection of utility functions for working with dates and daily notes in Obsidian plugins.


### PR DESCRIPTION
## Edited
Removed link to unmaintained documentation about the plugin API

## Checklist
**All not applicable**
- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
- [x] (if applicable) attached images have descriptive file names
- [x] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
