### PR TITLE
Silence error output on console for correct test of invalid theme.

### DIFF
--- a/.github/scripts/tests/test_themes.py
+++ b/.github/scripts/tests/test_themes.py
@@ -1,6 +1,7 @@
 import contextlib
 import os
 import sys
+import typing
 
 import approvaltests
 from approvaltests import verify
@@ -83,8 +84,9 @@ def verify_theme_data(theme_name: str) -> None:
 
 
 @contextlib.contextmanager
-def silence_stdout():
+def silence_stdout() -> typing.Iterator[None]:
     original_stdout = sys.stdout
     sys.stdout = None
     yield
     sys.stdout = original_stdout
+    None

--- a/.github/scripts/tests/test_themes.py
+++ b/.github/scripts/tests/test_themes.py
@@ -1,4 +1,6 @@
+import contextlib
 import os
+import sys
 
 import approvaltests
 from approvaltests import verify
@@ -24,9 +26,10 @@ def test_collect_data_for_theme_without_settings() -> None:
 def test_reading_theme__with_error_logs_error() -> None:
     theme_name = "InvalidSettingsData"
     theme, css_file, theme_downloads = get_raw_saved_sample_data_for_theme(theme_name)
-
     file_groups: utils.FileGroups = dict()
-    name, valid = theme.collect_data_for_theme_and_css(css_file, theme_downloads, file_groups)
+
+    with silence_stdout():
+        name, valid = theme.collect_data_for_theme_and_css(css_file, theme_downloads, file_groups)
 
     assert name == theme_name
     assert valid == False
@@ -77,3 +80,11 @@ def verify_theme_data(theme_name: str) -> None:
     s.add_frame(approvaltests.utils.to_json(theme.data()))
 
     verify(s)
+
+
+@contextlib.contextmanager
+def silence_stdout():
+    original_stdout = sys.stdout
+    sys.stdout = None
+    yield
+    sys.stdout = original_stdout

--- a/.github/scripts/tests/test_themes.py
+++ b/.github/scripts/tests/test_themes.py
@@ -1,4 +1,5 @@
 import contextlib
+import io
 import os
 import sys
 import typing
@@ -86,7 +87,7 @@ def verify_theme_data(theme_name: str) -> None:
 @contextlib.contextmanager
 def silence_stdout() -> typing.Iterator[None]:
     original_stdout = sys.stdout
-    sys.stdout = None
+    sys.stdout = io.StringIO()
     yield
     sys.stdout = original_stdout
     None


### PR DESCRIPTION
The test is working fine, it is just outputting what looks like an error to the console when it runs. The test itself is testing an invalid case, so that is expected behavior, but we don't need to see the expected error test case console output.

I wrote a little wrapper silence_stdout to suppress the console output just for the bit of the test that produces the confusing looking output.

All the test assertion related output is still printed to the console, and if someone needed to see more details when debugging this test commenting out the `with silence_stdout():` line (and de-indenting the contents of that block) should be easy.

