### PR TITLE
changed link to website for my people note

### DIFF
--- a/01 - Community/People/franciskafieh.md
+++ b/01 - Community/People/franciskafieh.md
@@ -10,7 +10,7 @@ publish: true
 
 - GitHub: [franciskafieh](https://github.com/franciskafieh/) ^github
 <!-- - Discord: `@` ^discord-->
-- Website: <https://github.com/franciskafieh> ^website
+- Website: <https://franciskafieh.com/> ^website
 <!-- - [[Publish sites|Publish site]]: <https://> ^publish-->
 
 %% Feel free to add a bio below this comment %%


### PR DESCRIPTION
## Edited
title

## Checklist
- [ ] before creating a new note, I searched the vault
- [ ] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
