### PR TITLE
Fix O_O 2022 submission link

### DIFF
--- a/01 - Community/Events/Obsidian October 2022.md
+++ b/01 - Community/Events/Obsidian October 2022.md
@@ -44,7 +44,7 @@ Any OOer who finishes their project before the end of November 13, 2022 (extende
 
 We'll be publicly celebrating O_O contributions after the event wraps up, so you might be featured on the Obsidian website, via Twitter, or elsewhere!
 
-<iframe class="airtable-embed" src="https://airtable.com/shraMn6xDv4LwgRvA?backgroundColor=purple" frameborder="0" onmousewheel="" width="100%" height="533" style="background: transparent; border: 1px solid #ccc;"></iframe>
+<iframe class="airtable-embed" src="https://airtable.com/embed/shraMn6xDv4LwgRvA?backgroundColor=purple" frameborder="0" onmousewheel="" width="100%" height="533" style="background: transparent; border: 1px solid #ccc;"></iframe>
 
 Also, be sure to submit your plugin and theme to our official community [plugin store](https://github.com/obsidianmd/obsidian-releases/blob/master/community-plugins.json) or [theme store](https://github.com/obsidianmd/obsidian-releases/blob/master/community-css-themes.json) by submitting a Pull Request to the relevant list.
 


### PR DESCRIPTION
## Edited
Fixed Airtable embed link for O_O 2022

## Added
<!-- Add a brief description here-->

## Checklist
- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
