### PR TITLE
Update the location of screenshot images for the Tasks plugin.

### DIFF
--- a/02 - Community Expansions/02.05 All Community Expansions/Plugins/obsidian-tasks-plugin.md
+++ b/02 - Community Expansions/02.05 All Community Expansions/Plugins/obsidian-tasks-plugin.md
@@ -49,16 +49,16 @@ A more convenient way to create a task is by using the `Tasks: Create or edit` c
 
 *All screenshots assume the global filter `#task` which is not set by default (see also "Getting Started").*
 
-![ACME Tasks](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/main/resources/screenshots/acme.png)
+![ACME Tasks](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/gh-pages/docs/images/acme.png)
 The `ACME` note has some tasks.
 
-![Important Project Tasks](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/main/resources/screenshots/important_project.png)
+![Important Project Tasks](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/gh-pages/docs/images/important_project.png)
 The `Important Project` note also has some tasks.
 
-![Tasks Queries](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/main/resources/screenshots/tasks_queries.png)
+![Tasks Queries](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/gh-pages/docs/images/tasks_queries.png)
 The `Tasks` note gathers all tasks from the vault and displays them using queries.
 
-![Create or Edit Modal](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/main/resources/screenshots/modal.png)
+![Create or Edit Modal](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/gh-pages/docs/images/modal.png)
 The `Tasks: Create or edit` command helps you when editing a task.
 
 %% Hub footer: Please don't edit anything below this line %%


### PR DESCRIPTION
Background: https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1287

## Edited

- Edited `02 - Community Expansions/02.05 All Community Expansions/Plugins/obsidian-tasks-plugin.md`, to update to use the new location of Tasks plugin screenshots.
    - The images previously linked-to here and to be deleted as soon as this PR has been merged.
    - Checked by viewing the edited page in Obsidian. It is identical to the previous version.



## Checklist
- [ ] before creating a new note, I searched the vault
- [ ] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
