### PR TITLE
Add descriptions to all the plugin category pages.

### DIFF
--- a/02 - Community Expansions/02.01 Plugins by Category/Automation plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Automation plugins.md
@@ -13,20 +13,20 @@ Automatically create, update, or delete notes.
 
 ## Plugins in this category
 
-- [[templater-obsidian|Templater]]
-- [[snippets|Snippets plugin]]
-- [[obsidian-text-expander|Text Expander]]
-- [[text-snippets-obsidian|Text Snippets]]
-- [[buttons|Buttons]]
-- [[python-lab-plugin|Python lab plugin]]
-- [[obsidian-qrcode-plugin|QR Code Generator Plugin]]
-- [[oz-clear-unused-images|Clear Unused Images]]
-- [[obsidian-image-uploader|Image Uploader]]
-- [[macro-plugin|Macros]]
-- [[obsidian-shellcommands|Shell commands]]
-- [[obsidian-autocomplete-plugin|Autocomplete]]
-- [[customjs|CustomJS]]
-- [[obsidian-javascript-init|JavaScript Init]]
+- [[templater-obsidian|Templater]]: Create and use templates
+- [[snippets|Snippets plugin]]: Execute simple scripts/snippets from obsidian. This plugin is experimental
+- [[obsidian-text-expander|Text Expander]]: Expand text shortcuts, run shell commands and python scripts right in your editor
+- [[text-snippets-obsidian|Text Snippets]]: Allows you to replace text templates for faster typing, create your own.
+- [[buttons|Buttons]]: Create Buttons in your Obsidian notes to run commands, open links, and insert templates
+- [[python-lab-plugin|Python lab plugin]]: An interface to experiment with python scripts and more.
+- [[obsidian-qrcode-plugin|QR Code Generator Plugin]]: This is a QR Code Generator plugin for Obsidian.
+- [[oz-clear-unused-images|Clear Unused Images]]: Clear the images that you are not using anymore in your markdown notes to save space.
+- [[obsidian-image-uploader|Image Uploader]]: This plugin uploads the image in your clipboard to any image hosting automatically when pasting.
+- [[macro-plugin|Macros]]: Group multiple Commands into one Macro.
+- [[obsidian-shellcommands|Shell commands]]: You can predefine system commands that you want to run frequently, and assign hotkeys for them. For example open external applications.
+- [[obsidian-autocomplete-plugin|Autocomplete]]: This plugin provides a text autocomplete feature to enhance typing speed.
+- [[customjs|CustomJS]]: This plugin allows for the loading and reuse of custom JS inside your vault.
+- [[obsidian-javascript-init|JavaScript Init]]: Run JavaScript when Obsidian loads, or any other time.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Backup plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Backup plugins.md
@@ -13,8 +13,8 @@ Plugins to backup your notes.
 
 ## Plugins in this category
 
-- [[obsidian-git|Obsidian Git]]
-- [[obsidian-dropbox-backups|Aut-O-Backups]]
+- [[obsidian-git|Obsidian Git]]: Backup your vault with git.
+- [[obsidian-dropbox-backups|Aut-O-Backups]]: Automated backups to Dropbox for your enjoyment.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Chinese Language Plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Chinese Language Plugins.md
@@ -13,9 +13,9 @@ Plugins related to Chinese language
 
 ## Plugins in this category
 
-- [[cm-chs-patch|Word Splitting for Simplified Chinese in Edit Mode]]
-- [[obsidian-pangu|Obsidian Pangu]]
-- [[obsidian-auto-pair-chinese-symbol|Auto pair chinese symbol]]
+- [[cm-chs-patch|Word Splitting for Simplified Chinese in Edit Mode]]: A patch for Obsidian's built-in CodeMirror Editor to support Simplified Chinese word splitting
+- [[obsidian-pangu|Obsidian Pangu]]: 自动为中英文之间插入空格，排版强迫者的福音。
+- [[obsidian-auto-pair-chinese-symbol|Auto pair chinese symbol]]: Auto pair chinese symbol
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Date and calendar plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Date and calendar plugins.md
@@ -13,14 +13,14 @@ Handling dates
 
 ## Plugins in this category
 
-- [[nldates-obsidian|Natural Language Dates]]
-- [[obsidian-juliandate|Julian Date Quick Insert]]
-- [[obsidian-jump-to-date-plugin|Obsidian42 - Jump-to-Date]]
-- [[calendar|Calendar]]
-- [[fantasy-calendar|Fantasy Calendar]]
-- [[big-calendar|Obsidian Big Calendar]]
-- [[obsidian-full-calendar|Full Calendar]]
-- [[heatmap-calendar|Heatmap Calendar]]
+- [[nldates-obsidian|Natural Language Dates]]: Create date-links based on natural language
+- [[obsidian-juliandate|Julian Date Quick Insert]]: Simple hotkey to insert the current Julian Date
+- [[obsidian-jump-to-date-plugin|Obsidian42 - Jump-to-Date]]: Popup calendar for quickly navigating dates
+- [[calendar|Calendar]]: Calendar view of your daily notes
+- [[fantasy-calendar|Fantasy Calendar]]: Fantasy calendars in Obsidian!
+- [[big-calendar|Obsidian Big Calendar]]: A Big Calendar for Obsidian
+- [[obsidian-full-calendar|Full Calendar]]: Obsidian integration with Full Calendar (fullcalendar.io)
+- [[heatmap-calendar|Heatmap Calendar]]: Activity Year Overview for DataviewJS, Github style – Track Goals, Progress, Habits, Tasks, Exercise, Finances, "Dont Break the Chain" etc.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Dictionary and Spellchecking Plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Dictionary and Spellchecking Plugins.md
@@ -16,10 +16,10 @@ publish: true
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
-- [[obsidian-dictionary-plugin|Dictionary]]
-- [[obsidian-languagetool-plugin|LanguageTool Integration]]
-- [[obsidian-orthography|Obsidian Orthography]]
-- [[obsidian-vale|Vale]]
+- [[obsidian-dictionary-plugin|Dictionary]]: This is a simple dictionary for the Obsidian Note-Taking Tool.
+- [[obsidian-languagetool-plugin|LanguageTool Integration]]: Spelling and grammar checks with the LanguageTool API
+- [[obsidian-orthography|Obsidian Orthography]]: Obsidian plugin to check & fix orthography errors in text
+- [[obsidian-vale|Vale]]: A Vale client for Obsidian.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Discontinued plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Discontinued plugins.md
@@ -15,13 +15,13 @@ These plugins were once published, but have have since been withdrawn, or are no
 
 %% Add a bullet here and link to the plugins you'd like to categorize - and sort them alphabetically! %%
 
-- [[obsidian-advanced-appearance|Advanced Appearance]]
+- [[obsidian-advanced-appearance|Advanced Appearance]]: Change colors, fonts and other cosmetic settings.
 - [[obsidian-extra-md-commands|Extra Markdown Commands]] (use [[obsidian-smarter-md-hotkeys|Smarter Markdown Hotkeys]] instead.)
-- [[linked-data-helper|Linked Data Helper]]
-- [[linked-data-vocabularies|Linked Data Vocabularies]]
-- [[pdf-to-markdown-plugin|PDF to Markdown]]
-- [[obsidian-stenography-plugin|Stenography]]
-- [[todo-txt|Todo.txt support]]
+- [[linked-data-helper|Linked Data Helper]]: Parse Linked data for Linked Data Vocabularies.
+- [[linked-data-vocabularies|Linked Data Vocabularies]]: Add linked data to the YAML of your notes.
+- [[pdf-to-markdown-plugin|PDF to Markdown]]: Save a PDF's text (headings, paragraphs, lists, etc.) to a Markdown file.
+- [[obsidian-stenography-plugin|Stenography]]: Auto Describe your code with machine learning using the Stenography API
+- [[todo-txt|Todo.txt support]]: Native support for todo.txt files
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Finance plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Finance plugins.md
@@ -13,7 +13,7 @@ publish: true
 
 ## Plugins in this category
 