### Test output BEFORE:
```
❯ ./run_tests.sh 
============================================================================================= test session starts =============================================================================================
platform linux -- Python 3.11.0, pytest-7.2.0, pluggy-1.0.0 -- /home/andy/.pyenv/versions/3.11.0/bin/python3
cachedir: .pytest_cache
rootdir: /home/andy/projects/obsidian-hub/.github/scripts/tests, configfile: pytest.ini
collected 25 items                                                                                                                                                                                            

test_add_footer.py::test_consistency_that_search_expression_matches_template PASSED
test_add_footer.py::test_footer_added_if_missing PASSED
test_add_footer.py::test_end_of_line_added_if_missing PASSED
test_add_footer.py::test_footer_updated_if_present PASSED
test_make_mocs.py::test_moc_name_for_directory PASSED
test_make_mocs.py::test_delimiter_detection PASSED
test_make_mocs.py::test_moc_for_empty_directory PASSED
test_make_mocs.py::test_moc_for_root_directory PASSED
test_make_mocs.py::test_updating_moc_with_zoottelkeeper_delimiters PASSED
test_make_mocs.py::test_updating_moc_with_hub_delimiters PASSED
test_plugins.py::test_author_augmented_for_ryanjamurphy PASSED
test_plugins.py::test_author_missing_from_manifest PASSED
test_templates.py::test_all_template_variables_are_valid PASSED
test_templates.py::test_author_from_jinja PASSED
test_templates.py::test_author_from_jinja_minimal PASSED
test_templates.py::test_author_from_templates PASSED
test_templates.py::test_real_data_in_plugin_template PASSED
test_templates.py::test_real_data_in_theme_template PASSED
test_templates.py::test_real_data_in_author_template PASSED
test_themes.py::test_collect_data_for_theme_with_settings PASSED
test_themes.py::test_collect_data_for_theme_without_settings PASSED
test_themes.py::test_reading_theme__with_error_logs_error ERROR processing theme InvalidSettingsData. Error message: while parsing a block mapping
  in "<unicode string>", line 11, column 5:
        id: bt-status-off
        ^
expected <block end>, but found '-'
  in "<unicode string>", line 16, column 5:
        -
        ^
PASSED
test_themes.py::test_rendering_of_theme PASSED
test_update_releases.py::test_process_authors PASSED
test_utils.py::test_get_root_of_vault PASSED

============================================================================================= 25 passed in 0.43s ==============================================================================================
```

Zooming in on this one test
```
test_themes.py::test_reading_theme__with_error_logs_error ERROR processing theme InvalidSettingsData. Error message: while parsing a block mapping
  in "<unicode string>", line 11, column 5:
        id: bt-status-off
        ^
expected <block end>, but found '-'
  in "<unicode string>", line 16, column 5:
        -
        ^
PASSED
```

Note that this last line says PASSED, that is the test_reading_theme__with_error_logs_error test passing. The "ERROR processing theme InvalidSettingsData..." text is from an expected part of this test running and is NOT an indication of a test failure. Very confusing!

### Test output AFTER:
```
❯ ./run_tests.sh
============================================================================================= test session starts =============================================================================================
platform linux -- Python 3.11.0, pytest-7.2.0, pluggy-1.0.0 -- /home/andy/.pyenv/versions/3.11.0/bin/python3
cachedir: .pytest_cache
rootdir: /home/andy/projects/obsidian-hub/.github/scripts/tests, configfile: pytest.ini
collected 25 items                                                                                                                                                                                            

test_add_footer.py::test_consistency_that_search_expression_matches_template PASSED
test_add_footer.py::test_footer_added_if_missing PASSED
test_add_footer.py::test_end_of_line_added_if_missing PASSED
test_add_footer.py::test_footer_updated_if_present PASSED
test_make_mocs.py::test_moc_name_for_directory PASSED
test_make_mocs.py::test_delimiter_detection PASSED
test_make_mocs.py::test_moc_for_empty_directory PASSED
test_make_mocs.py::test_moc_for_root_directory PASSED
test_make_mocs.py::test_updating_moc_with_zoottelkeeper_delimiters PASSED
test_make_mocs.py::test_updating_moc_with_hub_delimiters PASSED
test_plugins.py::test_author_augmented_for_ryanjamurphy PASSED
test_plugins.py::test_author_missing_from_manifest PASSED
test_templates.py::test_all_template_variables_are_valid PASSED
test_templates.py::test_author_from_jinja PASSED
test_templates.py::test_author_from_jinja_minimal PASSED
test_templates.py::test_author_from_templates PASSED
test_templates.py::test_real_data_in_plugin_template PASSED
test_templates.py::test_real_data_in_theme_template PASSED
test_templates.py::test_real_data_in_author_template PASSED
test_themes.py::test_collect_data_for_theme_with_settings PASSED
test_themes.py::test_collect_data_for_theme_without_settings PASSED
test_themes.py::test_reading_theme__with_error_logs_error PASSED
test_themes.py::test_rendering_of_theme PASSED
test_update_releases.py::test_process_authors PASSED
test_utils.py::test_get_root_of_vault PASSED

============================================================================================= 25 passed in 0.43s ==============================================================================================
```