### PR TITLE
Roundup rss to md post generator with new and regenerated notes

### DIFF
--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -8,3 +8,5 @@ types-PyYAML
 types-requests
 monkeytype
 github3api
+markdownify
+feedparser

--- a/.github/scripts/update_roundup.py
+++ b/.github/scripts/update_roundup.py
@@ -58,9 +58,6 @@ def entries_not_synced(synced_list: list[ContentFile], sync_pending_list: list[F
     last_repo_item_name = synced_list[-2].name
     pending_file_names = [get_normalized_file_name(entry) for entry in sync_pending_list]
     return sync_pending_list[0:pending_file_names.index(last_repo_item_name)]
-    
-def branch_exists(repo: Repository) -> bool:
-    return True if ROUNDUP_BRANCH in [i.name for i in repo.get_branches()] else False
 
 def is_authenticated(g: Github) -> bool:
     try:
@@ -77,8 +74,6 @@ def main():
         return
     obsidian_hub_repo = g.get_repo(COMMUNITY_REPO)
     list_of_roundup_files = obsidian_hub_repo.get_contents(ROUNDUP_FOLDER_PATH)
-    if not branch_exists(obsidian_hub_repo):
-        pass
     # TODO: handle how multiple files are PRed
     for entry in entries_not_synced(list_of_roundup_files, d.entries):
         if is_roundup_post(entry):

--- a/.github/scripts/update_roundup.py
+++ b/.github/scripts/update_roundup.py
@@ -48,10 +48,13 @@ def generate_file_with_hub_yaml(entry: FeedParserDict) -> str:
     frontmatter: str = f"---\nlink: {entry.link}\nauthor: {entry.author}\npublished: {datetime_from_parsed_feed_datetime(entry)}\npublish: true\n---\n\n"
     return frontmatter+convert_feed_html(entry.content[0].value)
 
-def add_file_to_repo(entry: FeedParserDict, repo: Repository):
-    file_contents:str = generate_file_with_hub_yaml(entry)
+def save_file(entry: FeedParserDict, repo: Repository):
+    file_contents: str = generate_file_with_hub_yaml(entry)
     # TODO: Handle 422s for when the file exists already
-    repo.create_file(f"{ROUNDUP_FOLDER_PATH}/{get_normalized_file_name(entry)}", "feat: add new feed item", file_contents, branch=ROUNDUP_BRANCH)
+    file_name = f"{ROUNDUP_FOLDER_PATH}/{get_normalized_file_name(entry)}"
+    with open(file_name, 'w', encoding='utf8') as roundup_file:
+        roundup_file.write(file_contents)
+    repo.create_file(file_name, "feat: add new feed item", file_contents, branch=ROUNDUP_BRANCH)
 
 def entries_not_synced(synced_list: list[ContentFile], sync_pending_list: list[FeedParserDict]):
     # The last file is a folder note and not the last synced item
@@ -78,7 +81,7 @@ def main():
     for entry in entries_not_synced(list_of_roundup_files, d.entries):
         if is_roundup_post(entry):
             # print(get_normalized_file_name(entry))
-            add_file_to_repo(entry, obsidian_hub_repo)
+            save_file(entry, obsidian_hub_repo)
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/update_roundup.py
+++ b/.github/scripts/update_roundup.py
@@ -54,28 +54,8 @@ def save_file(entry: FeedParserDict):
     with open(file_name, 'w', encoding='utf8') as roundup_file:
         roundup_file.write(file_contents)
 
-def entries_not_synced(synced_list: list[ContentFile], sync_pending_list: list[FeedParserDict]):
-    # The last file is a folder note and not the last synced item
-    last_repo_item_name = synced_list[-2].name
-    pending_file_names = [get_normalized_file_name(entry) for entry in sync_pending_list]
-    return sync_pending_list[0:pending_file_names.index(last_repo_item_name)]
-
-def is_authenticated(g: Github) -> bool:
-    try:
-        return True if g.get_user().login == USER_NAME else False
-    except: 
-        # TODO: Check for 401 bad creds
-        return False
-
 def main():
     parsed_feed = parse(FEED_URL)
-    g = Github(API_KEY)
-    if not is_authenticated(g):
-        # TODO: Add log message for incorrect auth
-        return
-    obsidian_hub_repo = g.get_repo(COMMUNITY_REPO)
-    list_of_roundup_files = obsidian_hub_repo.get_contents(ROUNDUP_FOLDER_PATH)
-    # TODO: handle how multiple files are PRed
     for entry in parsed_feed.entries:
         if is_roundup_post(entry):
             # print(get_normalized_file_name(entry))

--- a/.github/scripts/update_roundup.py
+++ b/.github/scripts/update_roundup.py
@@ -1,0 +1,111 @@
+from datetime import datetime
+from feedparser import FeedParserDict, parse
+from github import Github
+from github.ContentFile import ContentFile
+from github.Repository import Repository
+from github.GithubException import UnknownObjectException
+from markdownify import markdownify as md
+
+FEED_URL = "https://www.obsidianroundup.org/blog/rss/"
+USER_NAME = "AB1908"
+# COMMUNITY_REPO = "obsidian-community/obsidian-hub"
+REPO_NAME = "obsidian-hub"
+COMMUNITY_REPO = f"{USER_NAME}/{REPO_NAME}"
+ROUNDUP_FOLDER_PATH = "01 - Community/Obsidian Roundup"
+ROUNDUP_BRANCH = "roundup"
+LABELS = "scripted update"
+
+def date_conversion(parsed_feed_datetime: FeedParserDict) -> datetime:
+    """Converts published_parsed attribute of a feed item into a pythonic datetime object"""
+    return datetime(year=parsed_feed_datetime.tm_year, month=parsed_feed_datetime.tm_mon, day=parsed_feed_datetime.tm_mday, hour=parsed_feed_datetime.tm_hour, minute=parsed_feed_datetime.tm_min, second=parsed_feed_datetime.tm_sec)
+
+def datetime_from_parsed_feed_datetime(entry: FeedParserDict) -> str:
+    """Returns ISO formatted string for feed published timestamp"""
+    pythonic_datetime = date_conversion(entry.published_parsed)
+    return pythonic_datetime.isoformat()
+
+def date_from_parsed_feed_datetime(entry: FeedParserDict) -> str:
+    """Returns ISO formatted string for feed published date"""
+    pythonic_datetime = date_conversion(entry.published_parsed)
+    return pythonic_datetime.strftime("%Y-%m-%d")
+
+def does_previous_exist_in_hub():
+    pass
+
+def is_roundup_post(entry: FeedParserDict) -> bool:
+    if entry.title.startswith('🌠'):
+        return True
+    else:
+        return False
+
+def convert_feed_html(html_content: str) -> str:
+    return md(html_content)
+
+def get_normalized_file_name(entry: FeedParserDict) -> str:
+    return f"{date_from_parsed_feed_datetime(entry)} {entry.title[2:]}.md"
+
+def generate_file_with_hub_yaml(entry: FeedParserDict) -> str:
+    frontmatter: str = f"---\nlink: {entry.link}\nauthor: {entry.author}\npublished: {datetime_from_parsed_feed_datetime(entry)}\npublish: true\n---\n\n"
+    return frontmatter+convert_feed_html(entry.content[0].value)
+
+def merge_main_into_branch(repo: Repository):
+    repo.merge(base=ROUNDUP_BRANCH, head="main")
+
+def add_file_to_repo(entry: FeedParserDict, repo: Repository):
+    file_contents:str = generate_file_with_hub_yaml(entry)
+    # TODO: Handle 422s for when the file exists already
+    repo.create_file(f"{ROUNDUP_FOLDER_PATH}/{get_normalized_file_name(entry)}", "feat: add new feed item", file_contents, branch=ROUNDUP_BRANCH)
+
+def open_pr_against_main(entry: FeedParserDict, repo: Repository):
+    title = f"Add roundup post for {date_from_parsed_feed_datetime(entry)}"
+    body = f"Title: {entry.title}\nBody: {entry.link}"
+    pr = repo.create_pull(title=title, body=body, base=repo.default_branch, head=ROUNDUP_BRANCH, maintainer_can_modify=True)
+    pr.add_to_labels(LABELS)
+
+def entries_not_synced(synced_list: list[ContentFile], sync_pending_list: list[FeedParserDict]):
+    # The last file is a folder note and not the last synced item
+    last_repo_item_name = synced_list[-2].name
+    pending_file_names = [get_normalized_file_name(entry) for entry in sync_pending_list]
+    return sync_pending_list[0:pending_file_names.index(last_repo_item_name)]
+    
+def branch_exists(repo: Repository) -> bool:
+    return True if ROUNDUP_BRANCH in [i.name for i in repo.get_branches()] else False
+
+def create_branch(repo: Repository) -> None:
+    try:
+        main_head_sha = repo.get_branch(repo.default_branch).commit.sha
+        repo.create_git_ref(f"refs/heads/{ROUNDUP_BRANCH}", main_head_sha)
+        return
+    except UnknownObjectException:
+        # https://stackoverflow.com/a/67560638/13285428
+        # I had no idea 404s were because of scopes
+        print(UnknownObjectException)
+        print("Check your scopes")
+    
+def is_authenticated(g: Github) -> bool:
+    try:
+        return True if g.get_user().login == USER_NAME else False
+    except: 
+        # TODO: Check for 401 bad creds
+        return False
+
+def main():
+    d = parse(FEED_URL)
+    g = Github(API_KEY)
+    if not is_authenticated(g):
+        # TODO: Add log message for incorrect auth
+        return
+    obsidian_hub_repo = g.get_repo(COMMUNITY_REPO)
+    list_of_roundup_files = obsidian_hub_repo.get_contents(ROUNDUP_FOLDER_PATH)
+    if not branch_exists(obsidian_hub_repo):
+        create_branch(obsidian_hub_repo)
+    merge_main_into_branch(obsidian_hub_repo)
+    # TODO: handle how multiple files are PRed
+    for entry in entries_not_synced(list_of_roundup_files, d.entries):
+        if is_roundup_post(entry):
+            # print(get_normalized_file_name(entry))
+            add_file_to_repo(entry, obsidian_hub_repo)
+    open_pr_against_main(entry, obsidian_hub_repo)
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/update_roundup.py
+++ b/.github/scripts/update_roundup.py
@@ -36,7 +36,7 @@ def get_normalized_file_name(entry: FeedParserDict) -> str:
 
 def generate_file_with_hub_yaml(entry: FeedParserDict) -> str:
     frontmatter: str = f"---\nlink: {entry.link}\nauthor: {entry.author}\npublished: {datetime_from_parsed_feed_datetime(entry)}\npublish: true\n---\n\n"
-    return frontmatter+f"# {get_normalized_file_name(entry)}\n{entry.summary}\n\n"+convert_feed_html(entry.content[0].value)
+    return frontmatter+f"# {date_from_parsed_feed_datetime(entry)}: {entry.title[2:]}\n{entry.summary}\n\n"+convert_feed_html(entry.content[0].value)
 
 def save_file(entry: FeedParserDict):
     file_contents: str = generate_file_with_hub_yaml(entry)

--- a/.github/scripts/update_roundup.py
+++ b/.github/scripts/update_roundup.py
@@ -48,9 +48,6 @@ def generate_file_with_hub_yaml(entry: FeedParserDict) -> str:
     frontmatter: str = f"---\nlink: {entry.link}\nauthor: {entry.author}\npublished: {datetime_from_parsed_feed_datetime(entry)}\npublish: true\n---\n\n"
     return frontmatter+convert_feed_html(entry.content[0].value)
 
-def merge_main_into_branch(repo: Repository):
-    repo.merge(base=ROUNDUP_BRANCH, head="main")
-
 def add_file_to_repo(entry: FeedParserDict, repo: Repository):
     file_contents:str = generate_file_with_hub_yaml(entry)
     # TODO: Handle 422s for when the file exists already
@@ -93,7 +90,6 @@ def main():
     list_of_roundup_files = obsidian_hub_repo.get_contents(ROUNDUP_FOLDER_PATH)
     if not branch_exists(obsidian_hub_repo):
         create_branch(obsidian_hub_repo)
-    merge_main_into_branch(obsidian_hub_repo)
     # TODO: handle how multiple files are PRed
     for entry in entries_not_synced(list_of_roundup_files, d.entries):
         if is_roundup_post(entry):

--- a/.github/scripts/update_roundup.py
+++ b/.github/scripts/update_roundup.py
@@ -3,7 +3,7 @@ from feedparser import FeedParserDict, parse
 from markdownify import markdownify as md
 
 FEED_URL = "https://www.obsidianroundup.org/blog/rss/"
-ROUNDUP_FOLDER_PATH = "01 - Community/Obsidian Roundup"
+ROUNDUP_FOLDER_PATH = "../../01 - Community/Obsidian Roundup"
 
 def date_conversion(parsed_feed_datetime: FeedParserDict) -> datetime:
     """Converts published_parsed attribute of a feed item into a pythonic datetime object"""

--- a/.github/scripts/update_roundup.py
+++ b/.github/scripts/update_roundup.py
@@ -29,7 +29,7 @@ def is_roundup_post(entry: FeedParserDict) -> bool:
         return False
 
 def convert_feed_html(html_content: str) -> str:
-    return md(html_content)
+    return str(md(html_content, heading_style='ATX', strong_em_symbol='_'))
 
 def get_normalized_file_name(entry: FeedParserDict) -> str:
     return f"{date_from_parsed_feed_datetime(entry)} {entry.title[2:]}.md"

--- a/.github/scripts/update_roundup.py
+++ b/.github/scripts/update_roundup.py
@@ -1,9 +1,5 @@
 from datetime import datetime
 from feedparser import FeedParserDict, parse
-from github import Github
-from github.ContentFile import ContentFile
-from github.Repository import Repository
-from github.GithubException import UnknownObjectException
 from markdownify import markdownify as md
 
 FEED_URL = "https://www.obsidianroundup.org/blog/rss/"

--- a/.github/scripts/update_roundup.py
+++ b/.github/scripts/update_roundup.py
@@ -62,17 +62,6 @@ def entries_not_synced(synced_list: list[ContentFile], sync_pending_list: list[F
 def branch_exists(repo: Repository) -> bool:
     return True if ROUNDUP_BRANCH in [i.name for i in repo.get_branches()] else False
 
-def create_branch(repo: Repository) -> None:
-    try:
-        main_head_sha = repo.get_branch(repo.default_branch).commit.sha
-        repo.create_git_ref(f"refs/heads/{ROUNDUP_BRANCH}", main_head_sha)
-        return
-    except UnknownObjectException:
-        # https://stackoverflow.com/a/67560638/13285428
-        # I had no idea 404s were because of scopes
-        print(UnknownObjectException)
-        print("Check your scopes")
-    
 def is_authenticated(g: Github) -> bool:
     try:
         return True if g.get_user().login == USER_NAME else False
@@ -89,7 +78,7 @@ def main():
     obsidian_hub_repo = g.get_repo(COMMUNITY_REPO)
     list_of_roundup_files = obsidian_hub_repo.get_contents(ROUNDUP_FOLDER_PATH)
     if not branch_exists(obsidian_hub_repo):
-        create_branch(obsidian_hub_repo)
+        pass
     # TODO: handle how multiple files are PRed
     for entry in entries_not_synced(list_of_roundup_files, d.entries):
         if is_roundup_post(entry):

--- a/.github/scripts/update_roundup.py
+++ b/.github/scripts/update_roundup.py
@@ -68,7 +68,7 @@ def is_authenticated(g: Github) -> bool:
         return False
 
 def main():
-    d = parse(FEED_URL)
+    parsed_feed = parse(FEED_URL)
     g = Github(API_KEY)
     if not is_authenticated(g):
         # TODO: Add log message for incorrect auth
@@ -76,7 +76,7 @@ def main():
     obsidian_hub_repo = g.get_repo(COMMUNITY_REPO)
     list_of_roundup_files = obsidian_hub_repo.get_contents(ROUNDUP_FOLDER_PATH)
     # TODO: handle how multiple files are PRed
-    for entry in entries_not_synced(list_of_roundup_files, d.entries):
+    for entry in parsed_feed.entries:
         if is_roundup_post(entry):
             # print(get_normalized_file_name(entry))
             save_file(entry)

--- a/.github/scripts/update_roundup.py
+++ b/.github/scripts/update_roundup.py
@@ -36,7 +36,7 @@ def get_normalized_file_name(entry: FeedParserDict) -> str:
 
 def generate_file_with_hub_yaml(entry: FeedParserDict) -> str:
     frontmatter: str = f"---\nlink: {entry.link}\nauthor: {entry.author}\npublished: {datetime_from_parsed_feed_datetime(entry)}\npublish: true\n---\n\n"
-    return frontmatter+f"# {get_normalized_file_name(entry)}\n\n{entry.summary}\n\n"+convert_feed_html(entry.content[0].value)
+    return frontmatter+f"# {get_normalized_file_name(entry)}\n{entry.summary}\n\n"+convert_feed_html(entry.content[0].value)
 
 def save_file(entry: FeedParserDict):
     file_contents: str = generate_file_with_hub_yaml(entry)

--- a/.github/scripts/update_roundup.py
+++ b/.github/scripts/update_roundup.py
@@ -19,9 +19,6 @@ def date_from_parsed_feed_datetime(entry: FeedParserDict) -> str:
     pythonic_datetime = date_conversion(entry.published_parsed)
     return pythonic_datetime.strftime("%Y-%m-%d")
 
-def does_previous_exist_in_hub():
-    pass
-
 def is_roundup_post(entry: FeedParserDict) -> bool:
     if entry.title.startswith('🌠'):
         return True
@@ -38,13 +35,13 @@ def generate_file_with_hub_yaml(entry: FeedParserDict) -> str:
     frontmatter: str = f"---\nlink: {entry.link}\nauthor: {entry.author}\npublished: {datetime_from_parsed_feed_datetime(entry)}\npublish: true\n---\n\n"
     return frontmatter+f"# {date_from_parsed_feed_datetime(entry)}: {entry.title[2:]}\n{entry.summary}\n\n"+convert_feed_html(entry.content[0].value)
 
-def save_file(entry: FeedParserDict):
+def save_file(entry: FeedParserDict) -> None:
     file_contents: str = generate_file_with_hub_yaml(entry)
     file_name = f"{ROUNDUP_FOLDER_PATH}/{get_normalized_file_name(entry)}"
     with open(file_name, 'w', encoding='utf8') as roundup_file:
         roundup_file.write(file_contents)
 
-def main():
+def main() -> None:
     parsed_feed = parse(FEED_URL)
     for entry in parsed_feed.entries:
         if is_roundup_post(entry):

--- a/.github/scripts/update_roundup.py
+++ b/.github/scripts/update_roundup.py
@@ -56,12 +56,6 @@ def add_file_to_repo(entry: FeedParserDict, repo: Repository):
     # TODO: Handle 422s for when the file exists already
     repo.create_file(f"{ROUNDUP_FOLDER_PATH}/{get_normalized_file_name(entry)}", "feat: add new feed item", file_contents, branch=ROUNDUP_BRANCH)
 
-def open_pr_against_main(entry: FeedParserDict, repo: Repository):
-    title = f"Add roundup post for {date_from_parsed_feed_datetime(entry)}"
-    body = f"Title: {entry.title}\nBody: {entry.link}"
-    pr = repo.create_pull(title=title, body=body, base=repo.default_branch, head=ROUNDUP_BRANCH, maintainer_can_modify=True)
-    pr.add_to_labels(LABELS)
-
 def entries_not_synced(synced_list: list[ContentFile], sync_pending_list: list[FeedParserDict]):
     # The last file is a folder note and not the last synced item
     last_repo_item_name = synced_list[-2].name
@@ -105,7 +99,6 @@ def main():
         if is_roundup_post(entry):
             # print(get_normalized_file_name(entry))
             add_file_to_repo(entry, obsidian_hub_repo)
-    open_pr_against_main(entry, obsidian_hub_repo)
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/update_roundup.py
+++ b/.github/scripts/update_roundup.py
@@ -48,13 +48,11 @@ def generate_file_with_hub_yaml(entry: FeedParserDict) -> str:
     frontmatter: str = f"---\nlink: {entry.link}\nauthor: {entry.author}\npublished: {datetime_from_parsed_feed_datetime(entry)}\npublish: true\n---\n\n"
     return frontmatter+convert_feed_html(entry.content[0].value)
 
-def save_file(entry: FeedParserDict, repo: Repository):
+def save_file(entry: FeedParserDict):
     file_contents: str = generate_file_with_hub_yaml(entry)
-    # TODO: Handle 422s for when the file exists already
     file_name = f"{ROUNDUP_FOLDER_PATH}/{get_normalized_file_name(entry)}"
     with open(file_name, 'w', encoding='utf8') as roundup_file:
         roundup_file.write(file_contents)
-    repo.create_file(file_name, "feat: add new feed item", file_contents, branch=ROUNDUP_BRANCH)
 
 def entries_not_synced(synced_list: list[ContentFile], sync_pending_list: list[FeedParserDict]):
     # The last file is a folder note and not the last synced item
@@ -81,7 +79,7 @@ def main():
     for entry in entries_not_synced(list_of_roundup_files, d.entries):
         if is_roundup_post(entry):
             # print(get_normalized_file_name(entry))
-            save_file(entry, obsidian_hub_repo)
+            save_file(entry)
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/update_roundup.py
+++ b/.github/scripts/update_roundup.py
@@ -3,13 +3,7 @@ from feedparser import FeedParserDict, parse
 from markdownify import markdownify as md
 
 FEED_URL = "https://www.obsidianroundup.org/blog/rss/"
-USER_NAME = "AB1908"
-# COMMUNITY_REPO = "obsidian-community/obsidian-hub"
-REPO_NAME = "obsidian-hub"
-COMMUNITY_REPO = f"{USER_NAME}/{REPO_NAME}"
 ROUNDUP_FOLDER_PATH = "01 - Community/Obsidian Roundup"
-ROUNDUP_BRANCH = "roundup"
-LABELS = "scripted update"
 
 def date_conversion(parsed_feed_datetime: FeedParserDict) -> datetime:
     """Converts published_parsed attribute of a feed item into a pythonic datetime object"""

--- a/.github/scripts/update_roundup.py
+++ b/.github/scripts/update_roundup.py
@@ -36,7 +36,7 @@ def get_normalized_file_name(entry: FeedParserDict) -> str:
 
 def generate_file_with_hub_yaml(entry: FeedParserDict) -> str:
     frontmatter: str = f"---\nlink: {entry.link}\nauthor: {entry.author}\npublished: {datetime_from_parsed_feed_datetime(entry)}\npublish: true\n---\n\n"
-    return frontmatter+convert_feed_html(entry.content[0].value)
+    return frontmatter+f"# {get_normalized_file_name(entry)}\n\n{entry.summary}\n\n"+convert_feed_html(entry.content[0].value)
 
 def save_file(entry: FeedParserDict):
     file_contents: str = generate_file_with_hub_yaml(entry)

--- a/01 - Community/Obsidian Roundup/2022-08-06 Quick Share & a new Minimalist Theme.md
+++ b/01 - Community/Obsidian Roundup/2022-08-06 Quick Share & a new Minimalist Theme.md
@@ -1,0 +1,61 @@
+---
+link: https://www.obsidianroundup.org/2022-08-06/
+author: Eleanor Konik
+published: 2022-08-06T12:30:42
+publish: true
+---
+
+# 2022-08-06: Quick Share & a new Minimalist Theme
+Group snippets for one-click activation, compare tags and folders, & improve your inline metadata.
+
+## Housekeeping
+
+Fair warning, I caught a stomach bug from my son and it was too late to arrange coverage for the Roundup by the time I realized how badly it was going to interfere with my productivity yesterday. I'll loop back around later and include all the stuff from this week I didn't get a chance to add in 💚
+
+Also, as of last week, the Roundup ships at 8:30 EST instead of 7:30 EST. It's just easier for me to remember, since that's the time my [obscure history newsletter](https://newsletter.eleanorkonik.com/) ships and I kept mixing them up. 
+
+## Plugin News
+
+### New in Community Plugins
+
+_These plugins went through code review and are now available in Obsidian's plugin list._ _For the full list, check out the [plugin stats page](https://obsidian-plugin-stats.vercel.app/new)._
+
+* [Inline Scripts](https://github.com/jon-heard/obsidian-inline-scripts) by `@jon-heard`  lets users type text shortcuts which are then replaced with JavaScript generated text.
+* [PodNotes](https://github.com/chhoumann/podnotes) by `@chhoumann`  helps you write notes on podcasts.
+* [Open Related Url](https://github.com/dpickett/open-related-url) by `@dpickett`  opens URLs found in a note's YAML frontmatter
+* [Hard Breaks](https://github.com/bkis/obsidian-hard-breaks) by `@bkis`  turns soft line breaks in Markdown into hard line breaks.
+* [Focus and Highlight](https://github.com/nagi1999a/obsidian-focus-plugin) by `@nagi1999a`  is a plugin that will highlight and focus on the currently selected heading.
+* [Path Finder](https://github.com/jerrywcy/obsidian-path-finder) by `@jerrywcy`  is a plugin that can find the shortest path between two notes, similar to the old Journey plugin.
+* [Sidebar Toggler](https://github.com/chrisgrieser/obsidian-sidebar-toggler) by `@chrisgrieser`  offers finer control of the Obsidian sidebars for those who use external window managers.
+
+### Pending (as of Friday morning)
+
+_Note: Not all new plugins are available in the community list yet, as they need to go through code review first. You can manually install plugins that aren't in the community list yet by using the [Beta Reviewer's Auto-update Tool](https://github.com/TfTHacker/obsidian42-brat). Note, though, that this is not as safe as waiting for them to go through code review._
+
+* [Symbols Prettifier](https://github.com/FlorianWoelki/obsidian-symbols-prettifier) by `@FlorianWoelki`  allows users to prettify symbols you commonly type, like arrows.
+* [Obsidian Google Calendar](https://github.com/YukiGasai/obsidian-google-calendar) by `@YukiGasai`  lets users interact with your Google Calendar from Inside Obsidian; I suspect it's a more lightweight version of Full Calendar.
+* [Group Snippets](https://github.com/Mara-Li/obsidian-group-snippets) by `@Mara-Li`  lets users create a folder of snippets so you can activate them all in one click.
+* [Heading Shifter](https://github.com/k4a-dev/obsidian-heading-shifter) by `@k4a-dev`  lets users easily shift and change markdown headings.
+* [Account Linker](https://github.com/qwegat/Obsidian-Account-Linker) by `@qwegat` is a plugin for visual denoting external service accounts (like social media) in YAML front matter.
+* [Open File by Magic Date](https://github.com/SimplGy/obsidian-open-file-by-magic-date) by `@SimplGy`  lets users define a `Moment.js` date pattern that specifies the file that is most important to you (eg: your daily/weekly/monthly note). It'll also create the file if it doesn't exist already
+* [No dupe leaves](https://github.com/scambier/obsidian-no-dupe-leaves) by `@scambier`  will help make sure you don't reopen notes that are already open
+* [Better Inline Fields](https://github.com/dsarman/better-inline-fields) by `@dsarman`  enhances Dataview style inline fields, mostly by adding toggles for things like true/false and adding improved autocomplete.
+
+### Betas
+
+_Note: these plugins have not yet been submitted for code review, and are being made available primarily for testing purposes._
+
+* There's a new plugin for quickly sharing individual notes, with a (free) companion web app over at <https://noteshare.space/> although the codebase is completely open-source if you'd rather self-host. Here's the [github repository](https://github.com/mcndt/obsidian-note-sharing) if you'd like to take it for a spin.
+
+## Feature Requests
+
+* What if we could use YAML to [override the filesystem creation time](https://forum.obsidian.md/t/native-yaml-override-for-filesystem-creation-time/41240/2)?
+* Or [visually distinguish open notes on the graph view](https://forum.obsidian.md/t/render-open-notes-as-a-ring-in-graph-view/41321)?
+
+## Appearance
+
+* [Mado Miniflow](https://github.com/hydescarf/Obsidian-Theme-Mado-Miniflow) by `@hydescarf`  is a really beautiful minimalist theme that makes Obsidian feel like some of the web-based competitors people always rave about, particularly Doctave.
+
+## Discussions
+
+* I found this discussion of [why it can be helpful to block tags from showing up on the graph view](https://discord.com/channels/686053708261228577/710585052769157141/1005134287533789276) on Discord useful, as well as the accompanying discussion of the differences between tags and folders.

--- a/01 - Community/Obsidian Roundup/2022-08-13 Dataview to Mermaid & PDF conversions.md
+++ b/01 - Community/Obsidian Roundup/2022-08-13 Dataview to Mermaid & PDF conversions.md
@@ -1,7 +1,7 @@
 ---
 link: https://www.obsidianroundup.org/2022-08-13/
 author: Anon Person
-published: 2022-08-13T13:30:00
+published: 2022-08-13T13:13:55
 publish: true
 ---
 
@@ -10,74 +10,68 @@ Sync highlights and annotations from Raindrop & execute codeblocks interactively
 
 ## Obsidian Updates
 
-*   Obsidian Mobile v1.3.1 is available for testing [on Android](https://discord.com/channels/686053708261228577/817515900349448202/1006609288988463144) and iOS. It includes fixes up till v0.15.9 of Obsidian Desktop.
+* Obsidian Mobile v1.3.1 is available for testing [on Android](https://discord.com/channels/686053708261228577/817515900349448202/1006609288988463144) and iOS. It includes fixes up till v0.15.9 of Obsidian Desktop.
 
 ## Plugin News
 
-*   Marcus Olsson [teased a preview](https://discord.com/channels/686053708261228577/840286264964022302/1005826839337521272) of a plugin that does calendar, kanban, and table views together. It currently uses its own data storage format but looks very exciting!
+* Marcus Olsson [teased a preview](https://discord.com/channels/686053708261228577/840286264964022302/1005826839337521272) of a plugin that does calendar, kanban, and table views together. It currently uses its own data storage format but looks very exciting!
 
 ### Updates
 
 _If you want a more comprehensive list of what plugins updated this week, check out [this plugin updates index](https://obsidian-plugin-stats.vercel.app/updates) by Ganessh Kumar._
 
-*   [Obsidian Tasks](https://github.com/obsidian-tasks-group/obsidian-tasks) now supports tasks in blockquotes and Obsidian callouts. It also has a new bug reporting form.
-*   [Obsidian Database Folders](https://github.com/RafaelGB/obsidian-db-folder)' latest release fixes drag and drop and comes with a host of other improvements.
-*   [Initiative Tracker](https://github.com/valentine195/obsidian-initiative-tracker) now has support for combat logs.
+* [Obsidian Tasks](https://github.com/obsidian-tasks-group/obsidian-tasks) now supports tasks in blockquotes and Obsidian callouts. It also has a new bug reporting form.
+* [Obsidian Database Folders](https://github.com/RafaelGB/obsidian-db-folder)' latest release fixes drag and drop and comes with a host of other improvements.
+* [Initiative Tracker](https://github.com/valentine195/obsidian-initiative-tracker) now has support for combat logs.
 
 ### Pending
 
 _Note: Not all new plugins are available in the community list yet, as they need to go through code review first. You can manually install plugins that aren't in the community list yet by using the [Beta Reviewer's Auto-update Tool (BRAT)](https://github.com/TfTHacker/obsidian43-brat). Note, though, that this is not as safe as waiting for them to go through code review._
 
-*   [Rpg Manager](https://github.com/carlonicora/obsidian-rpg-manager) by `@carlonicora` helps manage your Tabletop Role Playing Game campaigns for Obsidian.
-*   [Greek](https://github.com/JeremyFunk/ObsidianGreek) by `@JeremyFunk` helps you easily add Greek letters without needing external programs or changing keyboard settings.
-*   [Party](https://github.com/shap-po/obsidian-party) by `@shap-po` gives you nice confetti and sparkle animations in Obsidian.
-*   [Code Emitter](https://github.com/mokeyish/obsidian-code-emitter) by `@mokeyish` lets you execute codeblocks interactively like in Jupyter notebooks. Supports Rust, Kotlin, Python, JavaScript, Typescript, etc. We are truly not far away from Emacs it seems.
-*   [Note Linker](https://github.com/AlexW00/obsidian-note-linker) by `@AlexW00` gives you a nice popup to interactively link your notes.
-*   [Obsidian Keyboard Shortcuts](https://github.com/aciq/obsidian-keyboard-shortcuts) by `@aciq` is a plugin that covers the author's most used shortcuts. There seems to be some overlap with the other plugins but there are a few unique ones as well.
-*   [Obsidian-PDF](https://github.com/BluBloos/Obsidian-PDF) by `@BluBloos` enables you to work with PDF files more effectively. It autogenerates a companion MD file which can store extra metadata for you and is updated automatically.
-*   [Raindrop Highlights](https://github.com/kaiiiz/obsidian-raindrop-highlights-plugin) by `@kaiiiz` tackles the use case of syncing highlights and annotations from Raindrop.
-*   [MathLinks](https://github.com/zhaoshenzhai/obsidian-mathlinks) by `@zhaoshenzhai` lets you display and manage MathJax in your links.
+* [Rpg Manager](https://github.com/carlonicora/obsidian-rpg-manager) by `@carlonicora` helps manage your Tabletop Role Playing Game campaigns for Obsidian.
+* [Greek](https://github.com/JeremyFunk/ObsidianGreek) by `@JeremyFunk` helps you easily add Greek letters without needing external programs or changing keyboard settings.
+* [Party](https://github.com/shap-po/obsidian-party) by `@shap-po` gives you nice confetti and sparkle animations in Obsidian.
+* [Code Emitter](https://github.com/mokeyish/obsidian-code-emitter) by `@mokeyish` lets you execute codeblocks interactively like in Jupyter notebooks. Supports Rust, Kotlin, Python, JavaScript, Typescript, etc. We are truly not far away from Emacs it seems.
+* [Note Linker](https://github.com/AlexW00/obsidian-note-linker) by `@AlexW00` gives you a nice popup to interactively link your notes.
+* [Obsidian Keyboard Shortcuts](https://github.com/aciq/obsidian-keyboard-shortcuts) by `@aciq` is a plugin that covers the author's most used shortcuts. There seems to be some overlap with the other plugins but there are a few unique ones as well.
+* [Obsidian-PDF](https://github.com/BluBloos/Obsidian-PDF) by `@BluBloos` enables you to work with PDF files more effectively. It autogenerates a companion MD file which can store extra metadata for you and is updated automatically.
+* [Raindrop Highlights](https://github.com/kaiiiz/obsidian-raindrop-highlights-plugin) by `@kaiiiz` tackles the use case of syncing highlights and annotations from Raindrop.
+* [MathLinks](https://github.com/zhaoshenzhai/obsidian-mathlinks) by `@zhaoshenzhai` lets you display and manage MathJax in your links.
 
 ### Betas
 
-*   [Obsidian Translate](https://github.com/Fevol/obsidian-translate/), which is still available on BRAT, received a comprehensive update and now supports 10 translation services in addtion to a few UI improvements.
-*   [Obsidian List Modified](https://github.com/franciskafieh/obsidian-list-modified)'s [2.0 version](https://github.com/franciskafieh/obsidian-list-modified/releases/tag/2.0) is in open beta. `@franciskafieh` is [looking for people](https://discord.com/channels/686053708261228577/855181471643861002/1007126058929238086) to help test performance and find bugs.
+* [Obsidian Translate](https://github.com/Fevol/obsidian-translate/), which is still available on BRAT, received a comprehensive update and now supports 10 translation services in addtion to a few UI improvements.
+* [Obsidian List Modified](https://github.com/franciskafieh/obsidian-list-modified)'s [2.0 version](https://github.com/franciskafieh/obsidian-list-modified/releases/tag/2.0) is in open beta. `@franciskafieh` is [looking for people](https://discord.com/channels/686053708261228577/855181471643861002/1007126058929238086) to help test performance and find bugs.
 
 ## Feature Requests
 
-*   There was [a request](https://forum.obsidian.md/t/fully-visual-editor-mode-wysiwyg/41517/5) for Obsidian to have a fully WSIWYG mode akin to Word or Google Docs.
-*   A user [requested](https://forum.obsidian.md/t/hovering-over-the-heading-of-a-note-and-a-pop-up-appears-that-shows-the-notes-title/41670) for showing the full note title on hovering over the title bar, in case the title has been truncated.
-*   There was [a request](https://forum.obsidian.md/t/embed-pdf-files-with-range-options/41677) for being able to embed page ranges from a PDF.
-*   A user is [looking for a way](https://forum.obsidian.md/t/obsidian-notes-kindle-workflow/41748) to push Obsidian notes to the Kindle for easier reading.
-*   Another user on the forum is [looking for a plugin](https://forum.obsidian.md/t/linked-pane-based-on-metadata/41741) to make a pinned sidebar display a workflow tied to the currently active note based on its metadata. The current solution involves manually changing and pinning the sidebar, which is quite tedious.
+* There was [a request](https://forum.obsidian.md/t/fully-visual-editor-mode-wysiwyg/41517/5) for Obsidian to have a fully WSIWYG mode akin to Word or Google Docs.
+* A user [requested](https://forum.obsidian.md/t/hovering-over-the-heading-of-a-note-and-a-pop-up-appears-that-shows-the-notes-title/41670) for showing the full note title on hovering over the title bar, in case the title has been truncated.
+* There was [a request](https://forum.obsidian.md/t/embed-pdf-files-with-range-options/41677) for being able to embed page ranges from a PDF.
+* A user is [looking for a way](https://forum.obsidian.md/t/obsidian-notes-kindle-workflow/41748) to push Obsidian notes to the Kindle for easier reading.
+* Another user on the forum is [looking for a plugin](https://forum.obsidian.md/t/linked-pane-based-on-metadata/41741) to make a pinned sidebar display a workflow tied to the currently active note based on its metadata. The current solution involves manually changing and pinning the sidebar, which is quite tedious.
 
 ## Appearance
 
-*   `@jdanielmourao`'s Sanctum theme got [a round of fixes and tweaks](https://discord.com/channels/686053708261228577/855181471643861002/1006264635298681012) for Obsidian v0.15.9.
-*   `@SlRvb` also [released](https://discord.com/channels/686053708261228577/855181471643861002/1007438472652538018) several improvements for the ITS theme, including a neat tweak to display Dataview lists as columns.
-*   [Fusion](https://github.com/zamsyt/obsidian-fusion) by `@zamsyt` is a new theme that aims to remove background color variations for the default theme.
-*   [Here's](https://discord.com/channels/686053708261228577/702656734631821413/1003776341843394622) a CSS snippet that fixes the misaligned calendar dots.
-*   [Here's](https://discord.com/channels/686053708261228577/702656734631821413/1007048772754350080) another CSS snippet for smooth header transforms in Live Preview.
+* `@jdanielmourao`'s Sanctum theme got [a round of fixes and tweaks](https://discord.com/channels/686053708261228577/855181471643861002/1006264635298681012) for Obsidian v0.15.9.
+* `@SlRvb` also [released](https://discord.com/channels/686053708261228577/855181471643861002/1007438472652538018) several improvements for the ITS theme, including a neat tweak to display Dataview lists as columns.
+* [Fusion](https://github.com/zamsyt/obsidian-fusion) by `@zamsyt` is a new theme that aims to remove background color variations for the default theme.
+* [Here's](https://discord.com/channels/686053708261228577/702656734631821413/1003776341843394622) a CSS snippet that fixes the misaligned calendar dots.
+* [Here's](https://discord.com/channels/686053708261228577/702656734631821413/1007048772754350080) another CSS snippet for smooth header transforms in Live Preview.
 
 ## Ancillary Code
 
-*   A Discord user [made a Dataview to Mermaid converter](https://discord.com/channels/686053708261228577/840286238928797736/1005354556135321650) where you can dynamically type in a query and it gets rendered as a Mermaid chart/diagram.
+* A Discord user [made a Dataview to Mermaid converter](https://discord.com/channels/686053708261228577/840286238928797736/1005354556135321650) where you can dynamically type in a query and it gets rendered as a Mermaid chart/diagram.
 
 ## Guides
 
-*   An AI researcher [shared their note-taking workflow](https://discord.com/channels/686053708261228577/722584061087842365/1003653163334778881), with the added note that they have ADHD. They mention how they wanted a very smooth and optimized flow for getting work done.
-*   A Reddit user [posted a guide](https://old.reddit.com/r/ObsidianMD/comments/whjm1w/guide_using_git_to_sync_your_obsidian_vault_on/) on how to set up Git sync on Android.
+* An AI researcher [shared their note-taking workflow](https://discord.com/channels/686053708261228577/722584061087842365/1003653163334778881), with the added note that they have ADHD. They mention how they wanted a very smooth and optimized flow for getting work done.
+* A Reddit user [posted a guide](https://old.reddit.com/r/ObsidianMD/comments/whjm1w/guide_using_git_to_sync_your_obsidian_vault_on/) on how to set up Git sync on Android.
 
 ## Discussions
 
-*   There was [another discussion on Reddit](https://old.reddit.com/r/ObsidianMD/comments/wk3t9n/is_it_a_risk_to_rely_too_much_on_plugins/) on the longevity of Obsidian and using too many plugins.
+* There was [another discussion on Reddit](https://old.reddit.com/r/ObsidianMD/comments/wk3t9n/is_it_a_risk_to_rely_too_much_on_plugins/) on the longevity of Obsidian and using too many plugins.
 
 ## Housekeeping
 
-*   I'm about to head to the airport; expect me back on Discord and Twitter tomorrow. Georgia was fun but I miss everyone. Thanks `@ab1908` for pinch hitting with the writing of this :)
-
-%% Hub footer: Please don't edit anything below this line %%
-
-# This note in GitHub
-
-<span class="git-footer">[Edit In GitHub](https://github.dev/obsidian-community/obsidian-hub/blob/main/01%20-%20Community/Obsidian%20Roundup/2022-08-13%20Dataview%20to%20Mermaid%20%26%20PDF%20conversions.md "git-hub-edit-note") | [Copy this note](https://raw.githubusercontent.com/obsidian-community/obsidian-hub/main/01%20-%20Community/Obsidian%20Roundup/2022-08-13%20Dataview%20to%20Mermaid%20%26%20PDF%20conversions.md "git-hub-copy-note") | [Download this vault](https://github.com/obsidian-community/obsidian-hub/archive/refs/heads/main.zip "git-hub-download-vault") </span>
+* I'm about to head to the airport; expect me back on Discord and Twitter tomorrow. Georgia was fun but I miss everyone. Thanks `@ab1908` for pinch hitting with the writing of this :)

--- a/01 - Community/Obsidian Roundup/2022-08-20 Mobile Git Backups & a Hotkey Keyboard Map.md
+++ b/01 - Community/Obsidian Roundup/2022-08-20 Mobile Git Backups & a Hotkey Keyboard Map.md
@@ -1,0 +1,104 @@
+---
+link: https://www.obsidianroundup.org/2022-08-20/
+author: Eleanor Konik
+published: 2022-08-20T12:30:46
+publish: true
+---
+
+# 2022-08-20: Mobile Git Backups & a Hotkey Keyboard Map
+A new tool for diffing PDFs, a new method for managing RPG campaigns, and guides for using Obsidian with Devonthink or Dendron.
+
+## Housekeeping
+
+* I'll be in Chicago for Worldcon the first couple of days of September. Here's my [official schedule](https://newsletter.eleanorkonik.com/chicon-2022-schedule/) if you're planning to attend or happen to live in the area and want to grab coffee or something.
+* I was able to install Obsidian on my new work laptop! This is very exciting — I wasn't expecting to be allowed to. I'm glad I procrastinated on figuring out how Docker works 😂
+
+## In the Community
+
+* There's a new book club being organized [via discord](https://discord.com/channels/686053708261228577/700466324840775831/1009112156064718951). So far most of the interest seems to be around genre fiction books. Here's the [resource document](https://docs.google.com/document/d/1Tltglt-UGwsqo2PAlcJGK4LwgGocHiUhV3GrPo6BiZs/edit), here's [the list of proposed books](https://docs.google.com/spreadsheets/d/1JthB7H9yfa-w4ksTIQGz72IxPEZqDpjI_jsRtV2c74w/edit?usp=sharing). Consider joining in and signing up!
+* There's a guy who is active in the Obsidian community who has low code integration experience but is looking to break into a software engineering role. He's primarily comfortable with Python but has recently picked up TS/JS. He's contributed to a few plugins you might have used like the SRS plugin and Dataview, but has no prior software dev experience and is looking for a junior role. He's open to remote contract work (lives abroad) but is willing to move back to the US as well. Please let me know if you'd like to get in touch.
+
+## Plugins
+
+* If you use the [File Hider plugin](https://github.com/Oliver-Akins/file-hider/discussions/19) please consider contributing to the discussion about the future direction of the plugin.
+
+### New in Community Plugins
+
+__These plugins went through code review and are now available in Obsidian's plugin list. For the full list, check out the [plugin stats page](https://obsidian-plugin-stats.vercel.app/new).__
+
+* [Heading Shifter](https://github.com/k4a-dev/obsidian-heading-shifter) by `@k4a-dev` makes it easier to shift and change markdown headings.
+* [Open File by Magic Date](https://github.com/SimplGy/obsidian-open-file-by-magic-date) by `@SimplGy` lets users define a Moment.js date pattern that specifies the file that is most important to you (eg: your daily/weekly/monthly note). It'll create the file if it doesn't exist.
+* [No dupe leaves](https://github.com/scambier/obsidian-no-dupe-leaves) by `@scambier` makes sure you don't open the same note multiple times.
+* [Better Inline Fields](https://github.com/dsarman/better-inline-fields) by `@dsarman` enhances Dataview style inline fields.
+* [Hide Sidebars on Window Resize](https://github.com/NomarCub/obsidian-hide-sidebars-on-window-resize) by `@NomarCub` automatically hides the sidebars when your window is resized to be narrower.
+* [Tagged Documents Viewer](https://github.com/mgeduld/obsidian-tagged-documents-viewer) by `@mgeduld` opens a modal with scrollable content of all documents that contain a specific tag or tags.
+* [Meeting notes](https://github.com/TimHi/obsidian-meeting-notes) by `@TimHi` automatically creates a meeting note if a new file is created in a meeting folder.
+
+### Pending (as of Friday morning)
+
+__Note: Not all new plugins are available in the community list yet, as they need to go through code review first. You can manually install plugins that aren't in the community list yet by using the [Beta Reviewer's Auto-update Tool](https://github.com/TfTHacker/obsidian42-brat). Note, though, that this is not as safe as waiting for them to go through code review.__
+
+* [QuickShare](https://github.com/mcndt/obsidian-quickshare) by `@mcndt` lets users securely share notes with one click. Notes are end-to-end encrypted with no API keys or configuration required.
+* [Auto Hide](https://github.com/skelato1/obsidian-auto-hide) by `@skelato1` collapses sidebars when clicking on the editor/viewer panel.
+* [Dashing cursor](https://github.com/9r0x/obsidian-dashing-cursor) by `@9r0x` enables a dashing cursor that follows the page scroll.
+* [Obsidian Git Isomorphic](https://github.com/Vinzent03/obsidian-git-isomorphic) by `@Vinzent03` is another way to backup your vault with git... that works on mobile.
+* [Anki Synchronizer](https://github.com/tansongchen/obsidian-anki-synchronizer) by `@tansongchen` is another spaced repetition app for Anki.
+* [URL Namer](https://github.com/zfei/obsidian-url-namer) by `@zfei` retrieves the HTML titles to name the raw URL links. I think it's manual instead of automatic the way [Auto Link Title](https://github.com/zolrath/obsidian-auto-link-title) is.
+* [Obsidian Header Format](https://github.com/dbarenholz/obsidian-headerformat) by `@dbarenholz` makes it easier to format the current line as a header.
+
+### Updates
+
+__If you want a comprehensive list of what plugins updated this week, check out this [plugin updates index](https://obsidian-plugin-stats.vercel.app/updates) by Ganessh Kumar.__
+
+* Another Quick Switcher plugin had a major update with lots of new featurs, including "insert all to editor," grep support, custom searches, an option to hide hotkey guides. Some settings also got removed, so make sure you [check the release notes](https://github.com/tadashi-aikawa/obsidian-another-quick-switcher/releases/tag/6.0.0) before updating. [6.1.0](https://github.com/tadashi-aikawa/obsidian-another-quick-switcher/releases/tag/6.1.0) added vim-like navigation, too.
+* [Obsidian Plaintext](https://github.com/dbarenholz/obsidian-plaintext) now supports Obsidian Mobile.
+* [Obsidian Linter 1.4.0](https://github.com/platers/obsidian-linter/releases/tag/1.4.0.) lets users format YAML arrays, tags, and aliases. Incidentally, I recently (re?) learned that this plugin lets you enforce `*` or `_` for bold/italic throughout your whole vault, if you're  like me and sometimes vary between the two.
+* [Metadata Menu 0.1.11](https://github.com/mdelobelle/metadatamenu) has a new field type: `file` which can be populated with a file in your vault. Here's [a demo](https://youtu.be/sYudigxPEnY).
+* [Obsidian Database Folder 2.2.0](https://github.com/RafaelGB/obsidian-db-folder/releases/tag/2.2.0) makes it possible to hide columns, and made filters accessible from the navbar. You can also sort and search tags.
+
+### Betas
+
+__Note: these plugins have not yet been submitted for code review, and are being made available primarily for testing purposes.__
+
+* [RPG Manager](https://github.com/carlonicora/obsidian-rpg-manager) requires dataview but is setting-agnostic and focuses on helping writing campaigns and linking various elements of a campaign together for ease of running sessions.
+* [Virtual Hotkey Board](https://github.com/Quorafind/Obsidian-Virtual-Hotkey-Keyboard/releases/tag/1.1.2) lets you see what hotkeys you have set in a nice keyboard layout style.
+
+## Ancillary Tools
+
+* Here's a tool mentioned on HackerNews that's useful for [cross-referencing the difference between PDFs](https://news.ycombinator.com/item?id=32353479).
+
+## Feature Requests
+
+* A word count that [ignores stuff only visible in source mode and counts from reading mode](https://forum.obsidian.md/t/word-count-based-on-preview-text-not-editor-text/4758) would be nice. Bonus if it shows word count for the currently active view mode.
+* The ability to [sync settings and options between different vaults on the same computer](https://forum.obsidian.md/t/option-to-sync-settings-themes-and-plugins-across-multiple-vaults/41789?u=synchronicity) would be nice.
+
+## Appearance
+
+* [ITS Theme](https://forum.obsidian.md/t/theme-its-dark-light-theme/12838/169) now has support for turning dataview lists into columns, and got some other callout updates.
+* [Primary](https://github.com/ceciliamay/obsidianmd-theme-primary/releases/tag/v.1.4.8) added variations for callouts and alternate checkbxoes, improved accessibility, and more checkbox styles.
+* [Wyrd](https://github.com/curio-heart/obsidian-wyrd/releases/tag/v0.3.4) got some bugfixes.
+* [Mado Miniflow 0.2.0](https://github.com/hydescarf/Obsidian-Theme-Mado-Miniflow/releases/tag/v0.2.0) has an improved mobile experience.
+
+## Guides
+
+* Here's a video from Bob Doto explaining how to [write essays using a zettelkasten system in Obsidian](https://youtu.be/9OUn2-h6oVc).
+* Here's a guide about how to use Obsidian to [track tasks, meetings, classes, and relationships](https://twelvetables.blog/taking-notes-with-obsidian/).
+* Here's an explanation of how someone used [Obsidian to help prepare for public speaking](https://realhardman.medium.com/public-speaking-a-nightmare-unlock-excellence-with-the-awesome-obsidian-4246f3022d27).
+* Here's an [argument for why DevonThink and Obsidian are great in tandem](https://simontheak.medium.com/why-i-use-both-devonthink-and-obsidian-to-manage-my-content-8f76490ee295), directed mostly at apple-ecosystem folks.
+* Here's a nice thread about the value of using [Dendron and Obsidian together](https://twitter.com/aadimator/status/1558435103990218753) and how to set that up.
+* Here's a migration guide for [making Obsidian work like Bear](https://www.reddit.com/r/ObsidianMD/comments/wrs5wi/bear_minimum_obsidian/).
+* Here's an [infographic about how to make notes and write](https://www.reddit.com/r/ObsidianMD/comments/ws3vk8/my_visualization_of_the_making_notes_portion_of/).
+* Here's a guide for [using Obsidian for team knowledge management](https://medium.com/@ensleytan/using-obsidian-for-group-km-145646068cd7).
+
+## Showcases
+
+* Here's an [example of a flexible working environment](https://echinopscis.github.io/) for folks in the biodiversity informatics area, along with a [twitter thread explaining its purpose](https://twitter.com/nickynicolson/status/1559524647175086081). It's basically an extensible notebook for open science on specimens — "a working environment that allows researchers to write, access data and create links between literature, specimens, names, institutions, people, traits etc."
+* [OB Templates](https://github.com/llZektorll/OB_Template) got a new template for creating a word dictionary.
+* Here's a [recording](https://www.youtube.com/watch?v=zCbXERZf8vM) of `@mapogatari` researching and processing the notes for those who find "working examples" and models more useful than lecture-style explanatory guides.
+
+## Food For Thought
+
+* Here's a lovely article about [the value of purposefully framing important habits as rituals](https://leisureguy.wordpress.com/2017/03/27/reprise-of-coveys-7-habits/) that focuses on things like weekly planning.
+* Here's a thread about [how historians take notes](https://www.reddit.com/r/AskHistorians/comments/wlu8df/how_historians_take_notes_when_working_with/) — the major takeaway is that there's no set standard and everyone has personalized systems, but the discussion was still valuable, particularly since it was from the AskHistorians subreddit and not a subreddit dedicated to notetaking nerds.
+* [The Rise and Fall of Getting Things Done](https://www.newyorker.com/tech/annals-of-technology/the-rise-and-fall-of-getting-things-done) was popular this week.
+* This article [in defense of complicated programming languages](https://viralinstruction.com/posts/defense/) really reminded me of my article about [the difficulties of teaching notetaking](https://www.obsidianroundup.org/the-difficulties-of-teaching-notetaking/), particularly the bit about how hard it is to get people to learn something they don't need just because it might be useful later down the line. Although ostensibly about programming languages, the core argument was very applicable to notetaking systems. In fact, I liked it so much that it inspired this month's thoughts: [don't minimize difficulty](https://www.obsidianroundup.org/dont-minimize-difficulty/).

--- a/01 - Community/Obsidian Roundup/2022-08-27 Visual Notetaking Guides & Demo Vaults for Managers.md
+++ b/01 - Community/Obsidian Roundup/2022-08-27 Visual Notetaking Guides & Demo Vaults for Managers.md
@@ -1,0 +1,90 @@
+---
+link: https://www.obsidianroundup.org/2022-08-27/
+author: Eleanor Konik
+published: 2022-08-27T12:30:05
+publish: true
+---
+
+# 2022-08-27: Visual Notetaking Guides & Demo Vaults for Managers
+You can now push notes to Readwise's Reader app for improved spaced repetition review. You can also comment on the Roundup!
+
+## 
+
+## Obsidian Updates
+
+* There was no release in the last week, but the team is planning on shipping 0.16 __early next week__. They're super excited for this one and jam-packed it with new features (like tabs!). Since it's such a big release, though, __it might be a bit disruptive__. There are likely to be some broken themes, and it will be a desktop update, not mobile. Most _plugins_ aren't affected, but if you're in the middle of anything critical, you might want to turn off the insider build option until you're ready. Insiders can check out this [preview of the new theme](https://discord.com/channels/686053708261228577/716028884885307432/1012786039624040518) from `@kepano`. I've been using it for a week or so now and it's very nice, but I did have to tweak some of my settings to make sure I wasn't syncing my theme between desktop and mobile.
+
+## In The Community
+
+* `@ladle` was inspired to write and record an album by the Obsidian community. Here it is [on bandcamp](https://ajrn.bandcamp.com/album/note-to-self-2).
+* The folks working on [the Kindle Highlights](https://github.com/hadynz/obsidian-kindle-plugin) are hoping to improve user experience over the next couple of months. They want to interview users of the plugin to get a better understanding of how the plugin actually gets used and do a discovery of other interesting problems that we can solve. DM `@hadynz#0075` to get involved.
+
+## Plugin News
+
+### Pending (as of Friday morning)
+
+_Note: Not all new plugins are available in the community list yet, as they need to go through code review first. You can manually install plugins that aren't in the community list yet by using the [Beta Reviewer's Auto-update Tool](https://github.com/TfTHacker/obsidian42-brat). That this is not as safe as waiting for them to go through code review._
+
+* [Obsidian to Reader](https://github.com/joerncodes/obsidian-readwise-reader) by `@joerncodes` lets users publish Obsidian documents to the Readwise's read-it-later service, Reader, which is currently in beta. It allows you to publish to Reader your Obsidian notes for later perusal, highlighting and reflecting with many settings and front matter options to finetune how you want your documents to show up in Reader. I spoke with Erin, the community manager over at Readwise, and she said that they're transitioning to an invite-based, self-serve onboarding for existing Readwise subscribers. If you shoot her an email at  `erin@readwise.io` and let her know I sent you, she said she'd get you set up. I use Reader for all of my longform newsletters and articles I want to take notes on. If you don't already have a Readwise subscription and want to try it out, [this link should get you a free month](https://readwise.io/i/ac9).
+* [Embed Code File](https://github.com/almariah/embed-code-file) by `@almariah`  allows for embedding code files.
+* [Script Launcher](https://github.com/AlessandroRuggiero/script-launcher) by `@AlessandroRuggiero`  allows you to add scripts shortcuts on your bottom bar and launch them with a click.
+* [Embedded Note Paths](https://github.com/b0o/obsidian-embedded-note-paths) by `@b0o`  inserts the note file path above each note, similar to how the `Show Current File Path` puts it in the bottom bar.
+* [Literate Haskell](https://github.com/jajaperson/obsidian-literate-haskell) by `@jajaperson`  makes it easier to integrate .lhs files into your vault.
+
+### Updates
+
+_If you want a comprehensive list of what plugins updated this week, check out this [plugin updates index](https://obsidian-plugin-stats.vercel.app/updates) by Ganessh Kumar._
+
+* [Podnotes](https://github.com/chhoumann/PodNotes) launched on [ProductHunt](https://www.producthunt.com/posts/podnotes), which I think is pretty cool. If you use it, go upvote! But also, it now lets you [create notes and timestamps without any extra plugins](https://twitter.com/chrisbbh/status/1562811601756909569), and define your own templates. You can even download episodes for offline listening. It supports any local audio file.
+* Tasks 1.12.0 now [supports regular expressions](https://obsidian-tasks-group.github.io/obsidian-tasks/queries/regular-expressions/).
+* Excalidraw 1.7.14 allows you to embed and link to parts of images, just like linking to paragraphs of text with block references. Here's [a walkthrough video](https://youtu.be/yZQoJg2RCKI) and `@TFTHacker` on [why this update is great](https://twitter.com/TfTHacker/status/1561360717638316032).
+* [Dataview](https://github.com/blacksmithgu/obsidian-dataview) 0.5.42 got some documentation improvements and tag queries are now case insensitive. There's also support for nested inline fields, custom date formats for task completions, and more.
+* [Another Quick Switcher plugin v6.2.0](https://github.com/tadashi-aikawa/obsidian-another-quick-switcher/releases/tag/6.2.0) added an option to alphabetically sort.
+* [Path Finder 1.1.1](https://github.com/jerrywcy/obsidian-path-finder) now supports the Style Settings plugin.
+
+### For Developers
+
+* Folks who contribute to the Tasks plugin should check out this discussion about [reformatting and rearranging the source code](https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/1052).
+* The developer of Gruvbox and Nord, `@insanum`, is looking for help updating these themes.
+
+## Feature Requests
+
+* Apparently you can [use Obsidian URIs to save searches](https://forum.obsidian.md/t/creating-links-for-saved-searches-in-notes/42337/2)... but there are definitely some ways that functionality can be made easier to use, if anyone is interested in picking up that project.
+* Improved behaviors for [filtering searches](https://forum.obsidian.md/t/filter-tags-list-in-tag-pane-when-choosing-tags/12352) would be handy.
+
+## New Themes
+
+* [Tomorrow Night Bright](https://github.com/gbraad/obsidian-tomorrow-night-bright-theme) by `@gbraad` is very dark.
+* [Omni](https://github.com/librity/omni-obsidian) by `@librity` is very purple.
+
+## Guides
+
+* Dan Allosso, a wonderful history teacher who runs an Obsidian book club, put out a [How to Make Notes and Write](https://boffosocko.com/2022/08/02/how-to-make-notes-and-write-a-handbook-by-dan-allosso-and-s-f-allosso/) handbook. Digital copies are free.
+* Here's how Nicole van der Hoeven [studies using Obsidian](https://www.youtube.com/watch?v=FAy9ZWaHSIw).
+* Denise Todd wrote a great [guide to tag-related plugins](https://denisetodd.medium.com/two-obsidian-plugins-youll-wonder-how-you-lived-without-ea135c664d62) aimed at new users.
+* Here's a guide for [using the pick four goal-tracking system](https://thebuccaneersbounty.wordpress.com/2022/08/24/how-to-use-pick-four-to-track-goals-and-habits-in-obsidian/) with Obsidian, along with a downloadable vault.
+* Zsolt, creator of Excalidraw, had a really wonderful video about how [we shape our tools, and our tools shape us](https://www.youtube.com/watch?v=AtdAAD47aQY), and how to recombine the ingredients we all have into a personalized notetaking systems. As you might expect, it has a lot of wonderful graphics. As you might _not_ expect, since I famously struggle with audiovisual content, I actually watched the whole thing.
+* He also met with Nicole van der Hoeven about [visual personal knowledge management](https://www.youtube.com/watch?v=fXGcOWycgG4) which is a bit less of an overview and a bit more about his personal methods. You can see an [example of this](https://www.youtube.com/watch?v=o49C8jQIsvs) where he created a "book in a page" for How to Take Smart Notes.
+* Here are [three ways to keep a project list](https://iwannabemewhenigrowup.medium.com/three-ways-to-keep-a-project-list-in-obsidian-23b34959e697)
+* Here's a guide to [project and task management with Obsidian and Dataview](https://mostlymaths.net/2022/08/obsidian-task-management.html/).
+
+## Discussions
+
+* Reddit had a nice discussion about why you should take a [just do it approach](https://www.reddit.com/r/ObsidianMD/comments/wwlgex/stop_looking_for_structure/) to taking notes.
+* Here's a [lengthy discussion about how and why to use tags](https://www.reddit.com/r/ObsidianMD/comments/wu84x2/can_you_guys_explain_what_value_do_tags_bring_and/).
+
+## Showcases
+
+* Here's a [workout plan using the Advanced Slides](https://mszturc.github.io/obsidian-advanced-slides/examples/) plugin.
+* Here's a video of `@alexdavidwright` using Obsidian to [read a paper and take notes](https://www.loom.com/share/47baf93fe0464d239f1574e36e3380df) for academic purposes. Here's a similar video from `@vglau` showcasing how to use Obsidian to [take notes for novel research](https://www.youtube.com/watch?v=eIjRsgcCaWI).
+* Here's a [demo vault for software developers and managers working on the corporate world](https://github.com/cuken/obsidian-weave). It's very opinionated but also very thorough. It uses Dataview, QuickAdd, and several other plugins to divide workstreams into applications, contacts, journals, and meetings.
+* Here's a nice showcase of someone's [specific use cases and zettel types](https://forum.toolsforthought.io/t/my-specific-use-cases-and-zettel-types/60) for maintaining a zettelkasten.
+* Here's a [collection of Obsidian vaults & starter kits](https://twitter.com/rsims/status/1556333756910288896).
+
+## Ancillary Tools
+
+* [The Sample](https://thesample.ai/?ref=9937) is a fun indie newsletter aggregator that sends a random blog or newsletter meant to align with your interests. I've mentioned them before, but they've had a bunch of updates. You can now flip through samples at your leisure, and the developer recently put together a [reading app](https://yakread.com/) meant to work with RSS, ebook, Pocket, and Twitter. It's still in the early days, but the developer is responsive and feels very strongly about open internet principles.
+
+## Housekeeping
+
+* Ghost, the software that I run this newsletter with, now supports native commenting features. If you'd like to leave a comment on any of the articles or roundup editions, click the "view online" button and scroll to the bottom. You need to be logged in to comment, but you don't need to be a financial supporter. Login uses "magic links" so you should be able to sign in with whatever email address you use to access the Roundup. Folks who prefer RSS but want to comment can just register and unsubscribe to emails. I'd love to know which item in this week's Roundup was most useful for you!

--- a/01 - Community/Obsidian Roundup/2022-09-03 Tabs and a new Default Theme.md
+++ b/01 - Community/Obsidian Roundup/2022-09-03 Tabs and a new Default Theme.md
@@ -1,0 +1,26 @@
+---
+link: https://www.obsidianroundup.org/2022-09-03/
+author: Eleanor Konik
+published: 2022-09-03T12:30:55
+publish: true
+---
+
+# 2022-09-03: Tabs and a new Default Theme
+Dataview has its own channel and I can’t access Discord until next week.
+
+First things first, an apology. I'm writing this week's Roundup from a (lovely) hotel room in Chicago, which normally isn't a problem, but I wasn't able to bring my laptop, which is. Worse, I don't even have a mouse for my iPad. Or access to Discord thanks to 2FA woes.  
+
+So this edition is going to be limited to the bare bones minimal critical information, and the pieces I had already put together before I caught my plane Thursday night. 
+
+First things first, the promised update for Obsidian. Insiders can now access the new default theme, and the new tabs feature, with versions [16.0 and above](https://forum.obsidian.md/t/obsidian-release-v0-16-0-insider-build/42536). I'm pretty sure that these two things together represent the most disruptive update to Obsidian ever, but it's worth it. The new theme is beautiful, and while theme developers will need to follow [the migration guide](https://forum.obsidian.md/t/0-16-0-theme-migration-guide/42537), as far as I know the new default theme was deliberately designed to be much easier for theme developers to work with in the long run. As far as I know, the only people who are having major trouble are people who use the Sliding Panes plugin, so those folks might want to hold off on updating for now. 
+
+Secondly, the [Idea Exchange](https://www.linkingyourthinking.com/idea-exchange-conference) is a week of free sessions (September 6-9) that explores how linking ideas may impact our creativity in practical and powerful ways. It's hosted by Nick Milo, but familiar faces like Danny Hatcher, Bob Doto, and Anne-Laure Le Cunff will be presenting. There will be 13 live sessions on topics such as ideation, next-gen thinking tools, the frontiers of extended cognition, the joys and importance of culture, note-making, zettelkasten, crafting time, and much more.
+
+Lastly, the Dataview thread in Discord got so big it became impossible to add any more people to it, so there's now a channel for discussing the Dataview plugin. 
+
+Until next week,
+
+Eleanor 
+
+PS: If you want a comprehensive list of what plugins got added and updated this week, check out this [plugin updates index](https://obsidian-plugin-stats.vercel.app/updates) by Ganessh Kumar.
+

--- a/01 - Community/Obsidian Roundup/2022-09-10 Bulk Rename, Cleanup Routines & Mobile git.md
+++ b/01 - Community/Obsidian Roundup/2022-09-10 Bulk Rename, Cleanup Routines & Mobile git.md
@@ -1,0 +1,107 @@
+---
+link: https://www.obsidianroundup.org/2022-09-10/
+author: Eleanor Konik
+published: 2022-09-10T12:30:54
+publish: true
+---
+
+# 2022-09-10: Bulk Rename, Cleanup Routines & Mobile git
+There's an upcoming discussion of daily logs, a new jira integration, and a job opportunity from the folks at Readwise right as Obsidian's team expanded too :)
+
+## In The Community
+
+* Bianca and Leah are going to chat about the advantages of daily logs [Sunday, September 11](https://lu.ma/5gqo20vg) on Twitter Spaces.
+* [This Reddit post](https://www.reddit.com/r/PKMS/comments/wq3u6g/im_researching_how_neurodivergent_people_use_pkm/) involves a PhD student with ADHD is asking people who identify as neurodivergent in some way (including but not limited to ADHD, autism, and dyslexia) to take a survey for dissertation research about how folks use personal knowledge management.
+
+## Obsidian Updates
+
+* The team size has officially doubled, which means the team's [About page](https://obsidian.md/about) has been updated; click through for super cute photos of the babies and cats!
+* Folks who were worried about losing Sliding Panes, rejoice! [Tab Stacks](https://forum.obsidian.md/t/obsidian-release-v0-16-2-insider-build/42829) replicate the functionality of Sliding Panes / Andy's Mode in core, as of Insider 0.16.2. [0.16.1](https://forum.obsidian.md/t/obsidian-release-v0-16-1-insider-build/42701) brought a bunch of improvements, including the nifty feature where we'll get in-app release notes after updates!
+
+## Plugin News
+
+### New in Community Plugins
+
+__These plugins went through code review and are now available in Obsidian's plugin list.__ For the full list, check out the [plugin stats page](https://obsidian-plugin-stats.vercel.app/new).
+
+* [Bulk Rename](https://github.com/OlegLustenko/obsidian-bulk-rename) by `@OlegLustenko` renames files based on patterns. As of 1.0.0, it allows users to search by tags across the vault and later move or update the names of those notes. It also lets users search for tags and move all files with a particular tag to a particular folder. There's also improved regex support.
+* [Note Linker](https://github.com/AlexW00/obsidian-note-linker) by `@AlexW00` will automatically find and link notes.
+* [Raindrop Highlights](https://github.com/kaiiiz/obsidian-raindrop-highlights-plugin) by `@kaiiiz` lets you sync your Raindrop.io highlights.
+* [Default New Tab Page](https://github.com/chrisgrieser/new-tab-default-page) by `@chrisgrieser` opens a note of your choice when creating a new tab, like in the browser.
+* [Open in other editor](https://github.com/yekingyan/obsidian-open-in-other-editor) by `@yekingyan` will open the currently active file in gVim or VScode.
+* [Agile Task Notes](https://github.com/BoxThatBeat/obsidian-agile-task-notes) by `@BoxThatBeat` lets users import tasks from your Azure or Jira to take notes on them and make todo-lists!
+* [Embed Code File](https://github.com/almariah/embed-code-file) by `@almariah` allows for embedding code files.
+* [Embedded Note Paths](https://github.com/b0o/obsidian-embedded-note-paths) by `@b0o` inserts the note file path above each note.
+* [Literate Haskell](https://github.com/jajaperson/obsidian-literate-haskell) by `@jajaperson` makes integrating .lhs files into your PKM easier.
+* [QuickShare](https://github.com/mcndt/obsidian-quickshare) by `@mcndt` lets users securely share Obsidian notes with one click. Notes are end-to-end encrypted. No API keys or configuration required.
+* [Dashing cursor](https://github.com/9r0x/obsidian-dashing-cursor) by `@9r0x` enables a dashing cursor that follows the page scroll.
+* [Obsidian Git Mobile](https://github.com/Vinzent03/obsidian-git-mobile) by `@Vinzent03` lets users back up with Git on all devices
+* [Kobo Highlights Importer](https://github.com/OGKevin/obsidian-kobo-highlights-import) by `@OGKevin` imports highlights from Kobo devices.
+* [RPG Manager](https://github.com/carlonicora/obsidian-rpg-manager) by `@carlonicora` makes it easier to manage your Tabletop Role Playing Game campaigns for Obsidian.
+
+### Pending (as of Friday morning)
+
+__Note: Not all new plugins are available in the community list yet, as they need to go through code review first. You can manually install plugins that aren't in the community list yet by using the __recently updated__ [Beta Reviewer's Auto-update Tool](https://github.com/TfTHacker/obsidian42-brat). Note, though, that this is not as safe as waiting for them to go through code review.__
+
+* [Todoist completed tasks](https://github.com/Ledaryy/obsidian-todoist-completed-tasks) by `@Ledaryy` fetches completed tasks from todoist API and adds them to the Obsidian note.
+* [Day and Night](https://github.com/CyberT17/obsidian-day-and-night) by `@CyberT17` automatically toggles themes between day theme and night theme on a set time schedule.
+* [TikZJax](https://github.com/artisticat1/obsidian-tikzjax) by `@artisticat1` renders LaTeX and TikZ diagrams in Obsidian notes.
+* [Copy Search URL](https://github.com/czottmann/obsidian-copy-search-url) by `@czottmann` adds a button to the search view for copying the Obsidian search URL.
+* [HTML Reader](https://github.com/nuthrash/obsidian-html-plugin) by `@nuthrash` is a HTML file reader plugin that can open documents with ".html" and ".htm" file extensions.
+* [Obsidian Editing Toolbar](https://github.com/cumany/obsidian-editing-toolbar) by `@cumany` is modified from cmenu, and provides more powerful customization settings and has many built-in editing commands to be a MS Word-like toolbar editing experience.
+* [Janitor](https://github.com/Canna71/obsidian-janitor) by `@Canna71` performs cleanup tasks on a Obsidian vault.
+* [Squiggle](https://github.com/jqhoogland/obsidian-squiggle) by `@jqhoogland` enables running squiggle code snippets within a note.
+
+### Updates
+
+__If you want a comprehensive list of what plugins updated this week, check out this [plugin updates index](https://obsidian-plugin-stats.vercel.app/updates) by Ganessh Kumar.__
+
+* [Obsidian Git](https://ko-fi.com/post/Obsidian-Git-on-Mobile-S6S1EESYJ) __officially__ works on Mobile now!
+* [Templater v0.13.0](https://github.com/SilentVoid13/Templater) added an option to show or hide the Templater ribbon icon.
+* Using Obsidian Linter v1.4.4, the "move footnote to bottom" option no longer ignores tags, regular markdown links, or wiki links, [among other things](https://github.com/platers/obsidian-linter/releases/tag/1.4.4).
+* [Database folder](https://github.com/RafaelGB/obsidian-db-folder) got new documentation as well as new ways to create database from command & sidebar menu with a wizard helper.
+* A bunch of plugins like [Commander](https://github.com/phibr0/obsidian-commander) have been updated to work with the Insider build.
+
+### Betas
+
+__Note: these plugins have not yet been submitted for code review, and are being made available primarily for testing purposes.__
+
+* [Literate Styles](https://github.com/johanfriis/obsidian-literate-styles) uses CSS codeblocks to enable styling.
+
+### For Developers
+
+* Readwise is [hiring a frontend engineer](https://readwise.notion.site/Frontend-Engineer-403ee91089204d3f81d354528ff6172d), so if you're good with Javascript & React, or have experience with iOS/Android, reach out -- from what I can tell they're pretty great to work with.
+* Here's a great [guide for how to use the new CSS variables effectively](https://www.youtube.com/watch?v=yl0pvIRTWWo&t=7s) for theme development.
+
+## Feature Requests
+
+* Here's a nice [roundup of feature requests to make Obsidian be a bit more in line with some nice features of Scrintal](https://forum.obsidian.md/t/workspace-plugin-update-2-0-discussion/43108).
+* [Vertical tabs](https://forum.obsidian.md/t/vertical-tabs-for-more-efficient-use-of-space-and-easier-faster-navigation/42987), a la the Vivaldi browser, would be handy.
+* It would be nice if we could [easily filter plugins and themes](https://forum.obsidian.md/t/filter-0-16-ready-themes/42910) for compatability.
+
+## Appearance
+
+* [Minimal](https://github.com/kepano/obsidian-minimal/releases/tag/6.0.1) is now updated to be compatible with the new default theme in 0.16+ and one of the neatest features is that you can color-code the frame by vault, to help differentiate between multiple vaults. There's a great [FAQ](https://github.com/kepano/obsidian-minimal/releases/tag/6.0.1) explaining the difference between Minimal and the new Default theme, and what the development of Default means for Minimal. v6.0.4 adds syntax highlighting options to Style Settings.
+* [Silence](https://github.com/luke-rmaki/silence-obsidian) by `@luke-rmaki` is a dark theme that looks updated for v0.16+
+
+## Guides
+
+* Here's a twitter thread detailing an entire [series on how to get the most out of Templater](https://twitter.com/kicki22/status/1565363960240656385).
+* Here's an [introduction to folders, links, and tags](https://www.youtube.com/watch?v=IaSl21e19ck).
+* Here's a nice guide on [outlining in Obsidian](https://thesweetsetup.com/outlining-in-obsidian/), written and with an accompanying video.
+* Here's a really neat breakdown of [how the Graph Analysis plugin works](https://medium.com/@ensleytan/obsidians-graph-analysis-plugin-c9c107da3331).
+* Here's a nice [setup guide and sample vault](https://twelvetables.blog/taking-notes-with-obsidian/).
+
+## Showcases
+
+* Here's a nice .gif of someone using [Obsidian like a bullet journal](https://media.discordapp.net/attachments/744933215063638183/1016847016938180749/bulletobsidian.gif).
+
+## Ancillary Tools
+
+* Readwise now has a twitter account just for the [Reader app](https://twitter.com/ReadwiseReader). If you're an existing [Readwise subscriber](https://readwise.io/i/ac9), they've got a self-serve onboarding set up, so the waitlist should move a lot more quickly than it used to.
+* Here's a fun photograph of an [analog zettelkasten card](https://discord.com/channels/686053708261228577/935988957034991628/1014875461039435776) from Discord's analog tools thread under the `#off-topic` channel. It's got page, source, zotero bibtex, tags, reference, importance rate, certainty rate, and support for vertical titling!
+* Glasp now allows users to import all highlights & notes in Kindle, and export them as a markdown file you can move into your Obsidian vault. Here's a [demonstration](https://twitter.com/_Glasp/status/1564108203368910848) and a [written tutorial](https://medium.com/glasp/tutorial-how-to-import-kindle-highlights-notes-into-glasp-export-them-as-a-file-92301bb539da).
+
+## Housekeeping
+
+* I think I'm caught up after my weekend without Discord or a mouse. If I missed something cool from the last 2-3 weeks (especially notable plugin or theme updates), please reach out and let me know! I'm still digesting some of the info in Discord, but from what I can tell, most of the focus is on the v0.16.x updates with tabs and all the new appearance stuff. I expect that'll take a few more weeks to shake out.

--- a/01 - Community/Obsidian Roundup/2022-09-17 Dataview Example Vault, Book Club, & Ecosystem Stats.md
+++ b/01 - Community/Obsidian Roundup/2022-09-17 Dataview Example Vault, Book Club, & Ecosystem Stats.md
@@ -1,0 +1,102 @@
+---
+link: https://www.obsidianroundup.org/2022-09-17/
+author: Eleanor Konik
+published: 2022-09-17T12:30:37
+publish: true
+---
+
+# 2022-09-17: Dataview Example Vault, Book Club, & Ecosystem Stats
+Memes about minimalism, bullet backlinks plugin, timeshifting, a book club, and an upcoming mystery event.
+
+## In The Community
+
+* For an upcoming mysterious community event, the Obsidian team is looking for speakers to talk about plugin development! DM `Silverica#8456` on Discord if you'd love to give a talk, whether you have a topic in mind or not. In addition to all the community love you get, you might also get a special merch shirt.
+* Here's the [ranked voting survey](https://docs.google.com/forms/d/e/1FAIpQLSduBKH9orU7Az1Hp4G9hFEUuyIEfncjYQNTblemtg7StFgLaA/viewform?usp=sf_link) for the Obsidian book club. The deadline for voting is September 20 at 17:00 EST. You can find more details in the `#off-topic` [thread for the book club](https://discord.com/channels/686053708261228577/1009112156064718951/1019217017536004096) in Discord.
+* Does anybody have any good guides on how to use n8n for anything related to Obsidian? It feels like there are opportunities to use it, but I generally only hear about Zapier even though n8n is self-hostable. What's up with that?
+* Here's a super neat write-up about [Obsidian ecosystem statistics](https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/Guides/Obsidian+ecosystem+statistics) including a best guess of how many (estimated) users use Windows, Mac, or (various distributions of) Linux, as well as how many downloads there were for themes and plugins. Only 3 themes have been downloaded more than 100,000 times!
+* For those who aren't familiar with it, the [Obsidian Meme subreddit](https://www.reddit.com/r/ObsidianMDMemes/) is new but a lot of fun, especially this one about [minimalists after installing Obsidian 0.16](https://www.reddit.com/r/ObsidianMDMemes/comments/x4answ/minimalists_after_installing_obsidian_16/)
+
+## Plugin News
+
+### New in Community Plugins
+
+_These plugins went through code review and are now available in Obsidian's plugin list._ For the full list, check out the [plugin stats page](https://obsidian-plugin-stats.vercel.app/new).
+
+* [TikZJax](https://github.com/artisticat1/obsidian-tikzjax) by `@artisticat1`  renders LaTeX and TikZ diagrams in your notes
+* [Janitor](https://github.com/Canna71/obsidian-janitor) by `@Canna71`  performs cleanup tasks on your vault
+* [Todoist completed tasks](https://github.com/Ledaryy/obsidian-todoist-completed-tasks) by `@Ledaryy`  fetches completed tasks from todoist API and adds them to the Obsidian note.
+* [Day and Night](https://github.com/CyberT17/obsidian-day-and-night) by `@CyberT17`  automatically toggles themes between day theme and night theme on a set time schedule.
+* [Script Launcher](https://github.com/AlessandroRuggiero/script-launcher) by `@AlessandroRuggiero`  launches scripts from bottom bar with just one click.
+* [Auto Hide](https://github.com/skelato1/obsidian-auto-hide) by `@skelato1`  collapses sidebars when clicking on the editor/viewer panel.
+
+### Pending (as of Friday morning)
+
+_Note: Not all new plugins are available in the community list yet, as they need to go through code review first. You can manually install plugins that aren't in the community list yet by using the [Beta Reviewer's Auto-update Tool](https://github.com/TfTHacker/obsidian42-brat). Note, though, that this is not as safe as waiting for them to go through code review._
+
+* [Influx](https://github.com/jensmtg/influx) by `@jensmtg` is a bullet journaling plugin that aggregates a terse stream of backlinked clippings in the footer of notes. It looks designed for outliners that don't want to mess with folders and tags but do want to use daily notes. If I'm understanding it correctly it should make people used to the Roam/Logseq paradigm intrigued.
+* [Custom File Explorer sorting](https://github.com/SebastianMC/obsidian-custom-sort) by `@SebastianMC`  allows for manual and automatic, config-driven reordering and sorting of files and folders in File Explorer.
+* [Image Inserter](https://github.com/cloudy9101/obsidian-image-inserter) by `@cloudy9101` helps users easily search and insert images to editors from Unsplash.
+* [3D Graph](https://github.com/AlexW00/obsidian-3d-graph) by `@AlexW00` uses D3.js to create an alternate graph view that lets nodes overlap.
+* [Time Tracker](https://github.com/daaru00/obsidian-time-tracker) by `@daaru00`  lets users add timer widgets.
+* [AWS S3 Sync](https://github.com/daaru00/obsidian-aws-s3-sync) by `@daaru00`  will synchronize vaults with an AWS s3 bucket, making it another option for third party syncing.
+* [System Theme](https://github.com/jgauth/obsidian-system-theme) by `@jgauth` is to help Linux users adapt their theme to adapt to the system theme.
+* [Publish](https://github.com/addozhang/obsidian-publish-plugin) by `@addozhang`  makes it easier to upload local images embedded in markdown to a remote store, and export markdown for publishing to static site.
+* [Blockquote Levels](https://github.com/czottmann/obsidian-blockquote-levels) by `@czottmann`  adds commands for increasing/decreasing the blockquote level of the current line or selection.
+
+### Updates
+
+_If you want a comprehensive list of what plugins updated this week, check out this [plugin updates index](https://obsidian-plugin-stats.vercel.app/updates) by Ganessh Kumar._
+
+* The folks over at Club Macstories [updated](https://www.macstories.net/news/ios-16-review-extras-ebooks-shortcuts-making-of-and-an-obsidian-plugin/) [Export Markdown with Embeds](https://club.macstories.net/posts/export-markdown-with-embeds), an Obsidian plugin for longform writing, and added new syntax for highlighting and compiling passages of text from a longform story.
+* [Database Folder](https://github.com/RafaelGB/obsidian-db-folder/releases/tag/2.5.0) now has mobile support, the option to import CSVs from the menu, and new metadata options for inlinks and outlinks. 2.6.0 added a new type of column for defining rules to display information about other cells in the same row.
+* [Sentence Navigator v1.1.1](https://github.com/timhor/obsidian-sentence-navigator/releases/tag/1.1.1) added a setting to configure sentence regex.
+* The [editing toolbar](https://github.com/cumany/obsidian-editing-toolbar/releases) added a formatting eraser to clear the text formatting, and now works fine in popout windows.
+* [FleetingNotesApp 0.3.5](https://github.com/fleetingnotes/fleeting-notes-obsidian/releases/tag/0.3.5) sync to Obsidian pluigin lets usres set default sync folder to FleetingNotesApp, added `created_date` and `modified_date` as variables, and more.
+* [Metadata Menu](https://github.com/mdelobelle/metadatamenu) now supports timeshifting: you can now set shift intervals to push Date fields in the future. It's useful for spaced repetition and project management. Here's [a demo](https://youtu.be/6dEk9no269g).
+* [Bulk Rename 0.3.5](https://github.com/OlegLustenko/obsidian-bulk-rename/releases/tag/0.3.5) got a nice UI overhaul.
+* [Readwise Inbox for Obsidian](https://github.com/TfTHacker/obsidian-readwise-inbox) added tag support. Here's a nifty [walkthrough](https://twitter.com/TfTHacker/status/1502376427701870597).
+* [Supercharged Links v0.9.0](https://github.com/mdelobelle/obsidian_supercharged_links) now also supercharges tab headers.
+* [The Path Finder Plugin](https://github.com/jerrywcy/obsidian-path-finder) now supports hotkeys.
+
+### Betas
+
+_Note: these plugins have not yet been submitted for code review, and are being made available primarily for testing purposes._
+
+* [Inline Scripts 0.22.0](https://github.com/jon-heard/obsidian-inline-scripts/releases/tag/0.22.0) added a panel that allows a user to add custom buttons that run shortcuts when clicked, shortcut links, tutorial videos, and UI supplements. Here's a [demo](https://www.youtube.com/watch?v=wOxZwovPfxg).
+
+## Feature Requests
+
+* [Querying by parent bullet](https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/1127) a la a "traditional" outliner would require a complete re-write of the Tasks plugin code... which doesn't mean it's impossible 👀 if anyone is up for creating a way to store full information about the tree of indented bullets it is within, I imagine some folks would be grateful.
+* Share if you'd like [the vault name to always be visible, even if you click away from the Files pane](https://forum.obsidian.md/t/vault-name-should-always-be-visible/43413/3).
+
+## Appearance
+
+* [v6.6 of CyberGlow](https://github.com/ArtexJay/Obsidian-CyberGlow/releases/tag/v6.6) revamped light mode, added stylized callouts that support `<cite>` tags, and more.
+
+## Ancillary Code
+
+* Here's a CSS snippet to make [code blocks look a little fancier](https://github.com/TheKoTech/obsidian_code_snippet).
+* Here's a CSS snippet to [hide block IDs in live preview](https://www.reddit.com/r/ObsidianMD/comments/xd0sir/hidden_block_id_snippet/).
+
+## Guides
+
+* This has been out for awhile, but it came up again on Twitter this week, and it's a method I use too so I want to share it again. Here's [how to use Fantasy Calendar plugin to create a content calendar in Obsidian](https://www.youtube.com/watch?v=iU60ItemuDo).
+* Here's a nice guide for Mac users to [create Hazel rules](https://twitter.com/hstagner/status/1569384103350534144) for organizing notes and automating repeated tasks.
+* Here's a [guide to using the PodNotes plugin](https://youtu.be/SGLfuN15uJY).
+* Here's a guide for using the [ExcaliBrain Obsidian plugin](https://www.youtube.com/watch?v=gqEtn3gCZF0) as an alternative to graph view.
+
+## Discussions
+
+* Reddit had a neat discussion about [structured vs. unstructured linking](https://www.reddit.com/r/ObsidianMD/comments/xa0khr/cleaned_up_my_obsidian_with_a_focus_on_a_clean/).
+
+## Showcases
+
+* This is a [dataview example vault](https://github.com/s-blu/obsidian_dataview_example_vault) is a fully functional downloadable vault intended to collect and explain various dataview queries, from based examples to complex javascript based ones. There's also a nice overview section.
+* Here's a [vault on github](https://github.com/gigaSecure/Tech-Notes) of about 500 notes about computers, software, programming, etc. There's also a nice list of note-taking methods used in its creation.
+
+## Ancillary Tools
+
+* The Alfred Workflow for Obsidian ([Shimmering Obsidian v.2.27.4](https://github.com/chrisgrieser/shimmering-obsidian#shimmering-obsidian-)) was updated for Obsidian v0.16 and now has support for enabling and disabling plugins via the Advanced URI plugin; 3.0 migrated to Alfred 5 options, re-wrote the docs, and deprecated the Daily Note features -- check out [this alternative](https://github.com/hauselin/obsidian-alfred) if you relied on it.
+* Glasp now allows users to [highlight YouTube video transcripts](https://medium.com/glasp/tutorial-how-to-highlight-youtube-transcript-30b5430efbe) and export them as Markdown.
+* Nicole van der Hoeven shared [why she likes Readwise Reader](https://www.youtube.com/watch?v=uNH1JDOmGJw). At 16:31 she talks about how she uses it with Obsidian.
+* Relatedly, this month's premium tips edition was all about [how I use RSS to curate opportunities](https://www.obsidianroundup.org/using-rss-to-curate-opportunities/), and although Readwise Reader isn't limited to RSS and it's entirely possible to replicate the workflow described using things other than Reader, there is a screenshot of how I take notes in Reader and send them to Obsidian.

--- a/01 - Community/Obsidian Roundup/2022-09-24 Community Contest & Spaced Repetition Improvements.md
+++ b/01 - Community/Obsidian Roundup/2022-09-24 Community Contest & Spaced Repetition Improvements.md
@@ -1,0 +1,96 @@
+---
+link: https://www.obsidianroundup.org/obsidian-october/
+author: Eleanor Konik
+published: 2022-09-24T12:30:10
+publish: true
+---
+
+# 2022-09-24: Community Contest & Spaced Repetition Improvements
+There's a new interactive medical terminology dictionary, & a step-by-step guide to setting up a second brain in minutes per day.
+
+## In The Community
+
+* It's almost October, so it's time to gear up for this year's annual Obsidian October event. The theme is "Back to School" (best creation for college students, graduate students, and specific subject matter will earn bonus prizes) and they've expanded the categories to include: new plugin (or significant update), video, demo vault, or written content. Here's the [daily progress and learnings](https://forum.obsidian.md/t/obsidian-october-2022-daily-progress-and-learnings/43767) thread, and the [official hub page](https://publish.obsidian.md/hub/01+-+Community/Events/Obsidian+October+2022). There's more clarification in Discord. If anyone is looking to contribute to an existing plugin, the [Hub has collected some issues of interest](https://publish.obsidian.md/hub/01+-+Community/Contributing+to+the+Community/Plugins+seeking+help).
+* Despite how many fiction options there were, first book for the book club is going to be How to Take Smart Notes. The current season will end December 13. Here's more in Discord about [how the voting looked](https://discord.com/channels/686053708261228577/1009112156064718951/1021767699073867786).
+
+## Obsidian Updates
+
+[Insider v0.16.3](https://forum.obsidian.md/t/obsidian-release-v0-16-3-insider-build/43654) Highlights:
+
+* The new Insider now has per tab history, which marks another plugin feature getting [sherlocked](https://en.wikipedia.org/wiki/Sherlock_(software)) into core; thanks to `@pjeby` for pioneering [Pane Relief](https://github.com/pjeby/pane-relief/releases/tag/0.4.0) and helping out with this feature that I for one rely on. If you are using insider builds, please update your Pane Relief version to 0.4.0 _before_ you launch Obsidian 0.16.3.
+* The Sliding Panes plugin will now automatically be disabled on startup.
+* They added an option to Export to PDF to show the name of the note at the beginning of the document.
+* Legacy themes are no longer deleted when updating to 0.16 compatible themes. This should improve compatibility when syncing to a device that’s not yet 0.16 compatible.
+
+## Plugin News
+
+### New in Community Plugins
+
+_These plugins went through code review and are now available in Obsidian's plugin list._ For the full list, check out the [plugin stats page](https://obsidian-plugin-stats.vercel.app/new).
+
+* [Quick snippets and navigation](https://github.com/aciq/obsidian-keyboard-shortcuts) by `@aciq`  adds up/down keyboard navigation for headings and the ability to copy code blocks via a keyboard shortcut.
+* [Google Calendar](https://github.com/YukiGasai/obsidian-google-calendar) by `@YukiGasai`  lets users interact a Google Calendar from inside Obsidian.
+
+### Pending (as of Friday morning)
+
+_Note: Not all new plugins are available in the community list yet, as they need to go through code review first. You can manually install plugins that aren't in the community list yet by using the [Beta Reviewer's Auto-update Tool](https://github.com/TfTHacker/obsidian42-brat). Note, though, that this is not as safe as waiting for them to go through code review._
+
+* [HTML Reader](https://github.com/nuthrash/obsidian-html-plugin) by `@nuthrash`  lets Obsidian open documents with ".html" and ".htm" file extensions.
+* [Obsidian Sqlite3](https://github.com/windily-cloud/obsidian-sqlite3) by `@windily-cloud`  gives Obsidian the ability to manipulate sqlite3 databases.
+* [Aosr](https://github.com/linanwx/aosr) by `@linanwx`  is "another obsidian spaced repetition" plugin.
+* [Week Planner](https://github.com/rwirdemann/obsidian-week-planner) by `@rwirdemann`  defines commands for creating planning documents and moving tasks between them.
+* [Sakana Widget](https://github.com/Quorafind/obsidian-sakana-widget) by `@Quorafind`  adds a cute character widget to your interface.
+* [Imgbb Plugin](https://github.com/notmmaoo/obsidian-imgbb-plugin) by `@notmmaoo`  uploads images to Imgbb for Obsidian.
+* [obsidian floating toc](https://github.com/cumany/obsidian-floating-toc-plugin) by `@cumany`  is a floating Toc plugin that hovers a table of content containing a header level on the notes sidebar.
+
+### Updates
+
+_If you want a comprehensive list of what plugins updated this week, check out this [plugin updates index](https://obsidian-plugin-stats.vercel.app/updates) by Ganessh Kumar._
+
+* [Templater 0.14.2](https://github.com/SilentVoid13/Templater) updated to the most recent version of Obsidian's API and go some nice bugfixes, including that syncing a new note with templates no longer... triggers the template. Also, I have a sneaking suspicion that if enough people joined the `#templater` [thread in Discord](https://discord.com/channels/686053708261228577/875720842443649045) that we filled up the thread and had to add a new channel, `shabogem` (one of the maintainers) would be overjoyed. So if you wanted to say thank you to the devs who work on this project, I suspect that's a good place to do it ;)
+* [Bulk Rename](https://github.com/OlegLustenko/obsidian-bulk-rename/releases/tag/0.4.0) lets you use RegExp to search files to rename.
+* [Linter](https://github.com/platers/obsidian-linter/releases/tag/1.5.0) has a new project board, and added custom commands, formatting for ordered lists, and the ability to copy tags into the frontmatter.
+* [Literate Styles v0.2.0](https://github.com/johanfriis/obsidian-literate-styles/releases/tag/0.2.0), for writing theme css in Obsidian itself, changes the flavour of css from sass to less, to improve bundle size and performance.
+
+### Betas
+
+_Note: these plugins have not yet been submitted for code review, and are being made available primarily for testing purposes._
+
+* Here's a plugin to [alert you if a note hasn't been updated](https://github.com/tadashi-aikawa/obsidian-old-note-admonitor) over a specific number of days.
+* [Inline Scripts](https://github.com/jon-heard/obsidian-inline-scripts/releases/tag/0.22.2) added an interface with the dice roller plugin and support for virtual cards (here's [a tutorial video](https://www.youtube.com/watch?v=-m4n7d3aKC8)).
+
+### For Developers
+
+* The developer of the new bullet-point-backlinks plugin [Influx](https://github.com/jensmtg/influx) is a bit stumped on how to get it working right in reading view, if you've got any insight into that or want to take a look at the puzzle I'm sure `@jensmtg` would appreciate it.
+
+## Appearance
+
+* There's now an [official dracula theme](https://github.com/dracula/obsidian).
+* [Cyber Glow](https://github.com/ArtexJay/Obsidian-CyberGlow) got some new glow effects and bugfixes and tweaks.
+
+## Guides
+
+* I really enjoyed this thread about [how to set up a second brain in 10 minutes or less per day](https://twitter.com/RichardHaggerty/status/1573315004253839361). It maps out the first 7 days for you in pretty solid detail.
+* Here's a [beginner's guide to the editor settings](https://denisetodd.medium.com/obsidian-editor-settings-for-beginners-b84610ea6ce3).
+* Here's how to create [interactive obsidian-anki flashcards that flip and fade](https://github.com/jeffchiou/obsidiflip), using CSS and two plugins.
+* Here's a [task management system](https://forum.obsidian.md/t/my-task-management-system/36198) that got shared recently.
+
+## Showcases
+
+* Here's someone in Discord [taking a video call and taking notes from within Obsidian](https://media.discordapp.net/attachments/916477002909876265/1020709395216224316/unknown.png).
+* This is an incredible [interactive medical terminology dictionary](https://forum.obsidian.md/t/interactive-medical-terminology-dictionary/43303) intended for use by medical students, and the best part is that it focuses on teaching Latin and Greek _roots_ that are useful for learning medical terms. It's even got dataview queries to help cross-reference related words. It's probably one of the most useful sample vaults I've ever seen.
+* Here's how someone recently [planned a vacation with map view](https://www.reddit.com/r/ObsidianMD/comments/xi42pt/planning_a_vacation_with_map_view/). Incidentally vacation planning is one of my primary uses of Obsidian right now; my 5 year anniversary is coming up 👀 It's not all atomic academic notes, yanno? Although here's a nice [reflection on the atoms of Obsidian](https://samgqroberts.com/posts/the-atoms-of-obsidian-md).
+* Here's how [someone uses Obsidian for writing novels](https://www.reddit.com/r/ObsidianMD/comments/xb869d/i_finally_figured_out_obsidian_using_omd_for/).
+
+## Food for Thought
+
+* Here are some thoughts about [why Obsidian isn't really a notetaking app](https://austingovella.medium.com/why-its-hard-to-get-started-obsidian-s-not-really-a-note-taking-app-75bafbebf6f3) and how that can make it hard to get used to.
+
+## Ancillary Tools
+
+* [iOS 16 + Launcher app](https://apps.apple.com/fi/app/launcher-with-multiple-widgets/id905099592?l=fi) enables Obsidian URL shortcuts on Lock Screen. iOS users can [find more details in Discord](https://discord.com/channels/686053708261228577/864046194195431425/1020371125806571530).
+* The [Raycast Obsidian extension](https://github.com/marcjulianschwarz/obsidian-raycast) was updated.
+
+## Housekeeping
+
+* I got a chance to see [Noteshare](https://noteshare.space/install) in action in the wild (i.e. used by someone in a discord server totally unrelated to Obsidian) this morning and it was really slick! If you want to quickly share a single Obsidian note with folks, this is a great way.

--- a/01 - Community/Obsidian Roundup/2022-10-01 Pandoc, Happiness, & Dataview Tricks.md
+++ b/01 - Community/Obsidian Roundup/2022-10-01 Pandoc, Happiness, & Dataview Tricks.md
@@ -1,0 +1,91 @@
+---
+link: https://www.obsidianroundup.org/2022-10-01/
+author: Eleanor Konik
+published: 2022-10-01T12:30:56
+publish: true
+---
+
+# 2022-10-01: Pandoc, Happiness, & Dataview Tricks
+Weekly notes, Eisenhower matrixes, and my new job with Readwise.
+
+## In The Community
+
+* Dan Allosso is hosting a book club using an Obsidian vault for __Poorly Understood: What America Gets Wrong About Poverty__, by Rank, Eppard, and Bullock. If you're interested in joining, you can probably contact him [on Twitter](https://twitter.com/allossodan).
+
+## Plugin News
+
+* Oliver, the developer of the Pandoc plugin, has rejoined discord and we will be going through his repo and issues and pull-requests / forks through the next week or so and make a plan how to go forward and whether and how to organize the repo in the future (which org, maintainers etc). If you'd like to take part in this in any capacity, please check out the [Pandoc thread in Discord](https://discord.com/channels/686053708261228577/965375879662424136/1023632135032143915).
+
+### New in Community Plugins
+
+__These plugins went through code review and are now available in Obsidian's plugin list.__ For the full list, check out the [plugin stats page](https://obsidian-plugin-stats.vercel.app/new).
+
+* [Super Simple Time Tracker](https://github.com/Ellpeck/ObsidianSimpleTimeTracker) by `@Ellpeck` adds multi-purpose time trackers for your notes!
+* [Copy Search URL](https://github.com/czottmann/obsidian-copy-search-url) by `@czottmann` adds a button to the search view for copying the Obsidian search URL.
+
+### Pending (as of Friday morning)
+
+__Note: Not all new plugins are available in the community list yet, as they need to go through code review first. You can manually install plugins that aren't in the community list yet by using the [Beta Reviewer's Auto-update Tool](https://github.com/TfTHacker/obsidian42-brat). Note, though, that this is not as safe as waiting for them to go through code review.__
+
+* [Duplicate Line Obsidian](https://github.com/1C0D/duplicate-line-obsidian) by `@1C0D` makes it easier to duplicate a line
+* [Keyboard Analyzer](https://github.com/cogscides/obsidian-keyboard-analyzer) by `@cogscides` lets users see and analyse keyboard hotkeys and shortcuts.
+* [Theme Toggler](https://github.com/larsmagnus/obsidian-theme-toggler) by `@larsmagnus` allows users to toggle the theme in Obsidian's panels.
+* [Min Width](https://github.com/doitian/obsidian-min-width) by `@doitian` lets users set the minimum width of the active pane.
+* [Update Relative Links](https://github.com/val3344/obsidian-update-relative-links) by `@val3344` will fix broken relative links after a move.
+
+### Updates
+
+__If you want a comprehensive list of what plugins updated this week, check out this [plugin updates index](https://obsidian-plugin-stats.vercel.app/updates) by Ganessh Kumar.__
+
+* [Front Matter Title Plugin, v2.2.0](https://github.com/Snezhig/obsidian-front-matter-title) added an option to change only links without aliases, show a modal before changing links, and a manager to replace displayed names of links to files with resolved titles.
+* [Tasks plugin, 1.14.0](https://github.com/obsidian-tasks-group/obsidian-tasks/releases/tag/1.14.0) added an option to hide and show urgency, and all "hide" commands now have a "show" equivalent. It's also now compatible with Alternative Checkboxes from `@SlRvb`. [1.15.0](https://github.com/obsidian-tasks-group/obsidian-tasks/releases/tag/1.15.0) added an 'Only future dates' checkbox.
+* Metadata Menu 0.2.0 has lookup fields that work like Dataview's inline expression but are persistent. Here's [a demo](https://youtu.be/ad0nJf8TZP8) and [documentation](https://mdelobelle.github.io/metadatamenu/settings/#lookup-options).
+* [Another Quick Switcher 7.0.0](https://github.com/tadashi-aikawa/obsidian-another-quick-switcher/releases/tag/7.0.0) got some breaking changes, and a bunch of features, including customizable hotkeys in dialogs, backlink search integration, and an "open all in new tabs" command. [7.1.0](https://github.com/tadashi-aikawa/obsidian-another-quick-switcher/releases/tag/7.1.0) added an "open in new tab in background" command in the dialog.
+* You can now use the built-in tab titlebar breadcrumbs to drop down [Quick Explorer](https://github.com/pjeby/quick-explorer/releases/tag/0.2.0) menus and browse through your vault using Obsidian 0.16.3+. You can even switch off QE's titlebar/statusbar crumbs using the Style Settings plugin.
+* [Note Auto Creator v1.3.0](https://github.com/SimonTC/obsidian-note-autocreation/releases/tag/1.3.1) made it possible to limit where note suggestions are collected from, include folder paths in suggestions, and use relative paths when inserting links.
+* [Latex Suite 1.5.0](https://github.com/artisticat1/obsidian-latex-suite/) adds popup preview windows for inline math.
+
+### For Developers
+
+* I'm told it would be helpful if someone put together a tutorial for esbuild with Obsidian -- perhaps as an Obsidian October entry?
+
+## Feature Requests
+
+* What if we could [have a hotkey to repeat our last command?](https://forum.obsidian.md/t/repeat-last-command/44228), or [unfold all callouts](https://forum.obsidian.md/t/add-a-new-command-to-unfold-all-callouts-in-a-note/36343) in a note.
+
+## Appearance
+
+* [SynthWave](https://github.com/marcoluzi/obsidian-synthwave) by `@marcoluzi` is inspired by a VS Code theme of the same name. It reminds me a bit of CyberGlow.
+* [Minimal 6.0.6](https://github.com/kepano/obsidian-minimal/releases/tag/6.0.6) made it so that focus mode supports tabs and tab title bar as separate elements.
+
+## Discussions
+
+* Here's a pretty good discussion about [different types of notetaking systems](https://www.reddit.com/r/ObsidianMD/comments/xn1mt9/other_school_of_thoughts_around_digital/)
+
+## Showcases
+
+* Did you know [Dataview has a calendar mode?](https://www.reddit.com/r/ObsidianMD/comments/xph2ch/period_tracking/) Apparently you can use it for period tracking. You can also use it to [display a random quote](https://www.reddit.com/r/ObsidianMD/comments/xpfk5j/how_to_render_a_random_quote_with_dataviewjs/).
+* Here's a nice explanation of a system to work out of a flat vault (i.e. no folders) with [weekly notes](https://discord.com/channels/686053708261228577/744933215063638183/1023283301357727764).
+* This is a nifty example of an Eisenhower matrix [with panes and the Tasks plugin](https://media.discordapp.net/attachments/965681451297304596/1024599580404350986/eisenhower.png) that was [shared in Discord](https://discord.com/channels/686053708261228577/965681451297304596/1024599580693762068).
+* Here's a vault that is meant to act as a [modern oracle](https://dreaming-moon.com/).
+
+## Food For Thought
+
+* I was reading an article about the difficulties of making a career with "pure" writing and someone joked that I should write an article about my perspective on Getting Things Done. My response was essentially that I subscribe to the Luhmann-esque philosophy of "if I feel like something is difficult or I'm feeling blocked, I go do something else," but right after that exchange I stumbled across an article called [excuse me, but why are you eating so many frogs?](https://experimentalhistory.substack.com/p/excuse-me-but-why-are-you-eating) that summed up my feelings pretty well. It starts off with "I think the devil is real and he wants you to be more productive. He’s everywhere, spreading wickedness disguised as wisdom" and is by the same guy who wrote "[why aren't smart people happier](https://experimentalhistory.substack.com/p/why-arent-smart-people-happier)?" which I found particularly insightful.
+
+## Ancillary Tools
+
+* Folks who use obsidian but sometimes wish they could use obsidian from the terminal should probably check out [Jot](https://news.ycombinator.com/item?id=32962524) -- it's not totally compatible yet but the dev is an obsidian user and discussed adding that feature in the HN comments.
+
+## Housekeeping
+
+On the topic of pursuing happiness...
+
+Remember how over the summer I was seriously considering quitting teaching, but some financial considerations tipped me into the direction of going back for another school year? Well, I'm a month in and while I don't regret the decision... things are not going great. They're probably going as well as I think they could be given my location and the impact the pandemic had on American education (especially from a bureaucratic perspective), but I still miss being able to eat and use the bathroom whenever I need to, if nothing else. And there's a lot else, especially on the technology front.
+
+But right as I was starting to get that panicky "I gotta get out of this" feeling in the pit of my stomach, though, the stars aligned. It turns out Readwise is looking for someone with my skillset – the bug hunting stuff, not the newsletter writing stuff.
+
+I agreed this week to do some part time work for them as a quality assurance specialist. I start next month. It will only be a few hours a week while I'm still teaching full time, but if all goes well I'll be transitioning around June. If you're a Readwise user, you might see me around helping out with some customer-facing things occasionally, but at least for the next few months, the majority of the actual "job" will be behind the scenes.
+
+In fact, during the hiring process they made sure to emphasize that this is not a community management / marketing position and they aren't trying to "buy" any influence over the Roundup or pull me away from the work I currently do in the Obsidian community. I'm going to continue mentioning Readwise's competitors here, along with everything else I think is relevant to the community. That said, it does mean I'll be appending a little conflict-of-interest disclaimer thing to all future mentions of Readwise in the Roundup. It also means I'll be learning more about other notetaking apps, which should be interesting 😅
+

--- a/01 - Community/Obsidian Roundup/2022-10-08 PDF Indexing & Live Preview Table Edits.md
+++ b/01 - Community/Obsidian Roundup/2022-10-08 PDF Indexing & Live Preview Table Edits.md
@@ -1,0 +1,90 @@
+---
+link: https://www.obsidianroundup.org/2022-10-08/
+author: Eleanor Konik
+published: 2022-10-08T12:30:57
+publish: true
+---
+
+# 2022-10-08: PDF Indexing & Live Preview Table Edits
+Tips on time blocking, a dashboard for dataview queries, & management tools for Magic: The Gathering.
+
+## In The Community
+
+_Note: a bunch of great things happen in Discord every week, but the links require you to be logged in to [the community server](https://obsidian.md/community) and generally launch in the browser version of Discord unless you paste them into your app directly. Sorry!_ 
+
+* Today at 1PM ET, Marcus Olsson (who maintains the unofficial plugin developer documentation) will explain accepting user input using commands and ribbon actions to make your plugin more useful. Then, Sam Morrison (who created Buttons and maintains Templater) will talk about how to contribute to popular plugins without writing a single line of code. It'll be on [Twitch](https://www.twitch.tv/obsdmd) and [Youtube](https://www.youtube.com/channel/UCRP5KXKq8Ytc6IH06VWRmkQ/videos).
+* Next week, October 15, Nicole van der Hoeven and Leah Ferguson will have a live discussion of [how to use Obsidian to take good D&D notes](https://twitter.com/leahthedesigner/status/1577288726081900544).
+
+## Obsidian Updates
+
+* v. [0.16.4](https://forum.obsidian.md/t/obsidian-release-v0-16-4-insider-build/44436) & [0.16.5](https://forum.obsidian.md/t/obsidian-release-v0-16-5-insider-build/44532) were mostly bugfixes.
+
+## Plugin News
+
+### New in Community Plugins
+
+_These plugins went through code review and are now available in Obsidian's plugin list._ _For the full list, check out the [plugin stats page](https://obsidian-plugin-stats.vercel.app/new)._
+
+* [System Theme](https://github.com/jgauth/obsidian-system-theme) by `@jgauth` is a plugin to automatically update to system theme.
+* [Blockquote Levels](https://github.com/czottmann/obsidian-blockquote-levels) by `@czottmann` adds commands for increasing/decreasing the blockquote level of the current line or selection.
+
+### Pending (as of Friday morning)
+
+_Not all new plugins are available in the community list yet, as they need to go through code review first. You can manually install plugins that aren't in the community list yet by using the [Beta Reviewer's Auto-update Tool](https://github.com/TfTHacker/obsidian42-brat). Note, though, that this is not as safe as waiting for them to go through code review._
+
+* [Actions URI](https://github.com/czottmann/obsidian-actions-uri) by `@czottmann` adds additional `x-callback-url` endpoints to the app for common actions — it's a clean, super-charged addition to Obsidian URI.
+* [Repeat](https://github.com/prncc/obsidian-repeat-plugin) by `@prncc` is another way to review notes using periodic or spaced repetition.
+* [Readavocado Sync](https://github.com/innneang/obsidian-readavocado-sync) by `@innneang` makes it easier to sync Readavocado highlights with Obsidian
+* [Plugin Update Tracker](https://github.com/swar8080/obsidian-plugin-update-tracker) by `@swar8080` makes it easier to know when installed plugins have updates and evaluate the risk of upgrading
+* [Obsidian MtG](https://github.com/omardelarosa/obsidian-mtg) by `@omardelarosa` is a plugin for managing Magic: The Gathering decks and card lists as Obsidian notes.
+* [Sync Graph Settings](https://github.com/Xallt/sync-graph-settings) by `@Xallt` makes it easier to sync graph settings (like Color Groups) to local graphs
+
+### Updates
+
+_If you want a comprehensive list of what plugins updated this week, check out this [plugin updates index](https://obsidian-plugin-stats.vercel.app/updates) by Ganessh Kumar._
+
+* [Another Quick Switcher 7.1.0](https://github.com/tadashi-aikawa/obsidian-another-quick-switcher/releases/tag/7.1.0) added an "open in new tab in background" command in the dialog.
+* [Front Matter Title 2.3.0](https://github.com/Snezhig/obsidian-front-matter-title/tree/2.3.0) added support for the Starred plugin.
+* [Obsidian Linter](https://github.com/platers/obsidian-linter) v1.6.0 now has the ability to search settings and has them broken into tabs on both desktop and mobile.
+* [Notion Like Tables](https://github.com/trey-wallis/obsidian-notion-like-tables/releases/tag/5.0.0) got a major rework and now will __allow you to edit tabular data in live preview mode.__ Note that previously-created tables will need to be migrated.
+
+### Betas
+
+_Note: these plugins have not yet been submitted for code review, and are being made available primarily for testing purposes._
+
+* [Omnisearch](https://github.com/scambier/obsidian-omnisearch/releases/tag/1.6.5-beta) is looking for beta testers for its new __PDF indexing__. This is a feature that I, personally, have really been looking forward to having in Obsidian and I'm extremely grateful for the hard work `@Sim` put into it.
+
+## Ancillary Code
+
+* Here's a dataview query to [list tasks by priority](https://discord.com/channels/686053708261228577/1014259487445622855/1027026939862597702) that was posted in Discord.
+
+## Guides
+
+* Tyler Suzuki on Twitter explained the benefits of how he uses tags to [keep track of his 12 top-of-mind problems](https://twitter.com/tsuzukinelson/status/1564721464317685760) and relate them to whatever he's writing about.
+* Nicole van der Hoeven did a nice, practical video about how to choose between [Dataview and Database Folder](https://t.co/I3ej0LGTf3) for a specific use-case; tracking kickstarters.
+* Marcus Olsson Learn did a great community event about [how to get up and running with building your first plugin](https://www.youtube.com/watch?v=CtR-d-gyxHg), no previous experience required!
+* [Basic Dataview Query Builder v1.0](https://s-blu.github.io/basic-dataview-query-builder/) is designed to help make Dataview more accessible. Give it a spin!
+* I really loved this [visual of a zettelkasten process](https://discord.com/channels/686053708261228577/710585052769157141/1027776810143985696) from `@Kristoffer#4553` in Discord.
+* Here's how to [do time blocking with the Tasks plugin](https://www.reddit.com/r/ObsidianMD/comments/xuduzc/how_to_do_time_blocking_with_the_tasks_plugin/).
+
+## Discussions
+
+* Here's Nick Milo and Tiago Forte talking about [the rise of Obsidian as a Second Brain](https://www.youtube.com/watch?v=nz99I7apNLI&t=1s).
+* Michael Brener Marcus interviewed Michael, the creator of the popular Dataview plugin, to learn [how he got started and where Dataview is going](https://www.youtube.com/watch?v=A4TQ_FRsQds).
+* Here's a lovely [reminder from Discord](https://discord.com/channels/686053708261228577/694233507500916796/1027992742799884329) that Obsidian doesn't have to be your "everything app" to still be useful. For example, here's a great task management system that leverages [Todoist and Obsidian together](https://discord.com/channels/686053708261228577/965681451297304596/1027762526567534654) from full time author `@pdworkman#8720`. Conversely, here's a discussion on Reddit with people discussing [what they use Obsidian for](https://www.reddit.com/r/ObsidianMD/comments/xu6gj3/what_do_you_use_obsidian_for/) — and for some folks, it's a lot!
+* Some folks on Reddit discussed [using Obsidian for planning and writing a novel](https://www.reddit.com/r/ObsidianMD/comments/xwcy3i/using_obsidian_for_novel_writingplanning/), which is timely given that National Novel Writing Month is fast approaching.
+
+## Showcases
+
+* Here's a really awesome [trailer for Obsidian](https://www.reddit.com/r/ObsidianMD/comments/xunff0/comment/iqymz5z/?context=3) that was shared on Reddit, and inspired one of my favorite D&D related Obsidian exchanges... but I don't want to spoil the effect ;)
+
+## Ancillary Tools
+
+* MarkDownload, which lets you download a webpage as a markdown file, now has [support for the Advanced URI plugin](https://twitter.com/AnthonyBaker/status/1573687618080231424).
+* [Actions for Obsidian](https://obsidian.actions.work/) adds Obsidian actions to the Shortcuts app on macOS and iOS.
+* If you want to [clip web content on Android](https://www.reddit.com/r/ObsidianMD/comments/xssu28/heres_the_best_way_that_i_have_found_to_clip_web/), here's a Reddit thread detailing some tips.
+
+## Housekeeping
+
+I had a day off work so I took some time to write down an article for Obsidian October comprehensively covering how I take notes. I've done a couple of explanatory videos but hadn't had anything up to date and written out to point people to for awhile. Unfortunately, I didn't finish it yet, since it's about 5,000 words and growing 🙈 but here's [the twitter thread in which I shared some sneak peeks while I wrote it](https://twitter.com/EleanorKonik/status/1577644860357713922). 
+

--- a/01 - Community/Obsidian Roundup/2022-10-15 Obsidian Out of Beta, Obsidian October Extended.md
+++ b/01 - Community/Obsidian Roundup/2022-10-15 Obsidian Out of Beta, Obsidian October Extended.md
@@ -1,0 +1,93 @@
+---
+link: https://www.obsidianroundup.org/2022-10-15/
+author: Eleanor Konik
+published: 2022-10-15T12:30:44
+publish: true
+---
+
+# 2022-10-15: Obsidian Out of Beta, Obsidian October Extended
+Table generators, advanced project management options, & a guide to Charles Darwin's note taking method.
+
+## In The Community
+
+_Note: a bunch of great things happen in Discord every week, but the links require you to be logged in to [the community server](https://obsidian.md/community) and generally launch in the browser version of Discord unless you paste them into your app directly. Sorry!_ 
+
+* 1.0 has dramatically changed how to create new themes, which is why the original Obsidian October event did not include a "Theme" category. Now that 1.0 is available to everyone, they added a Theme category and extended the deadline for Obsidian October entries by 2 weeks. The deadline is now November 13th. You can find out more in [the Discord channel for the event](https://discord.com/channels/686053708261228577/1022167089345216522/1030509531568025671).
+
+There will be an hour long live session every Saturday throughout October.
+
+* At 1PM Eastern, Stephan (`@kepano`), designer of Minimal and the new default theme, will be doing a live walkthrough of how to create a theme for Obsidian 1.0. Here's the [Discord](https://discord.gg/6kzvuPE9?event=1030119583392223302) link, the [YouTube](https://www.youtube.com/watch?v=8fbw2VRQAhk) link, and the [Twitch](https://www.twitch.tv/obsdmd) link.
+
+Also, the videos of the 2nd week of Obsidian October live sessions are up!
+
+* [Accept user input using commands and ribbon actions](https://www.youtube.com/watch?v=4B8imQQYM94) with Marcus Olsson walks you through accepting user input using commands and ribbon actions to make your plugin more useful.
+* [Templater 101](https://www.youtube.com/watch?v=-PYyO7y0aBs) with Sam Morrison talks about how they started maintaining the Templater plugin, as well as giving some basic examples on how powerful Templater can be. Here are some of the examples that were shown; [daily note, IMDB, and logging](https://shbgm.ca/blog/obsidian/O__O+Templater/O__O+2022+Talk).
+
+## Obsidian Updates
+
+Obsidian is officially out of beta! [Version 1.0](https://forum.obsidian.md/t/obsidian-release-v1-0-0/44873) launched on [ProductHunt](https://www.producthunt.com/posts/obsidian-1-0) and [HackerNews](https://news.ycombinator.com/item?id=33190433). It was also announced on [Reddit](https://www.reddit.com/r/ObsidianMD/comments/y2y2p2/obsidian_release_v100/), the community [discord](https://discord.com/channels/686053708261228577/702717892533157999/1030508945594392637) and [Twitter](https://twitter.com/obsdmd/status/1580548874246443010). Some of the discussions with the team were pretty interesting 👀
+
+As per the shiny new in-app release notes, it comes with a big redesign and the introduction of tabs – which you can now stack, a la the (now mostly deprecated) Sliding Panes plugin. It's a big redesign so might be a little jarring at first, but the devs have been saying that 1.0 means the API will stabilize for as long as I've been using Obsidian, so hopefully this should be the last big breaking update for a good long while. 
+
+Here's a video from Nicole van der Hoeven [going over the update](https://t.co/BVKPgGLgu1). And here was a great discussion about [options for if the change to file titles displays impacted you](https://www.reddit.com/r/ObsidianMD/comments/y3udh4/good_morning_to_everyone_else_who_is_spending/). 
+
+## Plugin News
+
+### New in Community Plugins
+
+_These plugins went through code review and are now available in Obsidian's plugin list._ _For the full list, check out the [plugin stats page](https://obsidian-plugin-stats.vercel.app/new)._
+
+* [Sakana Widget](https://github.com/Quorafind/obsidian-sakana-widget) by `@Quorafind` add a fun little Sakana! Widget to your vault.
+* [Table Generator](https://github.com/Quorafind/Obsidian-Table-Generator) by `@Quorafind` is a plugin to generate markdown tables quickly like in Typora.
+* [Min Width](https://github.com/doitian/obsidian-min-width) by `@doitian` can set the minimum width of the Active Pane.
+* [Aosr](https://github.com/linanwx/aosr) by `@linanwx` is another obsidian spaced repetition option.
+* [Custom File Explorer sorting](https://github.com/SebastianMC/obsidian-custom-sort) by `@SebastianMC` allows for manual and automatic, config-driven reordering and sorting of files and folders in the File Explorer.
+
+### Pending (as of Friday morning)
+
+_Not all new plugins are available in the community list yet, as they need to go through code review first. You can manually install plugins that aren't in the community list yet by using the [Beta Reviewer's Auto-update Tool](https://github.com/TfTHacker/obsidian42-brat). Note, though, that this is not as safe as waiting for them to go through code review._
+
+* [Projects](https://github.com/marcusolsson/obsidian-projects) by `@marcusolsson` enables advanced project management for Obsidian. It lets users create folder-based projects and switch between three different views: Table, Board, and Calendar. It also lets you configure note templates for each project. It's beautiful and makes me desperately wish I could use Obsidian at work. Here's a really [thoughtful post](https://discord.com/channels/686053708261228577/1022167089345216522/1029042785078235187) in Discord he wrote about his motivations for writing it, and how he's planning an API so more views can be integrated 👀
+* [Colorful Tag](https://github.com/rien7/obsidian-colorful-tag) by `@rien7` makes it easier to style your tags.
+* [Obsidian ava](https://github.com/louis030195/obsidian-ava) by `@louis030195` uses OpenAI API and stable diffusion to generate text and enhance reflection in Obsidian.
+* [Capitalize My Titles](https://github.com/joss-enet/obsidian-capitalize-my-titles) by `@joss-enet` will automatically capitalize titles.
+
+### Updates
+
+_If you want a comprehensive list of what plugins updated this week, check out this [plugin updates index](https://obsidian-plugin-stats.vercel.app/updates) by Ganessh Kumar._
+
+* Tasks plugin 1.15.1 improved the next-date calculation for monthly and yearly recurring tasks, to prevent skipping months and years in many cases. Check out the [detailed documentation](https://obsidian-tasks-group.github.io/obsidian-tasks/getting-started/recurring-tasks/#how-the-new-date-is-calculated-repeating-monthly).
+* [CardBoard](https://github.com/roovo/obsidian-card-board/releases/tag/0.5.0) (which provides a kanban-style board for your tasks wherever they are in your vault) updated so that boards can be scaled using a css snippet, tags used in the definition of Boards can be hidden from view on Cards., or Board filters can be used in either Allow (previous behavior) or a Deny (new behavior) mode.
+* Among other things, Metadata Menu can now create a custom values list with a dataview query. Here's [a demo](https://youtu.be/vc55ivQuHuY).
+* The appearance of the [Floating Table of Contents](https://github.com/cumany/obsidian-floating-toc-plugin/) plugin can now be more easily styled, using the Style Settings plugin.
+
+### Betas
+
+_Note: these plugins have not yet been submitted for code review, and are being made available primarily for testing purposes._
+
+* [Omnisearch](https://github.com/scambier/obsidian-omnisearch/releases/tag/1.6.5-beta.3) can now handle PDF indexing – on desktop. Results are cached, and this is still in beta, but it's a really neat feature.
+* The [2.0 beta of Longform](https://github.com/kevboh/longform/releases/tag/2.0.0) (which is useful for handling long form writing projects) corrects outstanding bugs and updates styling to use the 1.0 style system. If you're using BRAT you'll need to manually remove and re-add the plugin, as the version number hasn't changed.
+
+## Appearance
+
+* [Obsidianite](https://github.com/bennyxguo/Obsidian-Obsidianite/releases/tag/v2.0.0) now supports Live Preview mode.
+
+## Guides
+
+* Here's a really comprehensive article about [how tags work in Obsidian](https://medium.com/@noteapps/my-obsidian-tags-are-mine-all-mine-802e4b24682c). Here's a related article from Richard Carter explaining [a really nice, straightforward set of tags](http://richardcarter.com/sidelines/my-notes-tagsonomy/) that complement a book research system. Richard also put together a neat write-up of [Charles Darwin's note taking system](http://richardcarter.com/sidelines/charles-darwins-note-making-system/).
+* This video covers [creating concept notes from literature notes](https://www.youtube.com/watch?v=m6uIoQIKLA4&t=1s). It's pretty similar to some parts of my process, which I finally wrote a comprehensive article describing. If you've ever wanted a written guide to [the Konik Method of Making Notes](https://www.obsidianroundup.org/the-konik-method-for-making-notes/), it went live this week. Financial supporters got it as an email on Monday 💚
+* Here are some thoughts on [the choice to use multiple Obsidian vaults or not](https://medium.com/@noteapps/multiple-obsidian-vaults-oh-my-370b5f007e6e).
+* Here's a [guide for keeping track of people and connections](https://medium.com/@noteapps/keeping-track-of-people-and-connections-in-obsidian-cfd6339b50c), along with an [accompanying discussion on Twitter](https://twitter.com/NoteApps/status/1579134644687364097).
+* Here's an overview of how to use [Obsidian to make technical documentation](https://www.youtube.com/watch?v=cBzc5r-FNW0).
+
+## Showcases
+
+* This is a nice showcase of [the value of the Omnisearch plugin](https://preslav.me/2022/05/31/omnisearch-hidden-gem-for-discovering-content-in-obsidian/), which some folks like because the search feels more comprehensive and natural.
+* Here's a nice example of [using Obsidian to create a flexible working environment for biodiversity researchers](https://twitter.com/nickynicolson/status/1579114497385828353). It takes special advantage of kanbans and workspaces.
+* I really loved this discussion about [how different people use Obsidian for work](https://www.reddit.com/r/ObsidianMD/comments/y0ecbo/how_do_you_use_obsidian_for_work/).
+* Leah in Discord shared how she uses the [Kanban plugin for planning holiday meals](https://discord.com/channels/686053708261228577/744933215063638183/1028450671252480011). Happy belated Thanksgiving to her fellow Canadians.
+
+## Ancillary Tools
+
+* There is an unofficial Chrome extension for Obsidian that allows you to [create or add to existing entries in your notes](https://chrome.google.com/webstore/detail/obsidian-web/edoacekkjanmingkbkgjndndibhkegad) with information you've found online in your browser. It uses the "Local REST API" plugin, which is also helpful for automations.
+* [nb](https://xwmx.github.io/nb/) is a command line and local web note‑taking, bookmarking, archiving, and knowledge base application with pretty good compatibility with Obsidian as far as I can tell. If you decide to try it out, let me know how you liked it!

--- a/01 - Community/Obsidian Roundup/2022-10-22 Improved note relationship sensing & Catppuccinos!.md
+++ b/01 - Community/Obsidian Roundup/2022-10-22 Improved note relationship sensing & Catppuccinos!.md
@@ -1,0 +1,105 @@
+---
+link: https://www.obsidianroundup.org/mobile-pdf-indexing/
+author: Eleanor Konik
+published: 2022-10-22T12:30:48
+publish: true
+---
+
+# 2022-10-22: Improved note relationship sensing & Catppuccinos!
+Kepano shared some thoughts about the AI-assisted text generation plugins, there's a new plugin for RTL/LTR language detection, plus: improved OCR
+
+## In The Community
+
+_Note: a bunch of great things happen in Discord every week, but the links require you to be logged in to [the community server](https://obsidian.md/community) and generally launch in the browser version of Discord unless you paste them into your app directly. Sorry!_ 
+
+The videos of the 3rd week of Obsidian October live sessions are up:
+
+* [Setting up plugin settings](https://www.youtube.com/watch?v=gG4HJ3RbzD4) with Marcus Olsson.
+* [Creating a theme for Obsidian 1.0](https://www.youtube.com/watch?v=tARSN_dSaaI) with Stephan Ango (aka `@kepano`).
+
+## Obsidian Updates
+
+* Obsidian Mobile 1.4.0 updated Mobile to Obsidian 1.0, got a big user interface overhaul, new navigation bars, tabs, haptic feedback, and more. Definitely read [the release notes](https://forum.obsidian.md/t/obsidian-mobile-1-4-0/45618); a lot of things moved around.
+* Insider Desktop builds [v1.0.1](https://forum.obsidian.md/t/obsidian-release-v1-0-1-insider-build/45735/2) and [v1.0.2](https://forum.obsidian.md/t/obsidian-release-v1-0-2-insider-build/45769/2) were both mostly bugfixes.
+* I really enjoyed this [reflection on the update to Obsidian 1.0](https://miscellaneplans.medium.com/obsidian-1-0-frustration-fixes-fidelity-69178347cdea) and how it disrupted things for one user (Ellane W), but she adapted.
+
+## Plugin News
+
+### New in Community Plugins
+
+_These plugins went through code review and are now available in Obsidian's plugin list._ _For the full list, check out the [plugin stats page](https://obsidian-plugin-stats.vercel.app/new)._
+
+* [Influx](https://github.com/jensmtg/influx) by `@jensmtg` is a very exciting alternative backlinks plugin, which displays relevant and formatted excerpts from notes with linked mentions, based on the position of mentions in the notes' hierarchical structure (bullet level indentation).
+* [Doubleshift](https://github.com/Qwyntex/doubleshift) by `@Qwyntex` makes it possible to open the command palette by pressing Shift (or any other key) twice like in IntelliJ and create your own shortcuts
+* [Novel word count](https://github.com/isaaclyman/novel-word-count-obsidian) by `@isaaclyman` displays a word count (and more!) for each file, folder and vault in the File Explorer pane.
+* [Dynamic RTL](https://github.com/mwxgaf/obsidian-dynamic-rtl) by `@mwxgaf` will change the RTL/LTR direction per line / paragraph, depending on the language.
+* [Theme Toggler](https://github.com/larsmagnus/obsidian-theme-toggler) by `@larsmagnus` adds a theme toggle button to each pane in your workspace, allowing users to set the theme on a _per-panel_ basis, along with adding commands to toggle themes between states.
+* [HTML Reader](https://github.com/nuthrash/obsidian-html-plugin) by `@nuthrash` lets users open documents with ".html" and ".htm" file extensions.
+* [Week Planner](https://github.com/rwirdemann/obsidian-week-planner) by `@rwirdemann`defines commands for creating planning documents and moving tasks between them.
+* [Squiggle](https://github.com/jqhoogland/obsidian-squiggle) by `@jqhoogland` enables running squiggle code snippets within a note.
+
+### Pending (as of Friday morning)
+
+_Not all new plugins are available in the community list yet, as they need to go through code review first. You can manually install plugins that aren't in the community list yet by using the [Beta Reviewer's Auto-update Tool](https://github.com/TfTHacker/obsidian42-brat). Note, though, that this is not as safe as waiting for them to go through code review._
+
+* [Relation Pane](https://github.com/mottox2/obsidian-relation-pane) by `@mottox2`displays a panel that summarize relations between notes.
+* [Mathpad](https://github.com/Canna71/obsidian-mathpad) by `@Canna71` is a fancy calculator that works inline and in the sidebar.
+* [Obsidian Things3 Sync](https://github.com/royxue/obsidian-things3-sync) by `@royxue`  syncs between Obsidian and Things3, create Todo and sync Todo status.
+* [qmd as md](https://github.com/danieltomasz/qmd-as-md-obsidian) by `@danieltomasz` provides an initial support for viewing files with .qmd extension. QMD files contain a combination of markdown and executable code cells and are a format supported by Quarto open source publishing system.
+* [Obsidian Github Uploader](https://github.com/yaleiyale/obsidian-github-uploader) by `@yaleiyale` uploads the files in your clipboard to Github.
+* [Status Bar Quote](https://github.com/yesjinu/StatusBarQuote) by `@yesjinu` will display a favored quote in the status bar.
+* [Old Note Admonitor](https://github.com/tadashi-aikawa/obsidian-old-note-admonitor) by `@tadashi-aikawa`shows warnings if the note has not been updated in a period of time you set.
+* [Double Click Tab](https://github.com/Quorafind/Obsidian-Double-Click-Tab) by `@Quorafind`modifies the default behavior when you double click on the tab title, like close tab.
+* [Checkbox 3 states](https://github.com/hrenaud/obsidian-checkbox3states-plugin) by `@hrenaud`adds a third state to checkbox list.
+
+### Updates
+
+_If you want a comprehensive list of what plugins updated this week, check out this [plugin updates index](https://obsidian-plugin-stats.vercel.app/updates) by Ganessh Kumar._
+
+* [Obsidian OCR v1.3.0](https://github.com/MohrJonas/obsidian-ocr/releases/tag/1.3.0) got a bunch of stability and speed improvements, improved installation instructions, previews when searching, and more.
+* [Digital Garden 2.17.0](https://notes.ole.dev/set-up-your-digital-garden/) introduced the option to show backlinks and a local graph in your published notes.
+* [Latex Suite 1.6.0](https://github.com/artisticat1/obsidian-latex-suite/) now allows  you to load snippets from another file, which means you can use an external text editor to edit, backup and share snippets with others.
+* [database folder 2.7.4](https://github.com/RafaelGB/obsidian-db-folder/releases/tag/2.7.4) now has support for nested YAML fields and the ability to edit the name of tags which updates all the rows and files.
+* [Excalidraw 1.7.23](https://github.com/zsviczian/obsidian-excalidraw-plugin/releases/tag/1.7.23) added support for webp, bmp, and ico images, which extends the already supported formats (jpg, gif, png, svg). v1.7.24 also got a bunch of bug fixes and a new hook for changing the styling when the canvas color changes. The automations possible with Excalidraw are incredible.
+* Obsidian Bulk Rename, Media DB Plugin, Buttons, Obsidian Git, Advanced Slides (and probably more!) updated to have improved compatibility with the Obsidian 1.0 update. Please update often as developers adjust to the new stable (!) API.
+
+### Betas
+
+_Note: these plugins have not yet been submitted for code review, and are being made available primarily for testing purposes._
+
+* The [Omnisearch Beta](https://github.com/scambier/obsidian-omnisearch/releases/tag/1.6.5-beta.5) (which allows for PDF indexing) now works on mobile.
+* [Strange New Worlds](https://forum.obsidian.md/t/obsidian-october-2022-daily-progress-and-learnings/43767/13?u=tfthacker), from `@TfTHacker` is meant to help show the interconnections between notes and is sort of a spiritual successor to the Block Ref Counter plugin.
+
+## Appearance
+
+* ITS Theme, Wyrd, CyberGlow, Shimmering Focus (and probably more!) have been updated to work with Obsidian 1.0 – please update your themes if you experience problems.
+* [Fusion](https://github.com/zamsyt/obsidian-fusion) by `@zamsyt` aims at minimalism and has a nice blue tint.
+* The Catppuccino color scheme (a "soothing pastel theme for the high-spirited") is now available in [Catppuccin](https://github.com/catppuccin/obsidian) by `@mbeckrich`, [AnuPpuccin](https://github.com/AnubisNekhet/anuppuccin) by `@AnubisNekhet`, and [Minimal](https://minimal.guide/) by `@kepano`. The latter two support several other popular color schemes as well.
+* [Dayspring](https://github.com/erykwalder/dayspring-theme) by `@erykwalder` looks particularly nice for religious texts: it allows for putting things like verse numbers besides paragraphs in an unobtrusive way, outside of the flow of the main text.
+* Here's a snippet in Discord to [turn the highlightr plugin into a plugin that changes text color](https://discord.com/channels/686053708261228577/855181471643861002/1030379180430462987) just with a custom config & a css snippet.
+
+## Ancillary Code
+
+* Here's a MacOS shortcut that is useful for [intersitial journal entries](https://twitter.com/hstagner/status/1579804046306656258?s=20&t=oC2QljfioVCKe3ozMEa7Eg) explained in both video and written form.
+
+## Guides
+
+* This is a pretty good explanation of how to use Obsidian as a content management system for a website without using the official Publish plugin, with [the Obsidian vault and website directory as sibling directories](https://www.gatlin.io/content/how-i-use-obsidian-as-a-cms-for-my-website) so that it's easier to distinguish between public/private notes. It's a pretty novel approach as far as I know.
+* Here's an excellent [introduction to markdown for beginners](https://twitter.com/n_vanderhoeven/status/1583488865234345984) video.
+* This thread explains a method for [database style queries](https://twitter.com/ThoughtfulAtlas/status/1580251417993805825) with lots of screenshots.
+* Martine Ellis shared a [system for idea generation, journaling, and article outputs](https://twitter.com/MartineGuernsey/status/1581540522594045953).
+* This video describes an approach to [planning music classes & ensembles](https://www.youtube.com/watch?v=YhMVOtzcgX0) using Obsidian.
+
+## Discussions
+
+* There was an interesting folders vs. tags discussion in Discord where some nice thoughts were shared about [the value of neat tags and messy subtags](https://discord.com/channels/686053708261228577/710585052769157141/1033191865228472351).
+* Lots of folks on Twitter shared [meeting notes templates](https://twitter.com/Federico_Presta/status/1582383574224760832?s=20&t=oC2QljfioVCKe3ozMEa7Eg).
+
+## Showcases
+
+* Here's a neat [subscription tracker template](https://www.reddit.com/r/ObsidianMD/comments/y699wi/a_basic_subscription_tracker_template_for/) that uses the Advanced Tables plugin.
+* Here's how Zsolt (developer of the Excalidraw plugin) [integrates time into notes](https://www.youtube.com/watch?v=qIKg_1FNUgk).
+
+## Food For Thought
+
+* `@kepano` shared some [thoughts about AI-assisted writing](https://stephanango.com/photoshop-for-text) in the context of some of the relevant Obsidian plugins: [Text Generator](https://github.com/nhaouari/obsidian-textgenerator-plugin) and [Obsidian Ava](https://github.com/louis030195/obsidian-ava).


### PR DESCRIPTION
## Edited
<!-- Add a brief description here -->
- Regenerated `2022-08-13 Dataview to Mermaid & PDF conversions.md` using the roundup script

## Added
<!-- Add a brief description here-->
- Added `update_roundup.py` to generate a markdown file from Eleanor's Roundup posts.
- 7 files from the last 3 months of the roundup feed at the time of the PR

## Checklist
- [ ] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
