### PR TITLE
Add new step in hub update action that runs update_roundup.py

### DIFF
--- a/.github/workflows/update_hub.yml
+++ b/.github/workflows/update_hub.yml
@@ -49,6 +49,14 @@ jobs:
           git add .
           git commit -m "Add new plugins, themes and authors" || echo "nothing to commit"
 
+      - name: Add new roundup post, update existing if changed
+        run: |
+          cd .github/scripts
+          python3 ./update_roundup.py
+          cd ../..
+          git add .
+          git commit -m "Add new roundup post, update existing if changed" || echo "nothing to commit"
+
       - name: Update MOC files
         run: |
           cd .github/scripts


### PR DESCRIPTION
## Edited
<!-- Add a brief description here -->
Update update_hub.yml to include step to run update_roundup.py

## Added
<!-- Add a brief description here-->

## Checklist
- [ ] before creating a new note, I searched the vault
- [ ] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
