### PR TITLE
Update How to add your theme to the community theme store.md

### DIFF
--- a/04 - Guides, Workflows, & Courses/Guides/How to add your theme to the community theme store.md
+++ b/04 - Guides, Workflows, & Courses/Guides/How to add your theme to the community theme store.md
@@ -16,7 +16,7 @@ The TL;DR is that you have to add the information of your theme to the to the [`
 Your theme must be hosted on GitHub on a public repository. Before submitting your theme, make sure that your repository contains the following:
 1. A `README.md` file in the root of your repo
 2. A screenshot of your theme to be displayed in the community theme store. We recommend using an image of 1920×1080px.
-3. Your `.css` file must be named `obsidian.css` and be at the root of your repository.
+3. Your `.css` file must be named `theme.css` and be at the root of your repository.
 4. It is highly recommended that you add a license to your theme. You can use [Choose a License](https://choosealicense.com/) if you don't know which one to pick.
 5. To submit your theme, you can go ahead and make a [pull request](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork) if you are familiar with git. Otherwise keep reading for instructions on how to submit your theme through GitHub's web interface.
 


### PR DESCRIPTION
This corrects an error in the aforementioned guide.
## Edited
"obsidian.css" -> "theme.css"
## Added


## Checklist
- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
