### PR TITLE
Add pytest-runner to the python dependencies.

### DIFF
--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -3,6 +3,7 @@ pyyaml
 requests
 approvaltests==3.5.0
 pytest
+pytest-runner
 mypy
 types-PyYAML
 types-requests


### PR DESCRIPTION
## Edited
Python dependency listing adding pytest-runner. This was needed for setting up pycharm to run the tests. 

I'm offering it as a PR to help make it easier for future python contributors.
