### PR TITLE
Obsidian October 2022: Fix form link.

### DIFF
--- a/01 - Community/Events/Obsidian October 2022.md
+++ b/01 - Community/Events/Obsidian October 2022.md
@@ -40,7 +40,7 @@ There will be a special channel on Discord to ask questions and chat about your 
 
 ## Submitting your project
 
-Any OOer who finishes their project before the end of November 13, 2022 (extended due to 1.0 release and addition of the theme categories) [anywhere on Earth](https://en.wikipedia.org/wiki/Anywhere_on_Earth) can submit via [this form](https://airtable.com/shrUsaaJcOX7cEA73/) (embedded below, although it will not render if you're viewing this on GitHub).
+Any OOer who finishes their project before the end of November 13, 2022 (extended due to 1.0 release and addition of the theme categories) [anywhere on Earth](https://en.wikipedia.org/wiki/Anywhere_on_Earth) can submit via [this form](https://airtable.com/shraMn6xDv4LwgRvA) (embedded below, although it will not render if you're viewing this on GitHub).
 
 We'll be publicly celebrating O_O contributions after the event wraps up, so you might be featured on the Obsidian website, via Twitter, or elsewhere!
 


### PR DESCRIPTION
Create a PR from @ericaxu's published but un-merged `obsidian-october-2022` branch.

Goal: Try to fix this inconsistency in Obsidian Publish, where the published content differs from that on the default branch...

![image](https://user-images.githubusercontent.com/4840096/202567740-39f28526-2019-4758-9daf-204b25a54f17.png)