-- [[ledger-obsidian|Ledger]]
+- [[ledger-obsidian|Ledger]]: Plain text accounting
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Folder management plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Folder management plugins.md
@@ -16,14 +16,14 @@ publish: true
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
-- [[note-folder-autorename|Note Folder Autorename]]
-- [[folder-note-core|Folder Note Core]]
-- [[alx-folder-note|AidenLx's Folder Note]]
-- [[zoottelkeeper-obsidian-plugin|Zoottelkeeper Plugin]]
-- [[folder-note-plugin|Folder Note]]
-- [[obsidian-icon-folder|Obsidian Icon Folder]]
-- [[file-tree-alternative|File Tree Alternative Plugin]]
-- [[file-explorer-note-count|File Explorer Note Count]]
+- [[note-folder-autorename|Note Folder Autorename]]: Turn notes into folders and automaticaly move/rename their folders when they move or are renamed.
+- [[folder-note-core|Folder Note Core]]: Provide core features and API for folder notes
+- [[alx-folder-note|AidenLx's Folder Note]]: Add description, summary and more info to folders with folder notes.
+- [[zoottelkeeper-obsidian-plugin|Zoottelkeeper Plugin]]: This plugin automatically creates, maintains and tags MOCs for all your folders.
+- [[folder-note-plugin|Folder Note]]: Click a folder node to show a note describing the folder.
+- [[obsidian-icon-folder|Obsidian Icon Folder]]: This plugin allows to add an emoji in front of a folder or icon.
+- [[file-tree-alternative|File Tree Alternative Plugin]]: This plugin allows you to have an alternative file tree view.
+- [[file-explorer-note-count|File Explorer Note Count]]: The plugin helps you to see the number of notes under each folder within the file explorer.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Graph plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Graph plugins.md
@@ -15,14 +15,14 @@ publish: true
 ## Plugins in this category
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
-- [[neo4j-graph-view|Neo4j Graph View]]
-- [[adjacency-matrix-maker|Adjacency Matrix Maker]]
-- [[juggl|Juggl]]
-- [[breadcrumbs|Breadcrumbs]]
-- [[graph-analysis|Graph Analysis]]
-- [[obsidian-graphviz|Obsidian Graphviz]]
-- [[persistent-graph|Persistent Graph]]
-- [[obsidian-living-graph|Living Graph]]
+- [[neo4j-graph-view|Neo4j Graph View]]: An Obsidian plugin for advanced graph visualization and querying using Neo4j.
+- [[adjacency-matrix-maker|Adjacency Matrix Maker]]: Create an interactive image of an adjacency matrix of your vault
+- [[juggl|Juggl]]: Adds a completely interactive, stylable and expandable graph view to Obsidian.
+- [[breadcrumbs|Breadcrumbs]]: Visualise & navigate your vault's structure
+- [[graph-analysis|Graph Analysis]]: Analyse your Obsidian graph.
+- [[obsidian-graphviz|Obsidian Graphviz]]: Render Graphviz Diagrams
+- [[persistent-graph|Persistent Graph]]: Adds commands to save and restore the positions of nodes on the global graph view
+- [[obsidian-living-graph|Living Graph]]: A for-fun graph plugin
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Japanese Language Plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Japanese Language Plugins.md
@@ -13,9 +13,9 @@ Plugins related to Japanese language
 
 ## Plugins in this category
 
-- [[obsidian-markdown-furigana|Markdown Furigana]]
-- [[obsidian-furigana|Furigana]]
-- [[japanese-word-splitter|Word Splitting for Japanese in Edit Mode]]
+- [[obsidian-markdown-furigana|Markdown Furigana]]: Simple Markdown to Furigana Rendering Plugin for Obsidian.
+- [[obsidian-furigana|Furigana]]: Helper plugin for furigana and <ruby>
+- [[japanese-word-splitter|Word Splitting for Japanese in Edit Mode]]: A patch for Obsidian's built-in CodeMirror Editor to support Japanese word splitting
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Markdown formatting plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Markdown formatting plugins.md
@@ -15,11 +15,11 @@ Plugins that make it easier to format or write markdown.
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
-- [[cmenu-plugin|cMenu]]
-- [[obsidian-markdown-formatting-assistant-plugin|Markdown Formatting Assistant]]
-- [[table-editor-obsidian|Advanced Tables]]
-- [[markdown-attributes|Markdown Attributes]]
-- [[obsidian-underline|Underline]]
+- [[cmenu-plugin|cMenu]]: cMenu is a plugin that adds a minimal text editor modal for a smoother writing/editing experience ✍🏽.
+- [[obsidian-markdown-formatting-assistant-plugin|Markdown Formatting Assistant]]: This Plugin provides a simple Editor for Markdown, HTML and Colors and in addition a command line interface. The command line interface facilitate a faster workflow.
+- [[table-editor-obsidian|Advanced Tables]]: Improved table navigation, formatting, manipulation, and formulas
+- [[markdown-attributes|Markdown Attributes]]: Add markdown attributes to elements in Obsidian.md
+- [[obsidian-underline|Underline]]: Add underline(`<u>xxx</u>`) with shortcut, and `<center>xxx</center>`, `[[#xxx]]`, `[[#^xxx]]`
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Mathjax and LaTeX Plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Mathjax and LaTeX Plugins.md
@@ -13,12 +13,12 @@ Plugins to enhance your [[Mathjax]] and [[LaTeX]] experience.
 
 ## Plugins in this category
 
-- [[obsidian-latex-environments|Latex Environments]]
-- [[obsidian-latex|Extended MathJax]]
-- [[quick-latex|Quick Latex for Obsidian]]
-- [[obsidian-export-to-tex|Export To TeX]]
-- [[obsidian-pandoc|Pandoc Plugin]]
-- [[copy-as-latex|Copy as Latex]]
+- [[obsidian-latex-environments|Latex Environments]]: Allows to quickly insert and change latex environments within math environments.
+- [[obsidian-latex|Extended MathJax]]: Adds support for a MathJax preamble and enables additional MathJax extensions for specific domains (chemistry, proofs).
+- [[quick-latex|Quick Latex for Obsidian]]: Speedup latex math typing with auto fraction, align block shortcut, matrix shortcut...etc
+- [[obsidian-export-to-tex|Export To TeX]]: Export vault files in a format amenable to pasting into a tex document
+- [[obsidian-pandoc|Pandoc Plugin]]: This is a Pandoc export plugin for Obsidian. It provides commands to export to formats like DOCX, ePub and PDF.
+- [[copy-as-latex|Copy as Latex]]: Plugin to quickly copy markdown as Latex, with citations
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Mindmapping plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Mindmapping plugins.md
@@ -13,10 +13,10 @@ Display notes as mindmap
 
 ## Plugins in this category
 
-- [[obsidian-mind-map|Mind Map]]
-- [[obsidian-argdown-plugin|Argument Map with Argdown]]
-- [[obsidian-enhancing-mindmap|Enhancing mindmap]]
-- [[obsidian-markmind|Obsidian markmind]]
+- [[obsidian-mind-map|Mind Map]]: A plugin to preview notes as Markmap mind maps
+- [[obsidian-argdown-plugin|Argument Map with Argdown]]: Allows you to write argdown codeblocks and view the maps in Preview
+- [[obsidian-enhancing-mindmap|Enhancing mindmap]]: This is a enhancing mindmap plugin for Obsidian. You can edit mindmap on markdown.
+- [[obsidian-markmind|Obsidian markmind]]: This is a mindmap，outline and pdf annotate tool for obsidian.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/OCR Plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/OCR Plugins.md
@@ -15,7 +15,7 @@ Plugins that add OCR for images and/or PDF.
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
-- [[taskbone-ocr-plugin|Taskbone OCR]]
+- [[taskbone-ocr-plugin|Taskbone OCR]]: Extract text from images and make it available for search.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Paid and subscription-based plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Paid and subscription-based plugins.md
@@ -16,11 +16,11 @@ publish: true
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
-- [[todoist-sync-plugin|Todoist Plugin]]
-- [[readwise-mirror|Readwise Mirror]]
-- [[readwise-official|Readwise Official]]
-- [[obsidian-readwise|Readwise Community]]
-- [[ozanshare-publish|OzanShare Publish]]
+- [[todoist-sync-plugin|Todoist Plugin]]: Materialize Todoist tasks within Obsidian notes.
+- [[readwise-mirror|Readwise Mirror]]: Mirror your Readwise library directly to an Obsidian vault
+- [[readwise-official|Readwise Official]]: Official Readwise <-> Obsidian integration
+- [[obsidian-readwise|Readwise Community]]: Sync Readwise highlights into your notes
+- [[ozanshare-publish|OzanShare Publish]]: Publish your markdown notes with a single click from your vault.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Pane Management plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Pane Management plugins.md
@@ -15,13 +15,13 @@ Plugins to manage or cycle through panes.
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
-- [[sliding-panes-obsidian|Sliding Panes (Andy's Mode)]]
-- [[pane-relief|Pane Relief]]
-- [[cycle-through-panes|Cycle through Panes]]
-- [[maximise-active-pane-obsidian|Maximise Active Pane]]
-- [[obsidian-tabs|Obsidian Tabs]]
-- [[obsidian-focus-mode|Focus Mode]]
-- [[obsidian-fullscreen-plugin|Fullscreen Focus Mode]] 
+- [[sliding-panes-obsidian|Sliding Panes (Andy's Mode)]]: Sliding Panes! Based on the style of [Andy Matuschak's Notes](https://notes.andymatuschak.org/)
+- [[pane-relief|Pane Relief]]: Per-pane history, hotkeys for pane movement + navigation, and more
+- [[cycle-through-panes|Cycle through Panes]]: Cycle through your open Panes with `ctrl + Tab`, just like with Tabs in your Browser!, ctrl+shift+Tab for Reverse
+- [[maximise-active-pane-obsidian|Maximise Active Pane]]: Simply fills the workspace with the active pane
+- [[obsidian-tabs|Obsidian Tabs]]: Opens new leaves in tabs.
+- [[obsidian-focus-mode|Focus Mode]]: Add Focus Mode to Obsidian.
+- [[obsidian-fullscreen-plugin|Fullscreen Focus Mode]]: This plugin allows viewing a single document in fullscreen focus mode
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins Designed for Mobile.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins Designed for Mobile.md
@@ -13,8 +13,8 @@ Special plugins for the Obsidian mobile app.
 
 ## Plugins in this category
 
-- [[advanced-toolbar|Advanced Mobile Toolbar]]
-- [[customjs|CustomJS]]
+- [[advanced-toolbar|Advanced Mobile Toolbar]]: Enhances the Toolbar for Obsidian Mobile.
+- [[customjs|CustomJS]]: This plugin allows for the loading and reuse of custom JS inside your vault.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins for Chess.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins for Chess.md
@@ -13,9 +13,9 @@ publish: true
 
 ## Plugins in this category
 
-- [[chesser-obsidian|Chesser]]
-- [[obsidian-chessboard|Chessboard Viewer]]
-- [[obsidian-chess|Obsidian Chess]]
+- [[chesser-obsidian|Chesser]]: A chess game viewer/editor
+- [[obsidian-chessboard|Chessboard Viewer]]: Render chess positions diagrams in note preview.
+- [[obsidian-chess|Obsidian Chess]]: All you need to create your Chess related notes
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins for Diagrams.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins for Diagrams.md
@@ -15,12 +15,12 @@ Plugins to create diagrams other than [[Mermaid]] (which is [already natively su
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
-- [[obsidian-excalidraw-plugin|Excalidraw]]
-- [[drawio-obsidian|Diagrams]]
-- [[obsidian-plantuml|PlantUML]]
-- [[obsidian-kroki|Kroki]]
-- [[obsidian-nomnoml-diagram|Nomnoml Diagram]]
-- [[obsidian-graphviz|Obsidian Graphviz]]
+- [[obsidian-excalidraw-plugin|Excalidraw]]: An Obsidian plugin to edit and view Excalidraw drawings
+- [[drawio-obsidian|Diagrams]]: Draw.io diagrams for Obsidian. This plugin introduces diagrams that can be included within notes or as stand-alone files. Diagrams are created as SVG files (although .drawio extensions are also supported).
+- [[obsidian-plantuml|PlantUML]]: Render PlantUML Diagrams
+- [[obsidian-kroki|Kroki]]: Render Kroki Diagrams
+- [[obsidian-nomnoml-diagram|Nomnoml Diagram]]: Draw nomnoml diagrams in Obsidian notes
+- [[obsidian-graphviz|Obsidian Graphviz]]: Render Graphviz Diagrams
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins for Editing Notes.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins for Editing Notes.md
@@ -13,44 +13,44 @@ Plugins help in editing like toolbars, auto-completions, sorting, ...
 
 ## Plugins in this category
 
-- [[table-editor-obsidian|Advanced Tables]]
-- [[cm-typewriter-scroll-obsidian|Typewriter Scroll Obsidian Plugin]]
-- [[obsidian-emoji-toolbar|Emoji Toolbar]]
-- [[completed-area|Completed Area]]
-- [[obsidian-citation-plugin|Citations]]
-- [[obsidian-autocomplete-plugin|Autocomplete]]
-- [[obsidian-sort-and-permute-lines|Sort & Permute lines]]
-- [[obsidian-markdown-formatting-assistant-plugin|Markdown Formatting Assistant]]
-- [[various-complements|Various Complements]]
-- [[obsidian-plugin-toc|Table of Contents]]
-- [[obsidian-footnotes|Footnote Shortcut]]
-- [[remember-cursor-position|Remember cursor position]]
-- [[obsidian-outliner|Outliner]]
-- [[find-and-replace-in-selection|Find and replace in selection]]
-- [[obsidian-embedded-note-titles|Embedded Note Titles]]
-- [[table-extended|Table Extended]]
-- [[obsidian-dictionary-plugin|Dictionary]]
-- [[metaedit|MetaEdit]]
-- [[obsidian-smart-typography|Smart Typography]]
-- [[obsidian-text-format|Text Format]]
-- [[obsidian-find-and-replace-in-selection|Find & Replace in Selection]]
-- [[advanced-toolbar|Advanced Mobile Toolbar]]
-- [[cmenu-plugin|cMenu]]
-- [[multi-line-formatting|Multi-line Formatting]]
-- [[emoji-shortcodes|Emoji Shortcodes]]
-- [[obsidian-copy-block-link|Copy Block Link]]
-- [[obsidian-code-block-enhancer|Code Block Enhancer]]
-- [[ghost-fade-focus|Ghost Fade Focus]]
-- [[obsidian-banners|Banners]]
-- [[obsidian-paste-to-current-indentation|Paste to Current Indentation]]
-- [[obsidian-dynamic-toc|Dynamic Table of Contents]]
-- [[obsidian-carry-forward|Carry-Forward]]
-- [[obsidian42-text-transporter|Obsidian42 - Text Transporter]]
-- [[longform|Longform]]
-- [[obsidian-incremental-writing|Incremental Writing]]
-- [[obsidian-html-tags-autocomplete|HTML Tags Autocomplete]]
-- [[advanced-cursors|Advanced Cursors]]
-- [[obsidian-pipe-tricks|Pipe tricks]]
+- [[table-editor-obsidian|Advanced Tables]]: Improved table navigation, formatting, manipulation, and formulas
+- [[cm-typewriter-scroll-obsidian|Typewriter Scroll Obsidian Plugin]]: Typewriter-style scrolling which keeps the view centered in the editor.
+- [[obsidian-emoji-toolbar|Emoji Toolbar]]: Quickly search for and insert emojis into your notes.
+- [[completed-area|Completed Area]]: Move completed to-do items to a seperate completed area.
+- [[obsidian-citation-plugin|Citations]]: Automatically search and insert citations from a Zotero library
+- [[obsidian-autocomplete-plugin|Autocomplete]]: This plugin provides a text autocomplete feature to enhance typing speed.
+- [[obsidian-sort-and-permute-lines|Sort & Permute lines]]: 
+- [[obsidian-markdown-formatting-assistant-plugin|Markdown Formatting Assistant]]: This Plugin provides a simple Editor for Markdown, HTML and Colors and in addition a command line interface. The command line interface facilitate a faster workflow.
+- [[various-complements|Various Complements]]: This plugin enables you to complete words like the auto-completion of IDE
+- [[obsidian-plugin-toc|Table of Contents]]: Create a table of contents for a note.
+- [[obsidian-footnotes|Footnote Shortcut]]: Insert and write footnotes faster
+- [[remember-cursor-position|Remember cursor position]]: Remember cursor and scroll position for each note
+- [[obsidian-outliner|Outliner]]: Work with your lists like in Workflowy or RoamResearch.
+- [[find-and-replace-in-selection|Find and replace in selection]]: Finds what you are looking for in the selected text and replaces it with the specified text
+- [[obsidian-embedded-note-titles|Embedded Note Titles]]: Inserts the note file name as an H1 heading above each note.
+- [[table-extended|Table Extended]]: Enable extended table support with MultiMarkdown 6 syntax
+- [[obsidian-dictionary-plugin|Dictionary]]: This is a simple dictionary for the Obsidian Note-Taking Tool.
+- [[metaedit|MetaEdit]]: MetaEdit helps you manage your metadata.
+- [[obsidian-smart-typography|Smart Typography]]: Converts quotes to curly quotes, dashes to em dashes, and periods to ellipses
+- [[obsidian-text-format|Text Format]]: Format selected text lowercase/uppercase/capitalize/titlecase or remove redundant spaces/newline characters.
+- [[obsidian-find-and-replace-in-selection|Find & Replace in Selection]]: Replace text within your current selection.
+- [[advanced-toolbar|Advanced Mobile Toolbar]]: Enhances the Toolbar for Obsidian Mobile.
+- [[cmenu-plugin|cMenu]]: cMenu is a plugin that adds a minimal text editor modal for a smoother writing/editing experience ✍🏽.
+- [[multi-line-formatting|Multi-line Formatting]]: Apply formatting to selected text, dealing with the paragraph breaks.
+- [[emoji-shortcodes|Emoji Shortcodes]]: This Plugin enables the use of Markdown Emoji Shortcodes :smile:
+- [[obsidian-copy-block-link|Copy Block Link]]: Get links to blocks and headings from Obsidian's right click menu
+- [[obsidian-code-block-enhancer|Code Block Enhancer]]: Enhance obsidian markdown code block,provides copy button,linenumber,language name tip and so on.
+- [[ghost-fade-focus|Ghost Fade Focus]]: Focused on the current line, others faded like a ghost!
+- [[obsidian-banners|Banners]]: Add banner images to your notes!
+- [[obsidian-paste-to-current-indentation|Paste to Current Indentation]]: This plugin allows pasting and marking text as block-quotes at any level of indentation.
+- [[obsidian-dynamic-toc|Dynamic Table of Contents]]: An Obsidian plugin to generate Tables of Contents that stay up to date with your document outline.
+- [[obsidian-carry-forward|Carry-Forward]]: An Obsidian Notes plugin for generating and copying block IDs and for copying lines with links to the copied line.
+- [[obsidian42-text-transporter|Obsidian42 - Text Transporter]]: Advanced text tools for working with text in your vault
+- [[longform|Longform]]: Write novels, screenplays, and other long projects in Obsidian.
+- [[obsidian-incremental-writing|Incremental Writing]]: Incrementally review notes and blocks over time.
+- [[obsidian-html-tags-autocomplete|HTML Tags Autocomplete]]: Autocomplete HTML tags.
+- [[advanced-cursors|Advanced Cursors]]: Use multiple cursors even more powerfully.
+- [[obsidian-pipe-tricks|Pipe tricks]]: Adds support for pipe tricks in Obsidian.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins for Right-To-Left Languages.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins for Right-To-Left Languages.md
@@ -16,7 +16,7 @@ publish: true
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
-- [[obsidian-rtl|RTL Support]]
+- [[obsidian-rtl|RTL Support]]: Right to Left (RTL) text direction support for languages like Arabic, Hebrew and Farsi.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins for Security and Privacy.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins for Security and Privacy.md
@@ -13,9 +13,9 @@ publish: true
 
 ## Plugins in this category
 
-- [[meld-encrypt|Meld Encrypt]]
-- [[privacy-glasses|Privacy Glasses]]
-- [[garble-text|Garble Text]]
+- [[meld-encrypt|Meld Encrypt]]: Hide secrets in your notes
+- [[privacy-glasses|Privacy Glasses]]: Provides a button and command to obfuscate onscreen text for better privacy in public settings.
+- [[garble-text|Garble Text]]: Garbling text in Obsidian turns all content in the entire app (notes, sidebar, etc) into lines so you can take screenshots without exposing sensitive data.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins for TTRPG.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins for TTRPG.md
@@ -16,12 +16,12 @@ publish: true
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
-- [[obsidian-dice-roller|Dice Roller]]
-- [[initiative-tracker|Initiative Tracker]]
-- [[obsidian-5e-statblocks|5e Statblocks]]
-- [[fantasy-calendar|Fantasy Calendar]]
-- [[obsidian-leaflet-plugin|Obsidian Leaflet]]
-- [[generic-initiative-tracker|Generic Initiative Tracker]]
+- [[obsidian-dice-roller|Dice Roller]]: Inline dice rolling for Obsidian.md
+- [[initiative-tracker|Initiative Tracker]]: TTRPG Initiative Tracker for Obsidian.md
+- [[obsidian-5e-statblocks|5e Statblocks]]: Create 5e styled statblocks in Obsidian.md
+- [[fantasy-calendar|Fantasy Calendar]]: Fantasy calendars in Obsidian!
+- [[obsidian-leaflet-plugin|Obsidian Leaflet]]: Interactive maps inside your notes
+- [[generic-initiative-tracker|Generic Initiative Tracker]]: TTRPG Generic Initiative Tracker for Obsidian.md
 
 ## Unlisted plugins
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins for Video and Audio files.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins for Video and Audio files.md
@@ -13,9 +13,9 @@ Handle video/audio files
 
 ## Plugins in this category
 
-- [[media-extended|Media Extended]]
-- [[mx-bili-plugin|Media Extended BiliBili Plugin]]
-- [[podcast-note|Podcast Note]]
+- [[media-extended|Media Extended]]: Media(Video/Audio) Playback Enhancement for Obsidian.md
+- [[mx-bili-plugin|Media Extended BiliBili Plugin]]: Add advanced bilibili videos support for Media Extended plugin
+- [[podcast-note|Podcast Note]]: Podcast Note lets you automatically add podcast information to your notes.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins for Writers.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins for Writers.md
@@ -16,12 +16,12 @@ publish: true
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
-- [[obsidian-fountain|Fountain]]
-- [[longform|Longform]]
-- [[dangerzone-writing-plugin|Dangerzone Writing]]
-- [[obsidian-paper-cut|PaperCut]]
-- [[cm-typewriter-scroll-obsidian|Typewriter Scroll]]
-- [[obsidian-vale|Vale]]
+- [[obsidian-fountain|Fountain]]: Fountain Support for Obsidian
+- [[longform|Longform]]: Write novels, screenplays, and other long projects in Obsidian.
+- [[dangerzone-writing-plugin|Dangerzone Writing]]: “Elegant”, “Dangerous”, “Relaxing”, “Perverted”, “Your best friend”, “Your worst nightmare”. When you start a Dangerzone session, you have to write without stopping for X seconds. If you stop, think and look around, after Y seconds the plugin will DELETE what you've written in this note.
+- [[obsidian-paper-cut|PaperCut]]: Express an idea in the simplest possible way ... or else
+- [[cm-typewriter-scroll-obsidian|Typewriter Scroll]]: Typewriter-style scrolling which keeps the view centered in the editor.
+- [[obsidian-vale|Vale]]: A Vale client for Obsidian.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins for daily notes.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins for daily notes.md
@@ -15,12 +15,12 @@ Plugins to help you navigate or manage daily, weekly or monthly notes.
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
-- [[periodic-notes|Periodic Notes]]
-- [[obsidian-day-planner|Day Planner]]
-- [[obsidian-daily-named-folder|Daily Named Folder]]
-- [[obsidian-daf-yomi|Daf Yomi]]
-- [[random-structural-diary-plugin|Random Structural Diary]]
-- [[calendar|Calendar]]
+- [[periodic-notes|Periodic Notes]]: Create/manage your daily, weekly, and monthly notes
+- [[obsidian-day-planner|Day Planner]]: A plugin to help you plan your day and setup pomodoro timers
+- [[obsidian-daily-named-folder|Daily Named Folder]]: Like daily notes, but nested in a named daily folder. Better for attachment management. Includes more flexible naming.
+- [[obsidian-daf-yomi|Daf Yomi]]: Fill in Daf Yomi pages
+- [[random-structural-diary-plugin|Random Structural Diary]]: This is a plugin for picking random questions from prepared question list. It allows you answer on different questions each time.
+- [[calendar|Calendar]]: Calendar view of your daily notes
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins for vault statistics.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins for vault statistics.md
@@ -13,14 +13,14 @@ Show and display statistic information about your vault.
 
 ## Plugins in this category
 
-- [[youhavebeenstaring-plugin|YouHaveBeenStaring]]
-- [[obsidian-vault-statistics-plugin|Vault Statistics]]
-- [[obsidian-commits|Commits]]
-- [[obsidian-journey-plugin|Journey]]
-- [[obsidian-vault-changelog|Vault Changelog]]
-- [[obsidian-activity-history|Activity History]]
-- [[obsidian-activity-logger|Activity Logger]]
-- [[daily-activity|Daily Activity]]
+- [[youhavebeenstaring-plugin|YouHaveBeenStaring]]: This plugin tells you in the status bar for how long you've been staring at your obsidian vault. Well - at least how long your vault is open.
+- [[obsidian-vault-statistics-plugin|Vault Statistics]]: Status bar item with vault statistics such as number of notes, files, attachments, and links.
+- [[obsidian-commits|Commits]]: Track & show commits in obsidian vault or specified project.
+- [[obsidian-journey-plugin|Journey]]: Discover the stories between your notes.
+- [[obsidian-vault-changelog|Vault Changelog]]: Obsidian plugin to maintain a notes changelog in a vault
+- [[obsidian-activity-history|Activity History]]: Track activity of specified projects, Github like activity board
+- [[obsidian-activity-logger|Activity Logger]]: Log your activities like creating notes, modifying notes, deleting notes and so on.
+- [[daily-activity|Daily Activity]]: A collection of commands to track your writing activity.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins that add or manage hotkeys.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins that add or manage hotkeys.md
@@ -12,29 +12,29 @@ publish: true
 
 ## Plugins in this category
 
-- [[hotkeysplus-obsidian|Hotkeys++]]
-- [[leader-hotkeys-obsidian|Leader Hotkeys]]
-- [[shortcuts-extender|Shortcuts extender]]
-- [[macOS-keyboard-nav-obsidian|macOS Keyboard Navigation]]
-- [[extract-highlights-plugin|Extract Highlights]]
-- [[obsidian-juliandate|Julian Date Quick Insert]]
-- [[obsidian-min3ditorhotkeys-plugin|Min3ditorHotkeys]]
-- [[obsidian-shortcuts-for-starred-files|Hotkeys for starred files]]
-- [[obsidian-hotkeys-for-specific-files|Hotkeys for specific files]]
-- [[obsidian-footnotes|Footnote Shortcut]]
-- [[code-block-from-selection|Code block from selection]]
-- [[format-hotkeys-obsidian|Format Hotkeys]]
-- [[hotkey-helper|Hotkey Helper]]
-- [[obsidian-hotkeys-for-templates|Hotkeys for templates]]
-- [[obsidian-underline|Underline]]
-- [[obsidian-code-copy|Code Copy]]
-- [[editor-commands-remap|Editor Commands Remap]]
-- [[obsidian-command-alias-plugin|Command Alias]]
-- [[obsidian-editor-shortcuts|Code Editor Shortcuts]]
-- [[obsidian-smarter-md-hotkeys|Smarter Markdown Hotkeys]]
-- [[obsidian-global-hotkeys|Global Hotkeys]]
-- [[obsidian-hotkeys-chords|Hotkeys Chords]]
-- [[obsidian-key-sequence-shortcut|Key Sequence Shortcut]]
+- [[hotkeysplus-obsidian|Hotkeys++]]: Additional hotkeys to do common things in Obsidian
+- [[leader-hotkeys-obsidian|Leader Hotkeys]]: Add leader hotkey support to any command (like tmux or vim)
+- [[shortcuts-extender|Shortcuts extender]]: Use shortcuts for text formatting or input special symbols without language switching
+- [[macOS-keyboard-nav-obsidian|macOS Keyboard Navigation]]: This plugin adds alt+up arrow and alt+down arrow keyboard navigation to Obsidian.
+- [[extract-highlights-plugin|Extract Highlights]]: Create, extract and leverage your markdown highlights
+- [[obsidian-juliandate|Julian Date Quick Insert]]: Simple hotkey to insert the current Julian Date
+- [[obsidian-min3ditorhotkeys-plugin|Min3ditorHotkeys]]: Additional editor hotkeys inspired by coding editors
+- [[obsidian-shortcuts-for-starred-files|Hotkeys for starred files]]: Set an individual hotkey for the first 9 starred files and searches and open them just with your keyboard.
+- [[obsidian-hotkeys-for-specific-files|Hotkeys for specific files]]: Set hotkeys for specific files and open them just with your keyboard.
+- [[obsidian-footnotes|Footnote Shortcut]]: Insert and write footnotes faster
+- [[code-block-from-selection|Code block from selection]]: Adds code block for the selected text
+- [[format-hotkeys-obsidian|Format Hotkeys]]: Google Docs style formatting hotkeys for Obsidian
+- [[hotkey-helper|Hotkey Helper]]: Easily see and access any plugin's settings or hotkey assignments (and conflicts) from the Community Plugins tab
+- [[obsidian-hotkeys-for-templates|Hotkeys for templates]]: Add hotkeys to insert specific templates
+- [[obsidian-underline|Underline]]: Add underline(`<u>xxx</u>`) with shortcut, and `<center>xxx</center>`, `[[#xxx]]`, `[[#^xxx]]`
+- [[obsidian-code-copy|Code Copy]]: Easily copy the contents of code blocks in Obsidian.
+- [[editor-commands-remap|Editor Commands Remap]]: Map hotkeys to editor commands.
+- [[obsidian-command-alias-plugin|Command Alias]]: This plugin gives aliases to Obsidian commands.
+- [[obsidian-editor-shortcuts|Code Editor Shortcuts]]: Add keyboard shortcuts (hotkeys) commonly found in code editors such as Visual Studio Code (vscode) or Sublime Text
+- [[obsidian-smarter-md-hotkeys|Smarter Markdown Hotkeys]]: Hotkeys that select words and lines in a smart way before applying markup. Multiple cursors are supported as well.
+- [[obsidian-global-hotkeys|Global Hotkeys]]: Add support for global hotkeys
+- [[obsidian-hotkeys-chords|Hotkeys Chords]]: Set hotkeys chords to activate commands
+- [[obsidian-key-sequence-shortcut|Key Sequence Shortcut]]: Execute obsidian commands with short key sequences. For example, 'tp' for 'Toggle Preview' and 'tb' for 'Toggle Sidebar'. Easier to remember.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins to Enhance Workspaces.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins to Enhance Workspaces.md
@@ -13,8 +13,8 @@ Enhance Obsidian workspaces
 
 ## Plugins in this category
 
-- [[koncham-workspace|koncham workspace]]
-- [[workspaces-plus|Workspaces Plus]]
+- [[koncham-workspace|koncham workspace]]: obsidian workspace enhancements: vertical tabs, and more...
+- [[workspaces-plus|Workspaces Plus]]: Quickly switch and manage workspaces
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins to convert content into markdown.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins to convert content into markdown.md
@@ -13,16 +13,16 @@ Plugins to convert to [[Markdown]].
 
 ## Plugins in this category
 
-- [[convert-url-to-iframe|Convert url to preview (iframe)]]
-- [[wikilinks-to-mdlinks-obsidian|Wikilinks to MDLinks (Markdown Links)]]
-- [[pdf-to-markdown-plugin|PDF to Markdown]]
-- [[obsidian-extract-pdf-highlights|PDF Highlights]]
-- [[obsidian-file-path-to-uri|File path to URI]]
-- [[better-pdf-plugin|Better PDF Plugin]]
-- [[extract-url|Extract url content]]
-- [[obsidian-csv-table|CSV Table]]
-- [[obsidian-pluck|Pluck]]
-- [[obsidian-extract-pdf-annotations|Extract PDF Annotations]]
+- [[convert-url-to-iframe|Convert url to preview (iframe)]]: Convert an url (ex, youtube) into an iframe (preview)
+- [[wikilinks-to-mdlinks-obsidian|Wikilinks to MDLinks (Markdown Links)]]: A plugin that converts wikilinks to markdown links and vice versa
+- [[pdf-to-markdown-plugin|PDF to Markdown]]: Save a PDF's text (headings, paragraphs, lists, etc.) to a Markdown file.
+- [[obsidian-extract-pdf-highlights|PDF Highlights]]: Extract highlights, underlines and annotations from your PDFs into Obsidian
+- [[obsidian-file-path-to-uri|File path to URI]]: Convert file path to uri for easier use of links to local files outside of Obsidian
+- [[better-pdf-plugin|Better PDF Plugin]]: Goal of this Plugin in to implement a native PDF handling workflow
+- [[extract-url|Extract url content]]: Extract url converting content into markdown
+- [[obsidian-csv-table|CSV Table]]: Render CSV data as a table within your notes.
+- [[obsidian-pluck|Pluck]]: Quickly create notes in Obsidian from web pages.
+- [[obsidian-extract-pdf-annotations|Extract PDF Annotations]]: Extract PDF Annotations (Notes and Highlights) and sort them by topics
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins to create charts.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins to create charts.md
@@ -15,11 +15,11 @@ publish: true
 
 ## Plugins in this category
 
-- [[obsidian-charts|Obsidian Charts]]
-- [[obsidian-tracker|Tracker]]
-- [[obsidian-chartsview-plugin|Charts View]]
-- [[obsidian-jupyter|Jupyter plugin]]
-- [[obsidian-plotly|Plotly]]
+- [[obsidian-charts|Obsidian Charts]]: This Plugin lets you create Charts within Obsidian
+- [[obsidian-tracker|Tracker]]: A plugin tracks occurrences and numbers in your notes
+- [[obsidian-chartsview-plugin|Charts View]]: Data visualization solution in Obsidian based on Ant Design Charts.
+- [[obsidian-jupyter|Jupyter plugin]]: This plugin allows code blocks to be executed as Jupyter notebooks.
+- [[obsidian-plotly|Plotly]]: Obsidian plugin, which allow user to embed Plotly charts into markdown notes.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins to edit other file types.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins to edit other file types.md
@@ -13,13 +13,13 @@ Plugins enabling Obsidian to edit files other than markdown `.md`.
 
 ## Plugins in this category
 
-- [[ini-obsidian|ini Editor]]
-- [[txt-as-md-obsidian|txt as md]]
-- [[csv-obsidian|CSV Editor]]
-- [[mdx-as-md-obsidian|mdx as md]]
-- [[obsidian-org-mode|Org Mode]]
-- [[obsidian-fountain|Fountain]]
-- [[obsidian-excalidraw-plugin|Excalidraw]]
+- [[ini-obsidian|ini Editor]]: Edit ini files in Obsidian
+- [[txt-as-md-obsidian|txt as md]]: Edit txt files as if they were markdown
+- [[csv-obsidian|CSV Editor]]: Edit CSV files in Obsidian
+- [[mdx-as-md-obsidian|mdx as md]]: Edit mdx files as if they were markdown
+- [[obsidian-org-mode|Org Mode]]: Add Org Mode support to Obsidian.
+- [[obsidian-fountain|Fountain]]: Fountain Support for Obsidian
+- [[obsidian-excalidraw-plugin|Excalidraw]]: An Obsidian plugin to edit and view Excalidraw drawings
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins to export markdown content.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins to export markdown content.md
@@ -13,11 +13,11 @@ Plugins to convert from [[Markdown]].
 
 ## Plugins in this category
 
-- [[obsidian-export-to-tex|Export To TeX]]
-- [[obsidian-jsonifier|JSONifier]]
-- [[obsidian-static-file-server|Static File Server]]
-- [[obsidian-pandoc|Obsidian Pandoc]]
-- [[mochi-cards-exporter|Mochi Cards Exporter]]
+- [[obsidian-export-to-tex|Export To TeX]]: Export vault files in a format amenable to pasting into a tex document
+- [[obsidian-jsonifier|JSONifier]]: Select text that you want to JSON.stringify(), or JSON.parse(). Select text and use the keystroke and the transformation will be copied to your clipboard. Paste it wherever you want.
+- [[obsidian-static-file-server|Static File Server]]: Host obsidian subfolders as static file servers.
+- [[obsidian-pandoc|Obsidian Pandoc]]: This is a Pandoc export plugin for Obsidian. It provides commands to export to formats like DOCX, ePub and PDF.
+- [[mochi-cards-exporter|Mochi Cards Exporter]]: Export Markdown notes to Mochi cards from within obsidian
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins to handle images.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins to handle images.md
@@ -13,11 +13,11 @@ Plugins to handle image files.
 
 ## Plugins in this category
 
-- [[obsidian-gallery|Gallery]]
-- [[obsidian-image-toolkit|Obsidian Image Toolkit]]
-- [[obsidian-banners|Banners]]
-- [[copy-url-in-preview|Copy Image and URL in Preview]]
-- [[oz-image-plugin|Ozan's Image in Editor Plugin]]
+- [[obsidian-gallery|Gallery]]: Main Gallery to tag / filter / add notes to images. Display blocks to embed images inside notes. Display block to an image information
+- [[obsidian-image-toolkit|Obsidian Image Toolkit]]: This plugin provides some image viewing toolkit.
+- [[obsidian-banners|Banners]]: Add banner images to your notes!
+- [[copy-url-in-preview|Copy Image and URL in Preview]]: Copy Image and Copy URL context menu in preview mode
+- [[oz-image-plugin|Ozan's Image in Editor Plugin]]: View Images, Transclusions, iFrames and PDF Files within the Editor without a necessity to switch to Preview.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins to manage files and attachments.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins to manage files and attachments.md
@@ -13,15 +13,15 @@ Handle attachments, files, and folders
 
 ## Plugins in this category
 
-- [[obsidian-advanced-new-file|Obsidian Advanced New File]]
-- [[open-with|Open with]]
-- [[obsidian-daily-named-folder|Daily Named Folder]]
-- [[obsidian-file-link|Better File Link]]
-- [[quick-explorer|Quick Explorer]]
-- [[luhman|Luhman]]
-- [[copy-url-in-preview|Copy Image and URL in Preview]]
-- [[consistent-attachments-and-links|Consistent attachments and links]]
-- [[unique-attachments|Unique attachments]]
+- [[obsidian-advanced-new-file|Obsidian Advanced New File]]: This is a plugin for choosing folder on note creation.
+- [[open-with|Open with]]: This Plugin allows you to add multiple other programs to open notes with.
+- [[obsidian-daily-named-folder|Daily Named Folder]]: Like daily notes, but nested in a named daily folder. Better for attachment management. Includes more flexible naming.
+- [[obsidian-file-link|Better File Link]]: A plugin to add better external file links to notes.
+- [[quick-explorer|Quick Explorer]]: Perform file explorer operations (and see your current file path) from the title bar, using the mouse or keyboard
+- [[luhman|Luhman]]: Commands for handling a zettelkasten with Luhmann-style IDs as filenames
+- [[copy-url-in-preview|Copy Image and URL in Preview]]: Copy Image and Copy URL context menu in preview mode
+- [[consistent-attachments-and-links|Consistent attachments and links]]: This plugin ensures the consistency of attachments and links
+- [[unique-attachments|Unique attachments]]: Rename attachments, making their names unique (based on hashing of file content)
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins to manage internal and external links.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins to manage internal and external links.md
@@ -13,31 +13,31 @@ Plugins to manage external or internal links.
 
 ## Plugins in this category
 
-- [[url-into-selection|Paste URL into selection]]
-- [[mrj-crosslink-between-notes|Add links to current note]]
-- [[convert-url-to-iframe|Convert url to preview (iframe)]]
-- [[obsidian-link-indexer|Link indexer]]
-- [[find-unlinked-files|Find unlinked files]]
-- [[obsidian-dangling-links|Dangling links panel]]
-- [[extract-url|Extract url content]]
-- [[obsidian-advanced-uri|Advanced URI]]
-- [[obsidian-auto-link-title|Auto Link Title]]
-- [[obsidian-open-link-with|Open Link With]]
-- [[obsidian-rich-links|Obsidian Rich Links]]
-- [[tag-page-preview|Tag Page Preview]]
-- [[hover-external-link|Hover External Link]]
-- [[obsidian-pluck|Pluck]]
-- [[copy-url-in-preview|Copy Image and URL in Preview]]
-- [[block-reference-count|Block Reference Counts]]
-- [[folder-note-core|Folder Note Core]]
-- [[alx-folder-note|AidenLx's Folder Note]]
-- [[zoottelkeeper-obsidian-plugin|Zoottelkeeper Plugin]]
-- [[folder-note-plugin|Folder Note]]
-- [[link-headers-directly|Link Headers Directly]]
-- [[obsidian-link-archive|Link Archive]]
-- [[obsidian-link-converter|Obsidian Link Converter]]
-- [[supercharged-links-obsidian|Supercharged Links]]
-- [[map-of-content|Map of Content]]
+- [[url-into-selection|Paste URL into selection]]: Paste URL "into" selected text.
+- [[mrj-crosslink-between-notes|Add links to current note]]: This plugin adds a command which allows to add a link to the current note at the bottom of selected notes
+- [[convert-url-to-iframe|Convert url to preview (iframe)]]: Convert an url (ex, youtube) into an iframe (preview)
+- [[obsidian-link-indexer|Link indexer]]: Generate index notes with links based on various conditions
+- [[find-unlinked-files|Find unlinked files]]: Find files that are not linked anywhere and would otherwise be lost in your vault. In other words: files with no backlinks.
+- [[obsidian-dangling-links|Dangling links panel]]: This plugin shows any dangling links in your vault.
+- [[extract-url|Extract url content]]: Extract url converting content into markdown
+- [[obsidian-advanced-uri|Advanced URI]]: Advanced modes for Obsidian URI
+- [[obsidian-auto-link-title|Auto Link Title]]: This plugin automatically fetches the titles of links from the web
+- [[obsidian-open-link-with|Open Link With]]: Open external link with specific browser in Obsidian
+- [[obsidian-rich-links|Obsidian Rich Links]]: Rich Links plugin for Obsidian.
+- [[tag-page-preview|Tag Page Preview]]: Clicking a tag opens a dialog listing pages that use that tag
+- [[hover-external-link|Hover External Link]]: Hover on external links to see the destination URL.
+- [[obsidian-pluck|Pluck]]: Quickly create notes in Obsidian from web pages.
+- [[copy-url-in-preview|Copy Image and URL in Preview]]: Copy Image and Copy URL context menu in preview mode
+- [[block-reference-count|Block Reference Counts]]: Shows the count of block references next to the block-id
+- [[folder-note-core|Folder Note Core]]: Provide core features and API for folder notes
+- [[alx-folder-note|AidenLx's Folder Note]]: Add description, summary and more info to folders with folder notes.
+- [[zoottelkeeper-obsidian-plugin|Zoottelkeeper Plugin]]: This plugin automatically creates, maintains and tags MOCs for all your folders.
+- [[folder-note-plugin|Folder Note]]: Click a folder node to show a note describing the folder.
+- [[link-headers-directly|Link Headers Directly]]: When a header is linked, preview mode will show only the header, and not the note name.
+- [[obsidian-link-archive|Link Archive]]: This plugin archives links in your note so they're available to you even if the original site goes down or gets removed.
+- [[obsidian-link-converter|Obsidian Link Converter]]: Scan all your links in the vault and convert them to your desired format.
+- [[supercharged-links-obsidian|Supercharged Links]]: Add properties and menu options to links and style them!
+- [[map-of-content|Map of Content]]: Automatically generate a Map of Content for your vault
 
 
 ## Related categories

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins to manage or annotate PDF files.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins to manage or annotate PDF files.md
@@ -13,13 +13,13 @@ Plugins that handle PDF files.
 
 ## Plugins in this category
 
-- [[pdf-to-markdown-plugin|PDF to Markdown]]
-- [[obsidian-extract-pdf-highlights|PDF Highlights]]
-- [[better-pdf-plugin|Better PDF Plugin]]
-- [[obsidian-annotator|Annotator]]
-- [[oz-image-plugin|Ozan's Image in Editor Plugin]]
-- [[obsidian-markmind|Obsidian markmind]]
-- [[obsidian-extract-pdf-annotations|Extract PDF Annotations]]
+- [[pdf-to-markdown-plugin|PDF to Markdown]]: Save a PDF's text (headings, paragraphs, lists, etc.) to a Markdown file.
+- [[obsidian-extract-pdf-highlights|PDF Highlights]]: Extract highlights, underlines and annotations from your PDFs into Obsidian
+- [[better-pdf-plugin|Better PDF Plugin]]: Goal of this Plugin in to implement a native PDF handling workflow
+- [[obsidian-annotator|Annotator]]: This is a sample plugin for Obsidian. It allows you to open and annotate PDF and EPUB files.
+- [[oz-image-plugin|Ozan's Image in Editor Plugin]]: View Images, Transclusions, iFrames and PDF Files within the Editor without a necessity to switch to Preview.
+- [[obsidian-markmind|Obsidian markmind]]: This is a mindmap，outline and pdf annotate tool for obsidian.
+- [[obsidian-extract-pdf-annotations|Extract PDF Annotations]]: Extract PDF Annotations (Notes and Highlights) and sort them by topics
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins to navigate notes.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins to navigate notes.md
@@ -13,19 +13,19 @@ publish: true
 
 ## Plugins in this category
 
-- [[mrj-jump-to-link|Jump to link]]
-- [[darlal-switcher-plus|Quick Switcher++]]
-- [[obsidian-reveal-active-file|Automatically Reveal Active File]]
-- [[pane-relief|Pane Relief]]
-- [[obsidian-collapse-all-plugin|Collapse All]]
-- [[homepage|Homepage]]
-- [[file-explorer-markdown-titles|File Explorer Markdown Titles]]
-- [[obsidian-go-to-line|Go to Line]]
-- [[calendar|Calendar]]
-- [[breadcrumbs|Breadcrumbs]]
-- [[obsidian-zoom|Zoom]]
-- [[obsidian-another-quick-switcher|Another Quick Switcher]]
-- [[reveal-active-file-button|Reveal Active File Button]]
+- [[mrj-jump-to-link|Jump to link]]: This plugin allows open a link in current document or regex based navigation in editor mode using hotkey
+- [[darlal-switcher-plus|Quick Switcher++]]: Enhanced Quick Switcher, search open panels, and symbols.
+- [[obsidian-reveal-active-file|Automatically Reveal Active File]]: This plugin will reveal the active file in the navigation when a file is opened.
+- [[pane-relief|Pane Relief]]: Per-pane history, hotkeys for pane movement + navigation, and more
+- [[obsidian-collapse-all-plugin|Collapse All]]: This plugin adds a button to collapse or expand all folders in the file explorer.
+- [[homepage|Homepage]]: Open a specified note on startup.
+- [[file-explorer-markdown-titles|File Explorer Markdown Titles]]: Shows the first markdown header of a note in the file explorer
+- [[obsidian-go-to-line|Go to Line]]: This Plugin provides a go to Line Command
+- [[calendar|Calendar]]: Calendar view of your daily notes
+- [[breadcrumbs|Breadcrumbs]]: Visualise & navigate your vault's structure
+- [[obsidian-zoom|Zoom]]: Zoom into heading and lists.
+- [[obsidian-another-quick-switcher|Another Quick Switcher]]: This is an Obsidian plugin which is another choice of Quick switcher.
+- [[reveal-active-file-button|Reveal Active File Button]]: Add a button to the top of the File Explorer, to reveal the active file.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins with custom codeblock syntax.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins with custom codeblock syntax.md
@@ -13,20 +13,20 @@ Plugins that add specific renderers to Obsidian.
 
 ## Plugins in this category
 
-- [[dataview|Dataview]]
-- [[obsidian-kroki|Kroki]]
-- [[obsidian-wavedrom|Wavedrom]]
-- [[music-code-blocks|Music Sheet Code Blocks]]
-- [[drawio-obsidian|Diagrams]]
-- [[obsidian-plantuml|PlantUML]]
-- [[scales-chords|Scales and Chords]]
-- [[obsidian-5e-statblocks|5e Statblocks]]
-- [[initiative-tracker|Initiative Tracker]]
-- [[obsidian-markdown-furigana|Markdown Furigana]]
-- [[obsidian-query2table|query2table]]
-- [[obsidian-admonition|Admonition]]
-- [[obsidian-pikt|Pikt]]
-- [[obsidian-react-components|React Components]]
+- [[dataview|Dataview]]: Complex data views for the data-obsessed.
+- [[obsidian-kroki|Kroki]]: Render Kroki Diagrams
+- [[obsidian-wavedrom|Wavedrom]]: This is very rough and quick integration of WaveDrom into obsidian
+- [[music-code-blocks|Music Sheet Code Blocks]]: Plugin which renders music notation from code blocks. Uses the `music-abc` language.
+- [[drawio-obsidian|Diagrams]]: Draw.io diagrams for Obsidian. This plugin introduces diagrams that can be included within notes or as stand-alone files. Diagrams are created as SVG files (although .drawio extensions are also supported).
+- [[obsidian-plantuml|PlantUML]]: Render PlantUML Diagrams
+- [[scales-chords|Scales and Chords]]: Use this plugin to capture musical tab notation in your Obsidian vault.  Chords will become clickable links to modal images (provided by scales-chords.com)
+- [[obsidian-5e-statblocks|5e Statblocks]]: Create 5e styled statblocks in Obsidian.md
+- [[initiative-tracker|Initiative Tracker]]: TTRPG Initiative Tracker for Obsidian.md
+- [[obsidian-markdown-furigana|Markdown Furigana]]: Simple Markdown to Furigana Rendering Plugin for Obsidian.
+- [[obsidian-query2table|query2table]]: Represent files returned by a query as a table of their YAML frontmatter
+- [[obsidian-admonition|Admonition]]: Admonition block-styled content for Obsidian.md
+- [[obsidian-pikt|Pikt]]: A plugin to render Pikchr codeblocks.
+- [[obsidian-react-components|React Components]]: This is a plugin for Obsidian. It allows you to write and use React components with Jsx inside your Obsidian notes.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins with custom views.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins with custom views.md
@@ -14,30 +14,30 @@ Plugins that change or add new views, modify how notes are displayed or add popo
 ## Plugins in this category
 
 
-- [[obsidian-mind-map|Mind Map]]
-- [[obsidian-comments|Comments]]
-- [[obsidian-timelines|Timelines]]
-- [[obsidian-daily-stats|Daily Stats]]
-- [[obsidian-gallery|Gallery]]
-- [[obsidian-dice-roller|Dice Roller]]
-- [[obsidian-kanban|Kanban]]
-- [[obsidian-metatable|Metatable]]
-- [[obsidian-2hop-links-plugin|2Hop Links Plugin]]
-- [[obsidian-5e-statblocks|5e Statblocks]]
-- [[obsidian-zoom|Zoom]]
-- [[better-fn|Better footnote]]
-- [[obsidian-habit-tracker|Habit Tracker]]
-- [[obsidian-timeline|Timeline]]
-- [[breadcrumbs|Breadcrumbs]]
-- [[hover-external-link|Hover External Link]]
-- [[obsidian-image-toolkit|Obsidian Image Toolkit]]
-- [[oz-image-plugin|Ozan's Image in Editor Plugin]]
-- [[obsidian-stille|Stille]]
-- [[obsidian-card-view-mode|Card View Mode]]
-- [[obsidian-focus-mode|Focus Mode]]
-- [[obsidian-fullscreen-plugin|Fullscreen Focus Mode]] 
-- [[obsidian-view-mode-by-frontmatter|Force note view mode by front matter]]
-- [[obsidian-map-view|Map View]]
+- [[obsidian-mind-map|Mind Map]]: A plugin to preview notes as Markmap mind maps
+- [[obsidian-comments|Comments]]: Add, track and easily navigate between a note's Comments
+- [[obsidian-timelines|Timelines]]: Create a timeline view of all notes with the specified combination of tags
+- [[obsidian-daily-stats|Daily Stats]]: Track your daily word count across all notes in your vault.
+- [[obsidian-gallery|Gallery]]: Main Gallery to tag / filter / add notes to images. Display blocks to embed images inside notes. Display block to an image information
+- [[obsidian-dice-roller|Dice Roller]]: Inline dice rolling for Obsidian.md
+- [[obsidian-kanban|Kanban]]: Create markdown-backed Kanban boards in Obsidian.
+- [[obsidian-metatable|Metatable]]: Displays the full frontmatter as a table.
+- [[obsidian-2hop-links-plugin|2Hop Links Plugin]]: Add links to other pages at the bottom of the editor.
+- [[obsidian-5e-statblocks|5e Statblocks]]: Create 5e styled statblocks in Obsidian.md
+- [[obsidian-zoom|Zoom]]: Zoom into heading and lists.
+- [[better-fn|Better footnote]]: Footnote popover for Obsidian
+- [[obsidian-habit-tracker|Habit Tracker]]: This plguin creates a simple Month view for visualizing your punch records.
+- [[obsidian-timeline|Timeline]]: Used to build great timelines
+- [[breadcrumbs|Breadcrumbs]]: Visualise & navigate your vault's structure
+- [[hover-external-link|Hover External Link]]: Hover on external links to see the destination URL.
+- [[obsidian-image-toolkit|Obsidian Image Toolkit]]: This plugin provides some image viewing toolkit.
+- [[oz-image-plugin|Ozan's Image in Editor Plugin]]: View Images, Transclusions, iFrames and PDF Files within the Editor without a necessity to switch to Preview.
+- [[obsidian-stille|Stille]]: Focus on your writing, a section at a time.
+- [[obsidian-card-view-mode|Card View Mode]]: Enable to view your notes as cards.
+- [[obsidian-focus-mode|Focus Mode]]: Add Focus Mode to Obsidian.
+- [[obsidian-fullscreen-plugin|Fullscreen Focus Mode]]: This plugin allows viewing a single document in fullscreen focus mode
+- [[obsidian-view-mode-by-frontmatter|Force note view mode by front matter]]: This plugin allows to force the view mode (preview or source) for a note by using front matter
+- [[obsidian-map-view|Map View]]: An interactive map view.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Refactoring and auto-formatting plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Refactoring and auto-formatting plugins.md
@@ -13,19 +13,19 @@ Plugins that help you refactor and reformat your notes. These plugins offer addi
 
 ## Plugins in this category
 
-- [[note-refactor-obsidian|Note Refactor]]
-- [[markdown-prettifier|Markdown prettifier]]
-- [[footlinks|Footlinks]]
-- [[obsidian-plugin-prettier|Prettier Format]]
-- [[obsidian-tidy-footnotes|Tidy Footnotes]]
-- [[easy-typing-obsidian|Easy Typing]]
-- [[obsidian-title-index|Obsidian title index]]
-- [[obsidian-linter|Linter]]
-- [[obsidian-regex-pipeline|Regex Pipeline]]
-- [[number-headings-obsidian|Number Headings]]
-- [[tag-wrangler|Tag Wrangler]]
-- [[obsidian-task-archiver|Obsidian Task Archiver]]
-- [[completed-area|Completed Area]]
+- [[note-refactor-obsidian|Note Refactor]]: Extract note content into new notes and split notes
+- [[markdown-prettifier|Markdown prettifier]]: Tries to fix and reformat ugly Markdown and adds things like 'modified date' etc.
+- [[footlinks|Footlinks]]: Extracts links from the main text to footer.
+- [[obsidian-plugin-prettier|Prettier Format]]: Opinionated formatting for your notes.
+- [[obsidian-tidy-footnotes|Tidy Footnotes]]: Tidy your footnotes seamlessly.
+- [[easy-typing-obsidian|Easy Typing]]: Autoformat your note as typing.(Auto captalize, autospace)
+- [[obsidian-title-index|Obsidian title index]]: obsidian-title-index
+- [[obsidian-linter|Linter]]: Enforces consistent markdown styling.
+- [[obsidian-regex-pipeline|Regex Pipeline]]: Allows users setup custom regex rules to automatically format notes
+- [[number-headings-obsidian|Number Headings]]: Automatically number or re-number headings in an Obsidian document
+- [[tag-wrangler|Tag Wrangler]]: Rename, merge, toggle, and search tags from the tag pane
+- [[obsidian-task-archiver|Obsidian Task Archiver]]: Move completed tasks to an archive with a date tree
+- [[completed-area|Completed Area]]: Move completed to-do items to a seperate completed area.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Search and query plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Search and query plugins.md
@@ -13,21 +13,21 @@ Querying
 
 ## Plugins in this category
 
-- [[mrj-text-expand|Text {{expand}}]]
-- [[searchpp|Search++]]
-- [[smart-random-note|Smart Random Note]]
-- [[neo4j-graph-view|Neo4j Graph View]]
-- [[obsidian-query2table|query2table]]
-- [[search-on-internet|Search on Internet]]
-- [[vantage-obsidian|Vantage - Advanced search builder]]
-- [[obsidian-query-language|Obsidian Query Language]]
-- [[dataview|Dataview]]
-- [[obsidian-spotlight|Spotlight]]
-- [[obsidian-related-notes-finder|Related Notes Finder]]
-- [[obsidian-relative-find|Relative Find]]
-- [[obsidian-core-search-assistant-plugin|Core Search Assistant]]
-- [[obsidian-search-everywhere-plugin|Search Everywhere]]
-- [[obsidian-power-search|Power Search]]
+- [[mrj-text-expand|Text {{expand}}]]: Search and paste/transclude links to located files.
+- [[searchpp|Search++]]: Allow inserting text context search results on the active note, the plugin is based on the plugin mrj-text-expand-witb-text of MrJackphil.
+- [[smart-random-note|Smart Random Note]]: A smart random note plugin
+- [[neo4j-graph-view|Neo4j Graph View]]: An Obsidian plugin for advanced graph visualization and querying using Neo4j.
+- [[obsidian-query2table|query2table]]: Represent files returned by a query as a table of their YAML frontmatter
+- [[search-on-internet|Search on Internet]]: Add context menu items to search the internet within Obsidian.
+- [[vantage-obsidian|Vantage - Advanced search builder]]: Build advanced search queries in Obsidian.
+- [[obsidian-query-language|Obsidian Query Language]]: This plugin allows you to query notes and represent data within Obsidian
+- [[dataview|Dataview]]: Complex data views for the data-obsessed.
+- [[obsidian-spotlight|Spotlight]]: Block that features random notes or block of a note from vault / in a specified project or with a certain combination of tags.
+- [[obsidian-related-notes-finder|Related Notes Finder]]: An Obsidian plugin that adds extra features for finding related notes.
+- [[obsidian-relative-find|Relative Find]]: This Plugin lets you search relative to your Cursor Position.
+- [[obsidian-core-search-assistant-plugin|Core Search Assistant]]: Enhance built-in search: keyboard interface, card preview, bigger preview
+- [[obsidian-search-everywhere-plugin|Search Everywhere]]: Search Everywhere with pressing Double Shift like in IntelliJ
+- [[obsidian-power-search|Power Search]]: Searches Anki Notes based on current line
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Side bar plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Side bar plugins.md
@@ -15,13 +15,13 @@ Plugins that add panes to your sidebar.
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
-- [[juggl|Juggl]]
-- [[calendar|Calendar]]
-- [[customizable-sidebar|Customizable Sidebar]]
-- [[obsidian-hide-sidebars-when-narrow|Hide Sidebars When Narrow]]
-- [[window-collapse|Window Collapse]]
-- [[obsidian-sidebar-expand-on-hover|Sidebar Expand on Hover]]
-- [[obsidian-daily-stats|Daily Stats]]
+- [[juggl|Juggl]]: Adds a completely interactive, stylable and expandable graph view to Obsidian.
+- [[calendar|Calendar]]: Calendar view of your daily notes
+- [[customizable-sidebar|Customizable Sidebar]]: This Plugin allows to add any Command to Obsidian's Sidebar Ribbon.
+- [[obsidian-hide-sidebars-when-narrow|Hide Sidebars When Narrow]]: Automatically hides the sidebars when your window is narrow.
+- [[window-collapse|Window Collapse]]: This plugins provides an easy way to collapse the sidebars without going fullscreen.
+- [[obsidian-sidebar-expand-on-hover|Sidebar Expand on Hover]]: This Obsidian plugin expands or collapses the sidebars based on mouse hovering on the ribbons.
+- [[obsidian-daily-stats|Daily Stats]]: Track your daily word count across all notes in your vault.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Status bar plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Status bar plugins.md
@@ -13,15 +13,15 @@ Plugins that add an item to the status bar.
 
 ## Plugins in this category
 
-- [[obsidian-reading-time|Reading Time]]
-- [[obsidian-hider|Hider]]
-- [[youhavebeenstaring-plugin|YouHaveBeenStaring]]
-- [[obsidian-show-file-path|Show Current File Path]]
-- [[obsidian-vault-statistics-plugin|Vault Statistics]]
-- [[obsidian-grandfather|Grandfather]]
-- [[obsidian-statusbar-pomo|Status Bar Pomodoro Timer]]
-- [[obsidian-cursor-location-plugin|Cursor Location]]
-- [[better-word-count|Better Word Count]]
+- [[obsidian-reading-time|Reading Time]]: Add the current note's reading time to Obsidian's status bar.
+- [[obsidian-hider|Hider]]: Hide UI elements such as tooltips, status, titlebar and more
+- [[youhavebeenstaring-plugin|YouHaveBeenStaring]]: This plugin tells you in the status bar for how long you've been staring at your obsidian vault. Well - at least how long your vault is open.
+- [[obsidian-show-file-path|Show Current File Path]]: Show the full path of the currently open file in the status bar
+- [[obsidian-vault-statistics-plugin|Vault Statistics]]: Status bar item with vault statistics such as number of notes, files, attachments, and links.
+- [[obsidian-grandfather|Grandfather]]: A simple plugin to display the time and date on the status bar
+- [[obsidian-statusbar-pomo|Status Bar Pomodoro Timer]]: Adds a pomodoro timer to your status bar.
+- [[obsidian-cursor-location-plugin|Cursor Location]]: This displays the location of the cursor (character and line number).
+- [[better-word-count|Better Word Count]]: Counts the words of selected text in the editor.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Style and Appearance Plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Style and Appearance Plugins.md
@@ -13,25 +13,25 @@ Plugins that change the appearance or style of Obsidian's User Interface.
 
 ## Plugins in this category
 
-- [[obsidian-system-dark-mode|System Dark Mode]]
-- [[obsidian-icons-plugin|Icons Plugin]]
-- [[theme-picker|Theme Picker]]
-- [[obsidian-reset-font-size|Reset Font Size]]
-- [[obsidian-contextual-typography|Contextual Typography]]
-- [[obsidian-highlightpublicnotes-plugin|Highlight Public Notes]]
-- [[obsidian-codemirror-options|CodeMirror Options]]
-- [[cm-show-whitespace-obsidian|Show Whitespace]]
-- [[css-snippets|css snippets]]
-- [[obsidian-icon-folder|Icon Folder]]
-- [[obsidian-icon-swapper|Icon Swapper]]
-- [[obsidian-budget-wysiwyg|Budget WYSIWYG]]
-- [[obsidian-electron-window-tweaker|Electron Window Tweaker]]
-- [[open-note-to-window-title|Active note to window title]]
-- [[block-reference-count|Block Reference Counts]]
-- [[obsidian-embedded-code-title|Embedded Code Title]]
-- [[obsidian-relative-line-numbers|Relative Line Numbers]]
-- [[obsidian-indent-lines|Indentation Lines]]
-- [[obsidian-prominent-starred-files|Prominent Starred Files]]
+- [[obsidian-system-dark-mode|System Dark Mode]]: Automatically use the operating system's setting to switch between light and dark mode.
+- [[obsidian-icons-plugin|Icons Plugin]]: Add icons to your Obsidian notes.
+- [[theme-picker|Theme Picker]]: Quickly preview installed themes
+- [[obsidian-reset-font-size|Reset Font Size]]: Adds button and command to reset the font size back to its default value.
+- [[obsidian-contextual-typography|Contextual Typography]]: This plugin adds a data-tag-name attribute to all top-level divs in preview mode containing the child's tag name, allowing contextual typography styling.
+- [[obsidian-highlightpublicnotes-plugin|Highlight Public Notes]]: This plugin warns that a note is public (based on a frontmatter attribute) by colorizing the note red.
+- [[obsidian-codemirror-options|CodeMirror Options]]: Enhance Obsidian's desktop edit mode with features such as WYSIWYG / Live Preview, Syntax Highlighting, and more.
+- [[cm-show-whitespace-obsidian|Show Whitespace]]: Show whitespace in the editor
+- [[css-snippets|css snippets]]: Load and manage css snippets
+- [[obsidian-icon-folder|Icon Folder]]: This plugin allows to add an emoji in front of a folder or icon.
+- [[obsidian-icon-swapper|Icon Swapper]]: Allows swapping out Obsidian's default icons.
+- [[obsidian-budget-wysiwyg|Budget WYSIWYG]]: This is a plugin that automatically switches between preview mode and source mode based on if you are typing or not.
+- [[obsidian-electron-window-tweaker|Electron Window Tweaker]]: Tweak various Electron window settings.
+- [[open-note-to-window-title|Active note to window title]]: Allows template-based customization of the app window title
+- [[block-reference-count|Block Reference Counts]]: Shows the count of block references next to the block-id
+- [[obsidian-embedded-code-title|Embedded Code Title]]: This is an Obsidian plugin which can embeds title to code blocks.
+- [[obsidian-relative-line-numbers|Relative Line Numbers]]: Enables relative line numbers in editor mode
+- [[obsidian-indent-lines|Indentation Lines]]: Creates connection-lines for ordered and unordered lists regardless of nesting etc.
+- [[obsidian-prominent-starred-files|Prominent Starred Files]]: Prominently display starred notes in the file explorer
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Tag management plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Tag management plugins.md
@@ -15,11 +15,11 @@ Plugins to manage tags.
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
-- [[tag-wrangler|Tag Wrangler]]
-- [[tag-page-preview|Tag Page Preview]]
-- [[obsidian-tagfolder|TagFolder]]
-- [[obsidian-frontmatter-tag-suggest|Frontmatter Tag Suggest]]
-- [[tag-word-cloud|Tag & Word Cloud]]
+- [[tag-wrangler|Tag Wrangler]]: Rename, merge, toggle, and search tags from the tag pane
+- [[tag-page-preview|Tag Page Preview]]: Clicking a tag opens a dialog listing pages that use that tag
+- [[obsidian-tagfolder|TagFolder]]: Show tags as folder
+- [[obsidian-frontmatter-tag-suggest|Frontmatter Tag Suggest]]: Autocompletes tags in the frontmatter tags field
+- [[tag-word-cloud|Tag & Word Cloud]]: Show a cloud of your tags/words in a note
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Task management plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Task management plugins.md
@@ -13,31 +13,31 @@ publish: true
 
 ## Plugins in this category
 
-- [[slated-obsidian|Slated]]
-- [[todoist-sync-plugin|Todoist Sync Plugin]]
-- [[obsidian-day-planner|Day Planner]]
-- [[completed-area|Completed Area]]
-- [[obsidian-rollover-daily-todos|Rollover Daily Todos]]
-- [[completed-task-display|Completed Task Display]]
-- [[obsidian-checklist-plugin|Checklist]]
-- [[obsidian-plugin-todo|Obsidian TODO | Text-based GTD]]
-- [[todo-txt|Todo.txt support]]
-- [[obsidian-kanban|Kanban]]
-- [[obsidian-tasks-plugin|Tasks]]
-- [[tq-obsidian|tq]]
-- [[obsidian-statusbar-pomo|Status Bar Pomodoro Timer]]
-- [[obsidian-random-todo|Random To-Do]]
-- [[obsidian-reminder-plugin|Reminder]]
-- [[imdone-obsidian-plugin|Open cards in imdone from obsidian.]]
-- [[obsidian-amazingmarvin-plugin|Amazing Marvin]]
-- [[obsidian-task-archiver|Obsidian Task Archiver]]
-- [[obsidian-apple-reminders-plugin|Apple Reminders]]
-- [[things-logbook|Things Logbook]]
-- [[obsidian-overdue|Overdue]]
-- [[obsidian-task-collector|Task Collector (TC)]]
-- [[todoist-text|Todoist Text]]
-- [[obsidian-things-link|Things Link]]
-- [[card-board|CardBoard]]
+- [[slated-obsidian|Slated]]: Task Management - schedule, move, and repeat tasks
+- [[todoist-sync-plugin|Todoist Sync Plugin]]: Materialize Todoist tasks within Obsidian notes.
+- [[obsidian-day-planner|Day Planner]]: A plugin to help you plan your day and setup pomodoro timers
+- [[completed-area|Completed Area]]: Move completed to-do items to a seperate completed area.
+- [[obsidian-rollover-daily-todos|Rollover Daily Todos]]: This Obsidian.md plugin rolls over incomplete TODOs from the previous daily note to today's daily note. (https://obsidian.md)
+- [[completed-task-display|Completed Task Display]]: Provides a button in the ribbon to hide or display completed tasks
+- [[obsidian-checklist-plugin|Checklist]]: Combines checklists across pages into users sidebar
+- [[obsidian-plugin-todo|Obsidian TODO | Text-based GTD]]: Text-based GTD in Obsidian. Collects all outstanding TODOs from your vault and presents them in lists Today, Scheduled, Inbox and Someday/Maybe.
+- [[todo-txt|Todo.txt support]]: Native support for todo.txt files
+- [[obsidian-kanban|Kanban]]: Create markdown-backed Kanban boards in Obsidian.
+- [[obsidian-tasks-plugin|Tasks]]: Task management for Obsidian
+- [[tq-obsidian|tq]]: File-based Task Management
+- [[obsidian-statusbar-pomo|Status Bar Pomodoro Timer]]: Adds a pomodoro timer to your status bar.
+- [[obsidian-random-todo|Random To-Do]]: Open a random file containing your custom to-do marker, or a random marker at its position
+- [[obsidian-reminder-plugin|Reminder]]: Reminder plugin for Obsidian. This plugin adds feature to manage TODOs with reminder.
+- [[imdone-obsidian-plugin|Open cards in imdone from obsidian.]]: This plugin allows imdone users to open their imdone board from a document in their obsidian vault that contains imdone cards.
+- [[obsidian-amazingmarvin-plugin|Amazing Marvin]]: This is a plugin for Obsidian (https://obsidian.md) for Amazing Marvin (https://app.amazingmarvin.com/)
+- [[obsidian-task-archiver|Obsidian Task Archiver]]: Move completed tasks to an archive with a date tree
+- [[obsidian-apple-reminders-plugin|Apple Reminders]]: 
+- [[things-logbook|Things Logbook]]: Sync your Things.app Logbook with Daily Notes
+- [[obsidian-overdue|Overdue]]: Marks items as \[\[Overdue]] if they are not checked off by their due date
+- [[obsidian-task-collector|Task Collector (TC)]]: Manage completed tasks within a document
+- [[todoist-text|Todoist Text]]: This obsidian plugin integrates your Todoist tasks with markdown checkboxes.
+- [[obsidian-things-link|Things Link]]: Seamlessly create Things tasks and projects from Obsidian
+- [[card-board|CardBoard]]: Display markdown tasks on kanban-style boards.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Template plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Template plugins.md
@@ -13,14 +13,14 @@ Plugins to apply templates beyond what [[Obsidian Core Plugins#Templates]] offer
 
 ## Plugins in this category
 
-- [[templater-obsidian|Templater]]
-- [[obsidian-temple|Temple]]
-- [[obsidian-metatemplates|metatemplates]]
-- [[page-heading-from-links|Page Heading From Links]]
-- [[obsidian-filename-heading-sync|Filename Heading Sync]]
-- [[liquid-templates|Liquid Templates]]
-- [[podcast-note|Podcast Note]]
-- [[quickadd|QuickAdd]]
+- [[templater-obsidian|Templater]]: Create and use templates
+- [[obsidian-temple|Temple]]: A plugin for templating in Obsidian, powered by Nunjucks.
+- [[obsidian-metatemplates|metatemplates]]: Generate notes from templates using YAML front-matter
+- [[page-heading-from-links|Page Heading From Links]]: Inserts a heading into blank pages from the filename
+- [[obsidian-filename-heading-sync|Filename Heading Sync]]: Obsidian plugin for keeping the filename with the first heading of a file in sync
+- [[liquid-templates|Liquid Templates]]: Empower your template with LiquidJS tags
+- [[podcast-note|Podcast Note]]: Podcast Note lets you automatically add podcast information to your notes.
+- [[quickadd|QuickAdd]]: Quickly add new pages or content to your vault.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Theme settings plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Theme settings plugins.md
@@ -15,11 +15,11 @@ Plugins developed to adjust the settings of [[🗂️ Themes|Obsidian Themes]]. 
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
-- [[obsidian-style-settings|Style Settings]]
-- [[obsidian-minimal-settings|Minimal Theme Settings]]
-- [[obsidian-advanced-appearance|Advanced Appearance]]
-- [[obsidian-hider|Hider]]
-- [[discordian-plugin|Discordian Theme]]
+- [[obsidian-style-settings|Style Settings]]: Offers controls for adjusting theme, plugin, and snippet CSS variables.
+- [[obsidian-minimal-settings|Minimal Theme Settings]]: Change the colors, fonts and features of Minimal Theme.
+- [[obsidian-advanced-appearance|Advanced Appearance]]: Change colors, fonts and other cosmetic settings.
+- [[obsidian-hider|Hider]]: Hide UI elements such as tooltips, status, titlebar and more
+- [[discordian-plugin|Discordian Theme]]: Discordian plugin for tweaking Discordian theme
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Third-Party Integration Plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Third-Party Integration Plugins.md
@@ -13,56 +13,56 @@ Plugins to integrate with other services or applications.
 
 ## Plugins in this category
 
-- [[todoist-sync-plugin|Todoist Sync Plugin]]
-- [[obsidian-discordrpc|Discord Rich Presence]]
-- [[obsidian-youglish-plugin|Youglish Plugin]]
-- [[flashcards-obsidian|Flashcards]]
-- [[obsidian-to-anki-plugin|Obsidian_to_Anki]]
-- [[obsidian-apple-reminders-plugin|Apple Reminders]]
-- [[obsidian-imgur-plugin|Imgur Plugin]]
-- [[things-logbook|Things Logbook]]
-- [[notetweet|NoteTweet]]
-- [[obsidian-leaflet-plugin|Obsidian Leaflet]]
-- [[DEVONlink-obsidian|DEVONlink - Open or reveal notes in DEVONthink]]
-- [[imdone-obsidian-plugin|Open cards in imdone from obsidian.]]
-- [[obsidian-languagetool-plugin|LanguageTool Integration]]
-- [[obsidian-readwise|Readwise Community]]
-- [[obsidian-kindle-plugin|Kindle Highlights]]
-- [[beeminder-word-count-plugin|Beeminder Word Count Plugin]]
-- [[obsidian-image-auto-upload-plugin|Image auto upload Plugin]]
-- [[readwise-mirror|Readwise Mirror]]
-- [[obsidian-gist|Gist]]
-- [[obsidian-pandoc|Obsidian Pandoc]]
-- [[obsidian-amazingmarvin-plugin|Amazing Marvin]]
-- [[obsidian-map-view|Map View]]
-- [[open-vscode|Open vault in VSCode]]
-- [[phone-to-roam-to-obsidian|Phone to Roam to Obsidian]]
-- [[obsidian-wordnet-plugin|Obsidian42 - WordNet Dictionary]]
-- [[readwise-official|Readwise Official]]
-- [[obsidian-toggl-integration|Toggl Track Integration]]
-- [[ObsidianAnkiSync|Obsidian Anki Sync]]
-- [[mochi-cards-exporter|Mochi Cards Exporter]]
-- [[obsidian-trello|Obsidian Trello]]
-- [[obsidian-annotator|Annotator]]
-- [[obsidian-hackernews|HackerNews]]
-- [[obsidian-pocket|Pocket integration]]
-- [[obsimian-exporter|Obsimian Exporter]]
-- [[metadata-extractor|Metadata Extractor]]
-- [[uri-commands|URI Commands]]
-- [[obsidian-wikipedia|Wikipedia]]
-- [[obsidian-vale|Vale]]
-- [[obsidian-hypothesis-plugin|Hypothes.is]]
-- [[marginnote-companion|MarginNote Companion]]
-- [[obsidian-habitica-integration|Habitica Sync]]
-- [[obsidian-webhooks|Obsidian Webhooks]]
-- [[obsidian-tweet-to-markdown|Tweet to Markdown]]
-- [[netwik|Netwik]]
-- [[obsidian-jupyter|Jupyter plugin]]
-- [[obsidian-plotly|Plotly]]
-- [[obsidian-ankibridge|AnkiBridge]]
-- [[obsidian-tressel|Tressel Sync for Obsidian]]
-- [[obsidian-graphviz|Obsidian Graphviz]]
-- [[obsidian-power-search|Power Search]]
+- [[todoist-sync-plugin|Todoist Sync Plugin]]: Materialize Todoist tasks within Obsidian notes.
+- [[obsidian-discordrpc|Discord Rich Presence]]: Update your Discord Status to show your friends what you are working on in Obsidian. With Discord Rich Presence.
+- [[obsidian-youglish-plugin|Youglish Plugin]]: Use YouTube to improve your pronunciation. YouGlish gives you fast, unbiased answers about how words is spoken by real people and in context.
+- [[flashcards-obsidian|Flashcards]]: Anki integration
+- [[obsidian-to-anki-plugin|Obsidian_to_Anki]]: This is an Anki integration plugin! Designed for efficient bulk exporting.
+- [[obsidian-apple-reminders-plugin|Apple Reminders]]: 
+- [[obsidian-imgur-plugin|Imgur Plugin]]: This plugin uploads images from your clipboard to imgur.com and embeds uploaded image to your note
+- [[things-logbook|Things Logbook]]: Sync your Things.app Logbook with Daily Notes
+- [[notetweet|NoteTweet]]: This plugin allows you to post tweets directly from Obsidian.
+- [[obsidian-leaflet-plugin|Obsidian Leaflet]]: Interactive maps inside your notes
+- [[DEVONlink-obsidian|DEVONlink - Open or reveal notes in DEVONthink]]: Open or reveal the current note in DEVONthink.
+- [[imdone-obsidian-plugin|Open cards in imdone from obsidian.]]: This plugin allows imdone users to open their imdone board from a document in their obsidian vault that contains imdone cards.
+- [[obsidian-languagetool-plugin|LanguageTool Integration]]: Spelling and grammar checks with the LanguageTool API
+- [[obsidian-readwise|Readwise Community]]: Sync Readwise highlights into your notes
+- [[obsidian-kindle-plugin|Kindle Highlights]]: Sync your Kindle book highlights using your Amazon login or uploading your My Clippings file
+- [[beeminder-word-count-plugin|Beeminder Word Count Plugin]]: This lets you post word counts directly from obsidian file to Beeminder.
+- [[obsidian-image-auto-upload-plugin|Image auto upload Plugin]]: This plugin uploads images from your clipboard by PicGo
+- [[readwise-mirror|Readwise Mirror]]: Mirror your Readwise library directly to an Obsidian vault
+- [[obsidian-gist|Gist]]: This is a plugin to display the GitHub Gist.
+- [[obsidian-pandoc|Obsidian Pandoc]]: This is a Pandoc export plugin for Obsidian. It provides commands to export to formats like DOCX, ePub and PDF.
+- [[obsidian-amazingmarvin-plugin|Amazing Marvin]]: This is a plugin for Obsidian (https://obsidian.md) for Amazing Marvin (https://app.amazingmarvin.com/)
+- [[obsidian-map-view|Map View]]: An interactive map view.
+- [[open-vscode|Open vault in VSCode]]: Ribbon button and command to open vault as a Visual Studio Code workspace
+- [[phone-to-roam-to-obsidian|Phone to Roam to Obsidian]]: An Obsidian client for phonetoroam.com
+- [[obsidian-wordnet-plugin|Obsidian42 - WordNet Dictionary]]: WordNet is a large lexical database of English developed by Princeton University.
+- [[readwise-official|Readwise Official]]: Official Readwise <-> Obsidian integration
+- [[obsidian-toggl-integration|Toggl Track Integration]]: Manage timers and generate time reports using Toggl Track without leaving Obsidian.
+- [[ObsidianAnkiSync|Obsidian Anki Sync]]: Obsidian plugin to make flashcards and sync them to Anki.
+- [[mochi-cards-exporter|Mochi Cards Exporter]]: Export Markdown notes to Mochi cards from within obsidian
+- [[obsidian-trello|Obsidian Trello]]: Connect an existing or new Trello card to an Obsidian note. Once connected, see basic info, add and view comments, and check off checklist items.
+- [[obsidian-annotator|Annotator]]: This is a sample plugin for Obsidian. It allows you to open and annotate PDF and EPUB files.
+- [[obsidian-hackernews|HackerNews]]: Periodically fetches and displays top stories from HackerNews.
+- [[obsidian-pocket|Pocket integration]]: Access your Pocket reading list entries and create notes for them easily
+- [[obsimian-exporter|Obsimian Exporter]]: Exports data from Obsidian APIs, feeding the Obsimian simulation framework for testing plugins.
+- [[metadata-extractor|Metadata Extractor]]: Metadata export on a schedule for integration with third-party apps like launchers.
+- [[uri-commands|URI Commands]]: Execute URIs from the Obsidian command palette.
+- [[obsidian-wikipedia|Wikipedia]]: Grabs information from Wikipedia for a topic and brings it into Obsidian notes
+- [[obsidian-vale|Vale]]: A Vale client for Obsidian.
+- [[obsidian-hypothesis-plugin|Hypothes.is]]: Sync your Hypothesis highlights
+- [[marginnote-companion|MarginNote Companion]]: An Obsidian plugin to bridge MarginNote 3 and Obsidian
+- [[obsidian-habitica-integration|Habitica Sync]]: This plugin helps integrate Habitica user tasks and stats into Obsidian
+- [[obsidian-webhooks|Obsidian Webhooks]]: Plugin that connects your notes to the internet of things through webhooks!
+- [[obsidian-tweet-to-markdown|Tweet to Markdown]]: Save tweets as Markdown files, along with their images, polls, etc.
+- [[netwik|Netwik]]: This plugin provides access to global network of notes. Anyone can create, view or edit notes. All changes will be synchronized between all participants
+- [[obsidian-jupyter|Jupyter plugin]]: This plugin allows code blocks to be executed as Jupyter notebooks.
+- [[obsidian-plotly|Plotly]]: Obsidian plugin, which allow user to embed Plotly charts into markdown notes.
+- [[obsidian-ankibridge|AnkiBridge]]: Yet Another Anki Bridge
+- [[obsidian-tressel|Tressel Sync for Obsidian]]: Official Tressel plugin to sync/export your tweets and threads into Obsidian
+- [[obsidian-graphviz|Obsidian Graphviz]]: Render Graphviz Diagrams
+- [[obsidian-power-search|Power Search]]: Searches Anki Notes based on current line
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Time Management Plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Time Management Plugins.md
@@ -16,11 +16,11 @@ publish: true
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
-- [[obsidian-pomodoro-plugin|Pomodoro Plugin]]
-- [[obsidian-statusbar-pomo|Status Bar Pomodoro Timer]]
-- [[obsidian-toggl-integration|Toggl Track]]
-- [[obsidian-flexible-pomo|Flexible Pomodoro For Obsidian]]
-- [[obsidian-stopwatch-plugin|Stopwatch Plugin]]
+- [[obsidian-pomodoro-plugin|Pomodoro Plugin]]: This is a simple pomodoro plugin for Obsidian.
+- [[obsidian-statusbar-pomo|Status Bar Pomodoro Timer]]: Adds a pomodoro timer to your status bar.
+- [[obsidian-toggl-integration|Toggl Track]]: Manage timers and generate time reports using Toggl Track without leaving Obsidian.
+- [[obsidian-flexible-pomo|Flexible Pomodoro For Obsidian]]: Adds a pomodoro timer to your status bar. This pomodoro has additional options such as early log and extend.
+- [[obsidian-stopwatch-plugin|Stopwatch Plugin]]: Display stopwatch on Obsidian!
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Toolbar plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Toolbar plugins.md
@@ -15,8 +15,8 @@ Plugins that add toolbars.
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
-- [[cmenu-plugin|cMenu]]
-- [[table-editor-obsidian|Advanced Tables]]
+- [[cmenu-plugin|cMenu]]: cMenu is a plugin that adds a minimal text editor modal for a smoother writing/editing experience ✍🏽.
+- [[table-editor-obsidian|Advanced Tables]]: Improved table navigation, formatting, manipulation, and formulas
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Vim-related Plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Vim-related Plugins.md
@@ -13,13 +13,13 @@ Plugins related to [[Vim]] mode
 
 ## Plugins in this category
 
-- [[obsidian-vimrc-support|Vimrc Support]]
-- [[mrj-add-codemirror-matchbrackets|Add Codemirror's matchbrackets.js]]
-- [[obsidian-vim-im-switch-plugin|Vim Input Method Switch]]
-- [[obsidian-relative-line-numbers|Relative Line Numbers]]
-- [[improved-vimcursor|Improved VimCursor]]
-- [[vim-im-select|Vim IM Select]]
-- [[obsidian-vim-multibyte-char-search|Vim Multibyte Char Search]]
+- [[obsidian-vimrc-support|Vimrc Support]]: Auto-load a startup file with Obsidian Vim commands.
+- [[mrj-add-codemirror-matchbrackets|Add Codemirror's matchbrackets.js]]: This plugins adds matchbrackets.js which allows to use `di[` or `ya(` commands in Vim mode
+- [[obsidian-vim-im-switch-plugin|Vim Input Method Switch]]: Switch input method with fcitx-remote when Vim keymap is enabled.
+- [[obsidian-relative-line-numbers|Relative Line Numbers]]: Enables relative line numbers in editor mode
+- [[improved-vimcursor|Improved VimCursor]]: An improved experience with the cursor in obsidian
+- [[vim-im-select|Vim IM Select]]: Support auto select the apposite input method in different vim mode
+- [[obsidian-vim-multibyte-char-search|Vim Multibyte Char Search]]: Search multibyte characters by the first character of corresponding ASCII encoding of input method. For example, for Chinese, search by the first character of Pinyin.
 
 ## Related categories
 


### PR DESCRIPTION
## Edited: All the plugin category pages to add plugin descriptions
This uses descriptions extracted from the plugin pages themselves. This was @claremacrae's excellent idea since it retains any descriptions for plugins that are no longer present in the json feed.

This is intended as a one-time manual content adjustment. It was scripted to produce, but these areas of the category pages appear to be manually curated by humans, not machine generated, so I hesitate to introduce anything that manipulates them. Because of that the code that generates this is very strict and only manipulates lines that appear to be exactly a link to the target plugin page. There are a few examples where descriptions are not present or where the link line has been edited -- these lines have all been left exactly as they were. For example in the discontinued plugins page

```
- [[obsidian-extra-md-commands|Extra Markdown Commands]] (use [[obsidian-smarter-md-hotkeys|Smarter Markdown Hotkeys]] instead.)
```

Additionally this PR does not add descriptions to the uncategorized plugins page, as that has been automated in the related PR #551

This is another step in the overall progression of encouraging descriptions on all the plugin pages as described in #343 

## Code
Please forgive that this is not in python. As a throw-away one-time script I did it in the language that I know best. If we end up pursuing some ongoing automation, of course it will be in python. This script is meant to run in the root of the repository.
```ruby
#!/usr/bin/env ruby

descriptions_hash = {} # key: page_name, value: description
Dir["02 - Community Expansions/02.05 All Community Expansions/Plugins/*.md"].map do |plugin_page_path|
  contents = File.read(plugin_page_path)
  if contents =~ /Mobile compatible: .*\n\n(.*)\n\n%% -----/
    descriptions_hash[File.basename(plugin_page_path, '.md')] = $1&.strip
  end
end

Dir["02 - Community Expansions/02.01 Plugins by Category/*.md"].each do |category_page_path|
  contents = File.readlines(category_page_path)
  in_list = false
  out_list = false
  new_contents = contents.map do |line|
    out_list = true if in_list && line =~ /^## /
    in_list = true if line =~ /^## Plugins in this category/

    if in_list && !out_list
      if line =~ /^- \[\[(.*?)(?:\|(.*)){0,1}\]\]\s*\n$/
        page_name, link_alias = $1, $2
        p page_name: page_name, link_alias: link_alias, line: line
        description = descriptions_hash[page_name]
        if !description.nil?
          "- [[#{page_name}|#{link_alias}]]: #{description}\n"
        else
          line # no description, leave it alone.
        end
      else
        line # leave the line alone.
      end
    else
      line
    end
  end

  File.write(category_page_path, new_contents.join)
end
```