### PR TITLE
Add code to automatically alphabetize plugin lists by alias.

### DIFF
--- a/.github/scripts/sort_lists.py
+++ b/.github/scripts/sort_lists.py
@@ -1,0 +1,110 @@
+# The goal is to sort lists by their obsidian link alias.
+import os
+import re
+from glob import glob
+from typing import List, Tuple, Optional, Any
+import logging
+
+
+def extract_alias(markdown_link_list_item: str) -> str:
+    # Return the alias if we have it, otherwise the page name.
+    match = re.compile(r'^- \[\[(.*?)(?:\|(.*?))?]].*') \
+        .search(markdown_link_list_item)
+
+    if match is None:
+        # If we find neither alias nor page, sort as blank.
+        return ""
+
+    for text in match.groups()[::-1]:
+        if text is not None:
+            return text
+
+    return ""
+
+
+def sort_list(markdown_list: str) -> str:
+    lines = markdown_list.splitlines()
+    sorted_lines = sorted(lines, key=lambda line: extract_alias(line))
+    return "\n".join(sorted_lines) + "\n"
+
+
+def read_file(file_path: str) -> str:
+    with open(file_path) as f:
+        return f.read()
+
+def write_file(file_path: str , contents: str) -> None:
+    with open(file_path, 'w') as f:
+        f.write(contents)
+
+
+def extract_list_pos(markdown_text: str, header: str) -> Optional[Tuple[int, int]]:
+    """
+    Returns the text positions for the first Markdown list
+    within the block defined by the header.
+    """
+
+    # Find the header, which will be the beginning of our search range.
+    try:
+        header_start_pos = markdown_text.index(header)
+    except ValueError as e:
+        # No header found.
+        return None
+
+    header_end_pos = header_start_pos + len(header)
+
+    # Find the following heading, which will be the end of our search range.
+    next_header_match =  re.compile('^#+', re.M) \
+        .search(markdown_text[header_end_pos:])
+    if next_header_match is None:
+        return None
+
+    next_header_start_pos = header_end_pos + next_header_match.span(0)[0]
+
+    # Find a Markdown list within this block of text.
+    list_match = re.compile(r'\n*((?:- \[\[.*?\]\].*?\n)+)', re.M) \
+        .search(markdown_text[header_end_pos:next_header_start_pos])
+    if list_match is None:
+        # No list found.
+        return None
+
+    # Find the precise text range for this list block in the overall markdown_text.
+    start_pos = header_end_pos + list_match.span(1)[0]
+    end_pos = start_pos + len(list_match.group(1))
+    return (start_pos, end_pos)
+
+
+def plugin_page_paths() -> List[str]:
+    return glob("../../02 - Community Expansions/02.01 Plugins by Category/*.md")
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    log = logging.getLogger('sort_lists')
+
+    heading = '## Plugins in this category'
+    for page_path in plugin_page_paths():
+        page_contents = read_file(page_path)
+        log.debug(f"Sorting page: {page_path}")
+        log.debug(f"Within heading: {heading}")
+
+        list_pos = extract_list_pos(page_contents, heading)
+        if list_pos is None:
+            log.warning("Could not find heading in page. Skipping")
+            continue
+
+        [list_start, list_end] = list_pos
+        original_list = page_contents[list_start:list_end]
+
+        log.debug(f"Original List:\n{original_list}")
+        sorted_list = sort_list(original_list)
+
+        log.debug(f"Sorted List:\n{sorted_list}")
+        new_page_contents = page_contents[:list_start] + sorted_list + page_contents[list_end:]
+
+        if page_contents != new_page_contents:
+            log.info(f"Sort changed {page_path}")
+        write_file(page_path, new_page_contents)
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/scripts/sort_lists.py
+++ b/.github/scripts/sort_lists.py
@@ -89,7 +89,7 @@ def main() -> None:
 
         list_pos = extract_list_pos(page_contents, heading)
         if list_pos is None:
-            log.warning("Could not find heading in page. Skipping")
+            log.warning(f"Could not find heading in page. Skipping {page_path}")
             continue
 
         [list_start, list_end] = list_pos

--- a/.github/scripts/tests/test_sort_lists_unit.py
+++ b/.github/scripts/tests/test_sort_lists_unit.py
@@ -1,0 +1,50 @@
+import sort_lists
+
+def test_extract_list() -> None:
+    markdown_text = """
+# Heading 1
+
+## Heading 2
+
+- [[item1|alias1]]
+- [[item2|alias2]]: desc
+- [[item3|alias3]] - OTHER ALT
+- [[item4|alias4]] 
+
+## Heading 3
+"""
+    expected_list_text = """- [[item1|alias1]]
+- [[item2|alias2]]: desc
+- [[item3|alias3]] - OTHER ALT
+- [[item4|alias4]] 
+"""
+
+    [start_pos, end_pos] = sort_lists.extract_list_pos(markdown_text, "## Heading 2")
+    assert start_pos == 28
+    assert end_pos == 123
+    assert markdown_text[start_pos:end_pos] == expected_list_text[:]
+
+def test_extract_alias() -> None:
+    link = "- [[item1|alias1]]: desc"
+    alias = sort_lists.extract_alias(link)
+    assert alias == "alias1"
+
+def test_extract_alias_no_alias() -> None:
+    link = "- [[item1]]: desc"
+    alias = sort_lists.extract_alias(link)
+    assert alias == "item1"
+
+def test_sort_list() -> None:
+    unsorted_md = """- [[item1|alias4]]
+- [[item2|alias2]]: desc
+- [[item3|alias3]] - OTHER ALT
+- [[item4|alias1]] """
+
+    expected_md = """- [[item4|alias1]] 
+- [[item2|alias2]]: desc
+- [[item3|alias3]] - OTHER ALT
+- [[item1|alias4]]
+"""
+
+    sorted_md = sort_lists.sort_list(unsorted_md)
+    assert sorted_md == expected_md

--- a/02 - Community Expansions/02.01 Plugins by Category/Automation plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Automation plugins.md
@@ -13,20 +13,20 @@ Automatically create, update, or delete notes.
 
 ## Plugins in this category
 
-- [[templater-obsidian|Templater]]: Create and use templates
-- [[snippets|Snippets plugin]]: Execute simple scripts/snippets from obsidian. This plugin is experimental
-- [[obsidian-text-expander|Text Expander]]: Expand text shortcuts, run shell commands and python scripts right in your editor
-- [[text-snippets-obsidian|Text Snippets]]: Allows you to replace text templates for faster typing, create your own.
+- [[obsidian-autocomplete-plugin|Autocomplete]]: This plugin provides a text autocomplete feature to enhance typing speed.
 - [[buttons|Buttons]]: Create Buttons in your Obsidian notes to run commands, open links, and insert templates
+- [[oz-clear-unused-images|Clear Unused Images]]: Clear the images that you are not using anymore in your markdown notes to save space.
+- [[customjs|CustomJS]]: This plugin allows for the loading and reuse of custom JS inside your vault.
+- [[obsidian-image-uploader|Image Uploader]]: This plugin uploads the image in your clipboard to any image hosting automatically when pasting.
+- [[obsidian-javascript-init|JavaScript Init]]: Run JavaScript when Obsidian loads, or any other time.
+- [[macro-plugin|Macros]]: Group multiple Commands into one Macro.
 - [[python-lab-plugin|Python lab plugin]]: An interface to experiment with python scripts and more.
 - [[obsidian-qrcode-plugin|QR Code Generator Plugin]]: This is a QR Code Generator plugin for Obsidian.
-- [[oz-clear-unused-images|Clear Unused Images]]: Clear the images that you are not using anymore in your markdown notes to save space.
-- [[obsidian-image-uploader|Image Uploader]]: This plugin uploads the image in your clipboard to any image hosting automatically when pasting.
-- [[macro-plugin|Macros]]: Group multiple Commands into one Macro.
 - [[obsidian-shellcommands|Shell commands]]: You can predefine system commands that you want to run frequently, and assign hotkeys for them. For example open external applications.
-- [[obsidian-autocomplete-plugin|Autocomplete]]: This plugin provides a text autocomplete feature to enhance typing speed.
-- [[customjs|CustomJS]]: This plugin allows for the loading and reuse of custom JS inside your vault.
-- [[obsidian-javascript-init|JavaScript Init]]: Run JavaScript when Obsidian loads, or any other time.
+- [[snippets|Snippets plugin]]: Execute simple scripts/snippets from obsidian. This plugin is experimental
+- [[templater-obsidian|Templater]]: Create and use templates
+- [[obsidian-text-expander|Text Expander]]: Expand text shortcuts, run shell commands and python scripts right in your editor
+- [[text-snippets-obsidian|Text Snippets]]: Allows you to replace text templates for faster typing, create your own.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Backup plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Backup plugins.md
@@ -13,8 +13,8 @@ Plugins to backup your notes.
 
 ## Plugins in this category
 
-- [[obsidian-git|Obsidian Git]]: Backup your vault with git.
 - [[obsidian-dropbox-backups|Aut-O-Backups]]: Automated backups to Dropbox for your enjoyment.
+- [[obsidian-git|Obsidian Git]]: Backup your vault with git.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Chinese Language Plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Chinese Language Plugins.md
@@ -13,9 +13,9 @@ Plugins related to Chinese language
 
 ## Plugins in this category
 
-- [[cm-chs-patch|Word Splitting for Simplified Chinese in Edit Mode]]: A patch for Obsidian's built-in CodeMirror Editor to support Simplified Chinese word splitting
-- [[obsidian-pangu|Obsidian Pangu]]: 自动为中英文之间插入空格，排版强迫者的福音。
 - [[obsidian-auto-pair-chinese-symbol|Auto pair chinese symbol]]: Auto pair chinese symbol
+- [[obsidian-pangu|Obsidian Pangu]]: 自动为中英文之间插入空格，排版强迫者的福音。
+- [[cm-chs-patch|Word Splitting for Simplified Chinese in Edit Mode]]: A patch for Obsidian's built-in CodeMirror Editor to support Simplified Chinese word splitting
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Date and calendar plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Date and calendar plugins.md
@@ -13,14 +13,14 @@ Handling dates
 
 ## Plugins in this category
 
-- [[nldates-obsidian|Natural Language Dates]]: Create date-links based on natural language
-- [[obsidian-juliandate|Julian Date Quick Insert]]: Simple hotkey to insert the current Julian Date
-- [[obsidian-jump-to-date-plugin|Obsidian42 - Jump-to-Date]]: Popup calendar for quickly navigating dates
 - [[calendar|Calendar]]: Calendar view of your daily notes
 - [[fantasy-calendar|Fantasy Calendar]]: Fantasy calendars in Obsidian!
-- [[big-calendar|Obsidian Big Calendar]]: A Big Calendar for Obsidian
 - [[obsidian-full-calendar|Full Calendar]]: Obsidian integration with Full Calendar (fullcalendar.io)
 - [[heatmap-calendar|Heatmap Calendar]]: Activity Year Overview for DataviewJS, Github style – Track Goals, Progress, Habits, Tasks, Exercise, Finances, "Dont Break the Chain" etc.
+- [[obsidian-juliandate|Julian Date Quick Insert]]: Simple hotkey to insert the current Julian Date
+- [[nldates-obsidian|Natural Language Dates]]: Create date-links based on natural language
+- [[big-calendar|Obsidian Big Calendar]]: A Big Calendar for Obsidian
+- [[obsidian-jump-to-date-plugin|Obsidian42 - Jump-to-Date]]: Popup calendar for quickly navigating dates
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Folder management plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Folder management plugins.md
@@ -16,14 +16,14 @@ publish: true
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
-- [[note-folder-autorename|Note Folder Autorename]]: Turn notes into folders and automaticaly move/rename their folders when they move or are renamed.
-- [[folder-note-core|Folder Note Core]]: Provide core features and API for folder notes
 - [[alx-folder-note|AidenLx's Folder Note]]: Add description, summary and more info to folders with folder notes.
-- [[zoottelkeeper-obsidian-plugin|Zoottelkeeper Plugin]]: This plugin automatically creates, maintains and tags MOCs for all your folders.
-- [[folder-note-plugin|Folder Note]]: Click a folder node to show a note describing the folder.
-- [[obsidian-icon-folder|Obsidian Icon Folder]]: This plugin allows to add an emoji in front of a folder or icon.
-- [[file-tree-alternative|File Tree Alternative Plugin]]: This plugin allows you to have an alternative file tree view.
 - [[file-explorer-note-count|File Explorer Note Count]]: The plugin helps you to see the number of notes under each folder within the file explorer.
+- [[file-tree-alternative|File Tree Alternative Plugin]]: This plugin allows you to have an alternative file tree view.
+- [[folder-note-plugin|Folder Note]]: Click a folder node to show a note describing the folder.
+- [[folder-note-core|Folder Note Core]]: Provide core features and API for folder notes
+- [[note-folder-autorename|Note Folder Autorename]]: Turn notes into folders and automaticaly move/rename their folders when they move or are renamed.
+- [[obsidian-icon-folder|Obsidian Icon Folder]]: This plugin allows to add an emoji in front of a folder or icon.
+- [[zoottelkeeper-obsidian-plugin|Zoottelkeeper Plugin]]: This plugin automatically creates, maintains and tags MOCs for all your folders.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Graph plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Graph plugins.md
@@ -15,14 +15,14 @@ publish: true
 ## Plugins in this category
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
-- [[neo4j-graph-view|Neo4j Graph View]]: An Obsidian plugin for advanced graph visualization and querying using Neo4j.
 - [[adjacency-matrix-maker|Adjacency Matrix Maker]]: Create an interactive image of an adjacency matrix of your vault
-- [[juggl|Juggl]]: Adds a completely interactive, stylable and expandable graph view to Obsidian.
 - [[breadcrumbs|Breadcrumbs]]: Visualise & navigate your vault's structure
 - [[graph-analysis|Graph Analysis]]: Analyse your Obsidian graph.
+- [[juggl|Juggl]]: Adds a completely interactive, stylable and expandable graph view to Obsidian.
+- [[obsidian-living-graph|Living Graph]]: A for-fun graph plugin
+- [[neo4j-graph-view|Neo4j Graph View]]: An Obsidian plugin for advanced graph visualization and querying using Neo4j.
 - [[obsidian-graphviz|Obsidian Graphviz]]: Render Graphviz Diagrams
 - [[persistent-graph|Persistent Graph]]: Adds commands to save and restore the positions of nodes on the global graph view
-- [[obsidian-living-graph|Living Graph]]: A for-fun graph plugin
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Japanese Language Plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Japanese Language Plugins.md
@@ -13,8 +13,8 @@ Plugins related to Japanese language
 
 ## Plugins in this category
 
-- [[obsidian-markdown-furigana|Markdown Furigana]]: Simple Markdown to Furigana Rendering Plugin for Obsidian.
 - [[obsidian-furigana|Furigana]]: Helper plugin for furigana and <ruby>
+- [[obsidian-markdown-furigana|Markdown Furigana]]: Simple Markdown to Furigana Rendering Plugin for Obsidian.
 - [[japanese-word-splitter|Word Splitting for Japanese in Edit Mode]]: A patch for Obsidian's built-in CodeMirror Editor to support Japanese word splitting
 
 ## Related categories

--- a/02 - Community Expansions/02.01 Plugins by Category/Markdown formatting plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Markdown formatting plugins.md
@@ -15,11 +15,11 @@ Plugins that make it easier to format or write markdown.
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
-- [[cmenu-plugin|cMenu]]: cMenu is a plugin that adds a minimal text editor modal for a smoother writing/editing experience ✍🏽.
-- [[obsidian-markdown-formatting-assistant-plugin|Markdown Formatting Assistant]]: This Plugin provides a simple Editor for Markdown, HTML and Colors and in addition a command line interface. The command line interface facilitate a faster workflow.
 - [[table-editor-obsidian|Advanced Tables]]: Improved table navigation, formatting, manipulation, and formulas
 - [[markdown-attributes|Markdown Attributes]]: Add markdown attributes to elements in Obsidian.md
+- [[obsidian-markdown-formatting-assistant-plugin|Markdown Formatting Assistant]]: This Plugin provides a simple Editor for Markdown, HTML and Colors and in addition a command line interface. The command line interface facilitate a faster workflow.
 - [[obsidian-underline|Underline]]: Add underline(`<u>xxx</u>`) with shortcut, and `<center>xxx</center>`, `[[#xxx]]`, `[[#^xxx]]`
+- [[cmenu-plugin|cMenu]]: cMenu is a plugin that adds a minimal text editor modal for a smoother writing/editing experience ✍🏽.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Mathjax and LaTeX Plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Mathjax and LaTeX Plugins.md
@@ -13,12 +13,12 @@ Plugins to enhance your [[Mathjax]] and [[LaTeX]] experience.
 
 ## Plugins in this category
 
-- [[obsidian-latex-environments|Latex Environments]]: Allows to quickly insert and change latex environments within math environments.
-- [[obsidian-latex|Extended MathJax]]: Adds support for a MathJax preamble and enables additional MathJax extensions for specific domains (chemistry, proofs).
-- [[quick-latex|Quick Latex for Obsidian]]: Speedup latex math typing with auto fraction, align block shortcut, matrix shortcut...etc
-- [[obsidian-export-to-tex|Export To TeX]]: Export vault files in a format amenable to pasting into a tex document
-- [[obsidian-pandoc|Pandoc Plugin]]: This is a Pandoc export plugin for Obsidian. It provides commands to export to formats like DOCX, ePub and PDF.
 - [[copy-as-latex|Copy as Latex]]: Plugin to quickly copy markdown as Latex, with citations
+- [[obsidian-export-to-tex|Export To TeX]]: Export vault files in a format amenable to pasting into a tex document
+- [[obsidian-latex|Extended MathJax]]: Adds support for a MathJax preamble and enables additional MathJax extensions for specific domains (chemistry, proofs).
+- [[obsidian-latex-environments|Latex Environments]]: Allows to quickly insert and change latex environments within math environments.
+- [[obsidian-pandoc|Pandoc Plugin]]: This is a Pandoc export plugin for Obsidian. It provides commands to export to formats like DOCX, ePub and PDF.
+- [[quick-latex|Quick Latex for Obsidian]]: Speedup latex math typing with auto fraction, align block shortcut, matrix shortcut...etc
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Mindmapping plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Mindmapping plugins.md
@@ -13,9 +13,9 @@ Display notes as mindmap
 
 ## Plugins in this category
 
-- [[obsidian-mind-map|Mind Map]]: A plugin to preview notes as Markmap mind maps
 - [[obsidian-argdown-plugin|Argument Map with Argdown]]: Allows you to write argdown codeblocks and view the maps in Preview
 - [[obsidian-enhancing-mindmap|Enhancing mindmap]]: This is a enhancing mindmap plugin for Obsidian. You can edit mindmap on markdown.
+- [[obsidian-mind-map|Mind Map]]: A plugin to preview notes as Markmap mind maps
 - [[obsidian-markmind|Obsidian markmind]]: This is a mindmap，outline and pdf annotate tool for obsidian.
 
 ## Related categories

--- a/02 - Community Expansions/02.01 Plugins by Category/Paid and subscription-based plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Paid and subscription-based plugins.md
@@ -16,11 +16,11 @@ publish: true
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
-- [[todoist-sync-plugin|Todoist Plugin]]: Materialize Todoist tasks within Obsidian notes.
+- [[ozanshare-publish|OzanShare Publish]]: Publish your markdown notes with a single click from your vault.
+- [[obsidian-readwise|Readwise Community]]: Sync Readwise highlights into your notes
 - [[readwise-mirror|Readwise Mirror]]: Mirror your Readwise library directly to an Obsidian vault
 - [[readwise-official|Readwise Official]]: Official Readwise <-> Obsidian integration
-- [[obsidian-readwise|Readwise Community]]: Sync Readwise highlights into your notes
-- [[ozanshare-publish|OzanShare Publish]]: Publish your markdown notes with a single click from your vault.
+- [[todoist-sync-plugin|Todoist Plugin]]: Materialize Todoist tasks within Obsidian notes.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Pane Management plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Pane Management plugins.md
@@ -15,13 +15,13 @@ Plugins to manage or cycle through panes.
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
-- [[sliding-panes-obsidian|Sliding Panes (Andy's Mode)]]: Sliding Panes! Based on the style of [Andy Matuschak's Notes](https://notes.andymatuschak.org/)
-- [[pane-relief|Pane Relief]]: Per-pane history, hotkeys for pane movement + navigation, and more
 - [[cycle-through-panes|Cycle through Panes]]: Cycle through your open Panes with `ctrl + Tab`, just like with Tabs in your Browser!, ctrl+shift+Tab for Reverse
-- [[maximise-active-pane-obsidian|Maximise Active Pane]]: Simply fills the workspace with the active pane
-- [[obsidian-tabs|Obsidian Tabs]]: Opens new leaves in tabs.
 - [[obsidian-focus-mode|Focus Mode]]: Add Focus Mode to Obsidian.
 - [[obsidian-fullscreen-plugin|Fullscreen Focus Mode]]: This plugin allows viewing a single document in fullscreen focus mode
+- [[maximise-active-pane-obsidian|Maximise Active Pane]]: Simply fills the workspace with the active pane
+- [[obsidian-tabs|Obsidian Tabs]]: Opens new leaves in tabs.
+- [[pane-relief|Pane Relief]]: Per-pane history, hotkeys for pane movement + navigation, and more
+- [[sliding-panes-obsidian|Sliding Panes (Andy's Mode)]]: Sliding Panes! Based on the style of [Andy Matuschak's Notes](https://notes.andymatuschak.org/)
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins for Chess.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins for Chess.md
@@ -13,8 +13,8 @@ publish: true
 
 ## Plugins in this category
 
-- [[chesser-obsidian|Chesser]]: A chess game viewer/editor
 - [[obsidian-chessboard|Chessboard Viewer]]: Render chess positions diagrams in note preview.
+- [[chesser-obsidian|Chesser]]: A chess game viewer/editor
 - [[obsidian-chess|Obsidian Chess]]: All you need to create your Chess related notes
 
 ## Related categories

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins for Diagrams.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins for Diagrams.md
@@ -15,12 +15,12 @@ Plugins to create diagrams other than [[Mermaid]] (which is [already natively su
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
-- [[obsidian-excalidraw-plugin|Excalidraw]]: An Obsidian plugin to edit and view Excalidraw drawings
 - [[drawio-obsidian|Diagrams]]: Draw.io diagrams for Obsidian. This plugin introduces diagrams that can be included within notes or as stand-alone files. Diagrams are created as SVG files (although .drawio extensions are also supported).
-- [[obsidian-plantuml|PlantUML]]: Render PlantUML Diagrams
+- [[obsidian-excalidraw-plugin|Excalidraw]]: An Obsidian plugin to edit and view Excalidraw drawings
 - [[obsidian-kroki|Kroki]]: Render Kroki Diagrams
 - [[obsidian-nomnoml-diagram|Nomnoml Diagram]]: Draw nomnoml diagrams in Obsidian notes
 - [[obsidian-graphviz|Obsidian Graphviz]]: Render Graphviz Diagrams
+- [[obsidian-plantuml|PlantUML]]: Render PlantUML Diagrams
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins for Editing Notes.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins for Editing Notes.md
@@ -13,44 +13,44 @@ Plugins help in editing like toolbars, auto-completions, sorting, ...
 
 ## Plugins in this category
 
-- [[table-editor-obsidian|Advanced Tables]]: Improved table navigation, formatting, manipulation, and formulas
-- [[cm-typewriter-scroll-obsidian|Typewriter Scroll Obsidian Plugin]]: Typewriter-style scrolling which keeps the view centered in the editor.
-- [[obsidian-emoji-toolbar|Emoji Toolbar]]: Quickly search for and insert emojis into your notes.
-- [[completed-area|Completed Area]]: Move completed to-do items to a seperate completed area.
-- [[obsidian-citation-plugin|Citations]]: Automatically search and insert citations from a Zotero library
-- [[obsidian-autocomplete-plugin|Autocomplete]]: This plugin provides a text autocomplete feature to enhance typing speed.
-- [[obsidian-sort-and-permute-lines|Sort & Permute lines]]: 
-- [[obsidian-markdown-formatting-assistant-plugin|Markdown Formatting Assistant]]: This Plugin provides a simple Editor for Markdown, HTML and Colors and in addition a command line interface. The command line interface facilitate a faster workflow.
-- [[various-complements|Various Complements]]: This plugin enables you to complete words like the auto-completion of IDE
-- [[obsidian-plugin-toc|Table of Contents]]: Create a table of contents for a note.
-- [[obsidian-footnotes|Footnote Shortcut]]: Insert and write footnotes faster
-- [[remember-cursor-position|Remember cursor position]]: Remember cursor and scroll position for each note
-- [[obsidian-outliner|Outliner]]: Work with your lists like in Workflowy or RoamResearch.
-- [[find-and-replace-in-selection|Find and replace in selection]]: Finds what you are looking for in the selected text and replaces it with the specified text
-- [[obsidian-embedded-note-titles|Embedded Note Titles]]: Inserts the note file name as an H1 heading above each note.
-- [[table-extended|Table Extended]]: Enable extended table support with MultiMarkdown 6 syntax
-- [[obsidian-dictionary-plugin|Dictionary]]: This is a simple dictionary for the Obsidian Note-Taking Tool.
-- [[metaedit|MetaEdit]]: MetaEdit helps you manage your metadata.
-- [[obsidian-smart-typography|Smart Typography]]: Converts quotes to curly quotes, dashes to em dashes, and periods to ellipses
-- [[obsidian-text-format|Text Format]]: Format selected text lowercase/uppercase/capitalize/titlecase or remove redundant spaces/newline characters.
-- [[obsidian-find-and-replace-in-selection|Find & Replace in Selection]]: Replace text within your current selection.
-- [[advanced-toolbar|Advanced Mobile Toolbar]]: Enhances the Toolbar for Obsidian Mobile.
-- [[cmenu-plugin|cMenu]]: cMenu is a plugin that adds a minimal text editor modal for a smoother writing/editing experience ✍🏽.
-- [[multi-line-formatting|Multi-line Formatting]]: Apply formatting to selected text, dealing with the paragraph breaks.
-- [[emoji-shortcodes|Emoji Shortcodes]]: This Plugin enables the use of Markdown Emoji Shortcodes :smile:
-- [[obsidian-copy-block-link|Copy Block Link]]: Get links to blocks and headings from Obsidian's right click menu
-- [[obsidian-code-block-enhancer|Code Block Enhancer]]: Enhance obsidian markdown code block,provides copy button,linenumber,language name tip and so on.
-- [[ghost-fade-focus|Ghost Fade Focus]]: Focused on the current line, others faded like a ghost!
-- [[obsidian-banners|Banners]]: Add banner images to your notes!
-- [[obsidian-paste-to-current-indentation|Paste to Current Indentation]]: This plugin allows pasting and marking text as block-quotes at any level of indentation.
-- [[obsidian-dynamic-toc|Dynamic Table of Contents]]: An Obsidian plugin to generate Tables of Contents that stay up to date with your document outline.
-- [[obsidian-carry-forward|Carry-Forward]]: An Obsidian Notes plugin for generating and copying block IDs and for copying lines with links to the copied line.
-- [[obsidian42-text-transporter|Obsidian42 - Text Transporter]]: Advanced text tools for working with text in your vault
-- [[longform|Longform]]: Write novels, screenplays, and other long projects in Obsidian.
-- [[obsidian-incremental-writing|Incremental Writing]]: Incrementally review notes and blocks over time.
-- [[obsidian-html-tags-autocomplete|HTML Tags Autocomplete]]: Autocomplete HTML tags.
 - [[advanced-cursors|Advanced Cursors]]: Use multiple cursors even more powerfully.
+- [[advanced-toolbar|Advanced Mobile Toolbar]]: Enhances the Toolbar for Obsidian Mobile.
+- [[table-editor-obsidian|Advanced Tables]]: Improved table navigation, formatting, manipulation, and formulas
+- [[obsidian-autocomplete-plugin|Autocomplete]]: This plugin provides a text autocomplete feature to enhance typing speed.
+- [[obsidian-banners|Banners]]: Add banner images to your notes!
+- [[obsidian-carry-forward|Carry-Forward]]: An Obsidian Notes plugin for generating and copying block IDs and for copying lines with links to the copied line.
+- [[obsidian-citation-plugin|Citations]]: Automatically search and insert citations from a Zotero library
+- [[obsidian-code-block-enhancer|Code Block Enhancer]]: Enhance obsidian markdown code block,provides copy button,linenumber,language name tip and so on.
+- [[completed-area|Completed Area]]: Move completed to-do items to a seperate completed area.
+- [[obsidian-copy-block-link|Copy Block Link]]: Get links to blocks and headings from Obsidian's right click menu
+- [[obsidian-dictionary-plugin|Dictionary]]: This is a simple dictionary for the Obsidian Note-Taking Tool.
+- [[obsidian-dynamic-toc|Dynamic Table of Contents]]: An Obsidian plugin to generate Tables of Contents that stay up to date with your document outline.
+- [[obsidian-embedded-note-titles|Embedded Note Titles]]: Inserts the note file name as an H1 heading above each note.
+- [[emoji-shortcodes|Emoji Shortcodes]]: This Plugin enables the use of Markdown Emoji Shortcodes :smile:
+- [[obsidian-emoji-toolbar|Emoji Toolbar]]: Quickly search for and insert emojis into your notes.
+- [[obsidian-find-and-replace-in-selection|Find & Replace in Selection]]: Replace text within your current selection.
+- [[find-and-replace-in-selection|Find and replace in selection]]: Finds what you are looking for in the selected text and replaces it with the specified text
+- [[obsidian-footnotes|Footnote Shortcut]]: Insert and write footnotes faster
+- [[ghost-fade-focus|Ghost Fade Focus]]: Focused on the current line, others faded like a ghost!
+- [[obsidian-html-tags-autocomplete|HTML Tags Autocomplete]]: Autocomplete HTML tags.
+- [[obsidian-incremental-writing|Incremental Writing]]: Incrementally review notes and blocks over time.
+- [[longform|Longform]]: Write novels, screenplays, and other long projects in Obsidian.
+- [[obsidian-markdown-formatting-assistant-plugin|Markdown Formatting Assistant]]: This Plugin provides a simple Editor for Markdown, HTML and Colors and in addition a command line interface. The command line interface facilitate a faster workflow.
+- [[metaedit|MetaEdit]]: MetaEdit helps you manage your metadata.
+- [[multi-line-formatting|Multi-line Formatting]]: Apply formatting to selected text, dealing with the paragraph breaks.
+- [[obsidian42-text-transporter|Obsidian42 - Text Transporter]]: Advanced text tools for working with text in your vault
+- [[obsidian-outliner|Outliner]]: Work with your lists like in Workflowy or RoamResearch.
+- [[obsidian-paste-to-current-indentation|Paste to Current Indentation]]: This plugin allows pasting and marking text as block-quotes at any level of indentation.
 - [[obsidian-pipe-tricks|Pipe tricks]]: Adds support for pipe tricks in Obsidian.
+- [[remember-cursor-position|Remember cursor position]]: Remember cursor and scroll position for each note
+- [[obsidian-smart-typography|Smart Typography]]: Converts quotes to curly quotes, dashes to em dashes, and periods to ellipses
+- [[obsidian-sort-and-permute-lines|Sort & Permute lines]]: 
+- [[table-extended|Table Extended]]: Enable extended table support with MultiMarkdown 6 syntax
+- [[obsidian-plugin-toc|Table of Contents]]: Create a table of contents for a note.
+- [[obsidian-text-format|Text Format]]: Format selected text lowercase/uppercase/capitalize/titlecase or remove redundant spaces/newline characters.
+- [[cm-typewriter-scroll-obsidian|Typewriter Scroll Obsidian Plugin]]: Typewriter-style scrolling which keeps the view centered in the editor.
+- [[various-complements|Various Complements]]: This plugin enables you to complete words like the auto-completion of IDE
+- [[cmenu-plugin|cMenu]]: cMenu is a plugin that adds a minimal text editor modal for a smoother writing/editing experience ✍🏽.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins for Security and Privacy.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins for Security and Privacy.md
@@ -13,9 +13,9 @@ publish: true
 
 ## Plugins in this category
 
+- [[garble-text|Garble Text]]: Garbling text in Obsidian turns all content in the entire app (notes, sidebar, etc) into lines so you can take screenshots without exposing sensitive data.
 - [[meld-encrypt|Meld Encrypt]]: Hide secrets in your notes
 - [[privacy-glasses|Privacy Glasses]]: Provides a button and command to obfuscate onscreen text for better privacy in public settings.
-- [[garble-text|Garble Text]]: Garbling text in Obsidian turns all content in the entire app (notes, sidebar, etc) into lines so you can take screenshots without exposing sensitive data.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins for TTRPG.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins for TTRPG.md
@@ -16,12 +16,12 @@ publish: true
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
-- [[obsidian-dice-roller|Dice Roller]]: Inline dice rolling for Obsidian.md
-- [[initiative-tracker|Initiative Tracker]]: TTRPG Initiative Tracker for Obsidian.md
 - [[obsidian-5e-statblocks|5e Statblocks]]: Create 5e styled statblocks in Obsidian.md
+- [[obsidian-dice-roller|Dice Roller]]: Inline dice rolling for Obsidian.md
 - [[fantasy-calendar|Fantasy Calendar]]: Fantasy calendars in Obsidian!
-- [[obsidian-leaflet-plugin|Obsidian Leaflet]]: Interactive maps inside your notes
 - [[generic-initiative-tracker|Generic Initiative Tracker]]: TTRPG Generic Initiative Tracker for Obsidian.md
+- [[initiative-tracker|Initiative Tracker]]: TTRPG Initiative Tracker for Obsidian.md
+- [[obsidian-leaflet-plugin|Obsidian Leaflet]]: Interactive maps inside your notes
 
 ## Unlisted plugins
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins for Writers.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins for Writers.md
@@ -16,9 +16,9 @@ publish: true
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
+- [[dangerzone-writing-plugin|Dangerzone Writing]]: “Elegant”, “Dangerous”, “Relaxing”, “Perverted”, “Your best friend”, “Your worst nightmare”. When you start a Dangerzone session, you have to write without stopping for X seconds. If you stop, think and look around, after Y seconds the plugin will DELETE what you've written in this note.
 - [[obsidian-fountain|Fountain]]: Fountain Support for Obsidian
 - [[longform|Longform]]: Write novels, screenplays, and other long projects in Obsidian.
-- [[dangerzone-writing-plugin|Dangerzone Writing]]: “Elegant”, “Dangerous”, “Relaxing”, “Perverted”, “Your best friend”, “Your worst nightmare”. When you start a Dangerzone session, you have to write without stopping for X seconds. If you stop, think and look around, after Y seconds the plugin will DELETE what you've written in this note.
 - [[obsidian-paper-cut|PaperCut]]: Express an idea in the simplest possible way ... or else
 - [[cm-typewriter-scroll-obsidian|Typewriter Scroll]]: Typewriter-style scrolling which keeps the view centered in the editor.
 - [[obsidian-vale|Vale]]: A Vale client for Obsidian.

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins for collaboration.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins for collaboration.md
@@ -15,8 +15,8 @@ If you ever had to work on some kind of group project and wanted to collaborate 
 
 ## Plugins in this category
 
-- [[02 - Community Expansions/02.05 All Community Expansions/Plugins/sekund|Sekund]] is social media for your notes. Engage others in peer-to-peer thinking and get feedback on drafts. Start discussions and gather in your group chat.
 - [[obsidian-git|Obsidian Git]] can help you keep track of external changes to your notes by leveraging the [version control](https://www.wikiwand.com/en/Version_control) system [Git](https://book.git-scm.com/). Vaults could be shared through [GitHub](https://docs.github.com/en/get-started/quickstart).
+- [[02 - Community Expansions/02.05 All Community Expansions/Plugins/sekund|Sekund]] is social media for your notes. Engage others in peer-to-peer thinking and get feedback on drafts. Start discussions and gather in your group chat.
 - [@egradman's Etherpad Lite plugin](https://github.com/egradman/obsidian-etherpad-lite)(currently still in [[Plugins in Beta|beta]]) lets you upload any note to a self-hosted [Etherpad Lite](https://etherpad.org/) server and share the URL for live collaborative editing. This lightweight tool links your local document to its online version via a YAML key and continuously updates it as you type.
 - [[for Plugin Developers|Plugin developers]] might also be interested in [[netwik|Netwik]] which wanted to provide global access to notes by hosting them on a specified remote server. Be aware that this plugin is currently [[Discontinued plugins|unmaintained]].
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins for daily notes.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins for daily notes.md
@@ -15,12 +15,12 @@ Plugins to help you navigate or manage daily, weekly or monthly notes.
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
-- [[periodic-notes|Periodic Notes]]: Create/manage your daily, weekly, and monthly notes
-- [[obsidian-day-planner|Day Planner]]: A plugin to help you plan your day and setup pomodoro timers
-- [[obsidian-daily-named-folder|Daily Named Folder]]: Like daily notes, but nested in a named daily folder. Better for attachment management. Includes more flexible naming.
-- [[obsidian-daf-yomi|Daf Yomi]]: Fill in Daf Yomi pages
-- [[random-structural-diary-plugin|Random Structural Diary]]: This is a plugin for picking random questions from prepared question list. It allows you answer on different questions each time.
 - [[calendar|Calendar]]: Calendar view of your daily notes
+- [[obsidian-daf-yomi|Daf Yomi]]: Fill in Daf Yomi pages
+- [[obsidian-daily-named-folder|Daily Named Folder]]: Like daily notes, but nested in a named daily folder. Better for attachment management. Includes more flexible naming.
+- [[obsidian-day-planner|Day Planner]]: A plugin to help you plan your day and setup pomodoro timers
+- [[periodic-notes|Periodic Notes]]: Create/manage your daily, weekly, and monthly notes
+- [[random-structural-diary-plugin|Random Structural Diary]]: This is a plugin for picking random questions from prepared question list. It allows you answer on different questions each time.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins for vault statistics.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins for vault statistics.md
@@ -13,14 +13,14 @@ Show and display statistic information about your vault.
 
 ## Plugins in this category
 
-- [[youhavebeenstaring-plugin|YouHaveBeenStaring]]: This plugin tells you in the status bar for how long you've been staring at your obsidian vault. Well - at least how long your vault is open.
-- [[obsidian-vault-statistics-plugin|Vault Statistics]]: Status bar item with vault statistics such as number of notes, files, attachments, and links.
-- [[obsidian-commits|Commits]]: Track & show commits in obsidian vault or specified project.
-- [[obsidian-journey-plugin|Journey]]: Discover the stories between your notes.
-- [[obsidian-vault-changelog|Vault Changelog]]: Obsidian plugin to maintain a notes changelog in a vault
 - [[obsidian-activity-history|Activity History]]: Track activity of specified projects, Github like activity board
 - [[obsidian-activity-logger|Activity Logger]]: Log your activities like creating notes, modifying notes, deleting notes and so on.
+- [[obsidian-commits|Commits]]: Track & show commits in obsidian vault or specified project.
 - [[daily-activity|Daily Activity]]: A collection of commands to track your writing activity.
+- [[obsidian-journey-plugin|Journey]]: Discover the stories between your notes.
+- [[obsidian-vault-changelog|Vault Changelog]]: Obsidian plugin to maintain a notes changelog in a vault
+- [[obsidian-vault-statistics-plugin|Vault Statistics]]: Status bar item with vault statistics such as number of notes, files, attachments, and links.
+- [[youhavebeenstaring-plugin|YouHaveBeenStaring]]: This plugin tells you in the status bar for how long you've been staring at your obsidian vault. Well - at least how long your vault is open.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins that add or manage hotkeys.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins that add or manage hotkeys.md
@@ -12,29 +12,29 @@ publish: true
 
 ## Plugins in this category
 
-- [[hotkeysplus-obsidian|Hotkeys++]]: Additional hotkeys to do common things in Obsidian
-- [[leader-hotkeys-obsidian|Leader Hotkeys]]: Add leader hotkey support to any command (like tmux or vim)
-- [[shortcuts-extender|Shortcuts extender]]: Use shortcuts for text formatting or input special symbols without language switching
-- [[macOS-keyboard-nav-obsidian|macOS Keyboard Navigation]]: This plugin adds alt+up arrow and alt+down arrow keyboard navigation to Obsidian.
-- [[extract-highlights-plugin|Extract Highlights]]: Create, extract and leverage your markdown highlights
-- [[obsidian-juliandate|Julian Date Quick Insert]]: Simple hotkey to insert the current Julian Date
-- [[obsidian-min3ditorhotkeys-plugin|Min3ditorHotkeys]]: Additional editor hotkeys inspired by coding editors
-- [[obsidian-shortcuts-for-starred-files|Hotkeys for starred files]]: Set an individual hotkey for the first 9 starred files and searches and open them just with your keyboard.
-- [[obsidian-hotkeys-for-specific-files|Hotkeys for specific files]]: Set hotkeys for specific files and open them just with your keyboard.
-- [[obsidian-footnotes|Footnote Shortcut]]: Insert and write footnotes faster
-- [[code-block-from-selection|Code block from selection]]: Adds code block for the selected text
-- [[format-hotkeys-obsidian|Format Hotkeys]]: Google Docs style formatting hotkeys for Obsidian
-- [[hotkey-helper|Hotkey Helper]]: Easily see and access any plugin's settings or hotkey assignments (and conflicts) from the Community Plugins tab
-- [[obsidian-hotkeys-for-templates|Hotkeys for templates]]: Add hotkeys to insert specific templates
-- [[obsidian-underline|Underline]]: Add underline(`<u>xxx</u>`) with shortcut, and `<center>xxx</center>`, `[[#xxx]]`, `[[#^xxx]]`
 - [[obsidian-code-copy|Code Copy]]: Easily copy the contents of code blocks in Obsidian.
-- [[editor-commands-remap|Editor Commands Remap]]: Map hotkeys to editor commands.
-- [[obsidian-command-alias-plugin|Command Alias]]: This plugin gives aliases to Obsidian commands.
 - [[obsidian-editor-shortcuts|Code Editor Shortcuts]]: Add keyboard shortcuts (hotkeys) commonly found in code editors such as Visual Studio Code (vscode) or Sublime Text
-- [[obsidian-smarter-md-hotkeys|Smarter Markdown Hotkeys]]: Hotkeys that select words and lines in a smart way before applying markup. Multiple cursors are supported as well.
+- [[code-block-from-selection|Code block from selection]]: Adds code block for the selected text
+- [[obsidian-command-alias-plugin|Command Alias]]: This plugin gives aliases to Obsidian commands.
+- [[editor-commands-remap|Editor Commands Remap]]: Map hotkeys to editor commands.
+- [[extract-highlights-plugin|Extract Highlights]]: Create, extract and leverage your markdown highlights
+- [[obsidian-footnotes|Footnote Shortcut]]: Insert and write footnotes faster
+- [[format-hotkeys-obsidian|Format Hotkeys]]: Google Docs style formatting hotkeys for Obsidian
 - [[obsidian-global-hotkeys|Global Hotkeys]]: Add support for global hotkeys
+- [[hotkey-helper|Hotkey Helper]]: Easily see and access any plugin's settings or hotkey assignments (and conflicts) from the Community Plugins tab
 - [[obsidian-hotkeys-chords|Hotkeys Chords]]: Set hotkeys chords to activate commands
+- [[obsidian-hotkeys-for-specific-files|Hotkeys for specific files]]: Set hotkeys for specific files and open them just with your keyboard.
+- [[obsidian-shortcuts-for-starred-files|Hotkeys for starred files]]: Set an individual hotkey for the first 9 starred files and searches and open them just with your keyboard.
+- [[obsidian-hotkeys-for-templates|Hotkeys for templates]]: Add hotkeys to insert specific templates
+- [[hotkeysplus-obsidian|Hotkeys++]]: Additional hotkeys to do common things in Obsidian
+- [[obsidian-juliandate|Julian Date Quick Insert]]: Simple hotkey to insert the current Julian Date
 - [[obsidian-key-sequence-shortcut|Key Sequence Shortcut]]: Execute obsidian commands with short key sequences. For example, 'tp' for 'Toggle Preview' and 'tb' for 'Toggle Sidebar'. Easier to remember.
+- [[leader-hotkeys-obsidian|Leader Hotkeys]]: Add leader hotkey support to any command (like tmux or vim)
+- [[obsidian-min3ditorhotkeys-plugin|Min3ditorHotkeys]]: Additional editor hotkeys inspired by coding editors
+- [[shortcuts-extender|Shortcuts extender]]: Use shortcuts for text formatting or input special symbols without language switching
+- [[obsidian-smarter-md-hotkeys|Smarter Markdown Hotkeys]]: Hotkeys that select words and lines in a smart way before applying markup. Multiple cursors are supported as well.
+- [[obsidian-underline|Underline]]: Add underline(`<u>xxx</u>`) with shortcut, and `<center>xxx</center>`, `[[#xxx]]`, `[[#^xxx]]`
+- [[macOS-keyboard-nav-obsidian|macOS Keyboard Navigation]]: This plugin adds alt+up arrow and alt+down arrow keyboard navigation to Obsidian.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins to Enhance Workspaces.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins to Enhance Workspaces.md
@@ -13,8 +13,8 @@ Enhance Obsidian workspaces
 
 ## Plugins in this category
 
-- [[koncham-workspace|koncham workspace]]: obsidian workspace enhancements: vertical tabs, and more...
 - [[workspaces-plus|Workspaces Plus]]: Quickly switch and manage workspaces
+- [[koncham-workspace|koncham workspace]]: obsidian workspace enhancements: vertical tabs, and more...
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins to convert content into markdown.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins to convert content into markdown.md
@@ -13,16 +13,16 @@ Plugins to convert to [[Markdown]].
 
 ## Plugins in this category
 
-- [[convert-url-to-iframe|Convert url to preview (iframe)]]: Convert an url (ex, youtube) into an iframe (preview)
-- [[wikilinks-to-mdlinks-obsidian|Wikilinks to MDLinks (Markdown Links)]]: A plugin that converts wikilinks to markdown links and vice versa
-- [[pdf-to-markdown-plugin|PDF to Markdown]]: Save a PDF's text (headings, paragraphs, lists, etc.) to a Markdown file.
-- [[obsidian-extract-pdf-highlights|PDF Highlights]]: Extract highlights, underlines and annotations from your PDFs into Obsidian
-- [[obsidian-file-path-to-uri|File path to URI]]: Convert file path to uri for easier use of links to local files outside of Obsidian
 - [[better-pdf-plugin|Better PDF Plugin]]: Goal of this Plugin in to implement a native PDF handling workflow
-- [[extract-url|Extract url content]]: Extract url converting content into markdown
 - [[obsidian-csv-table|CSV Table]]: Render CSV data as a table within your notes.
-- [[obsidian-pluck|Pluck]]: Quickly create notes in Obsidian from web pages.
+- [[convert-url-to-iframe|Convert url to preview (iframe)]]: Convert an url (ex, youtube) into an iframe (preview)
 - [[obsidian-extract-pdf-annotations|Extract PDF Annotations]]: Extract PDF Annotations (Notes and Highlights) and sort them by topics
+- [[extract-url|Extract url content]]: Extract url converting content into markdown
+- [[obsidian-file-path-to-uri|File path to URI]]: Convert file path to uri for easier use of links to local files outside of Obsidian
+- [[obsidian-extract-pdf-highlights|PDF Highlights]]: Extract highlights, underlines and annotations from your PDFs into Obsidian
+- [[pdf-to-markdown-plugin|PDF to Markdown]]: Save a PDF's text (headings, paragraphs, lists, etc.) to a Markdown file.
+- [[obsidian-pluck|Pluck]]: Quickly create notes in Obsidian from web pages.
+- [[wikilinks-to-mdlinks-obsidian|Wikilinks to MDLinks (Markdown Links)]]: A plugin that converts wikilinks to markdown links and vice versa
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins to create charts.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins to create charts.md
@@ -15,11 +15,11 @@ publish: true
 
 ## Plugins in this category
 
-- [[obsidian-charts|Obsidian Charts]]: This Plugin lets you create Charts within Obsidian
-- [[obsidian-tracker|Tracker]]: A plugin tracks occurrences and numbers in your notes
 - [[obsidian-chartsview-plugin|Charts View]]: Data visualization solution in Obsidian based on Ant Design Charts.
 - [[obsidian-jupyter|Jupyter plugin]]: This plugin allows code blocks to be executed as Jupyter notebooks.
+- [[obsidian-charts|Obsidian Charts]]: This Plugin lets you create Charts within Obsidian
 - [[obsidian-plotly|Plotly]]: Obsidian plugin, which allow user to embed Plotly charts into markdown notes.
+- [[obsidian-tracker|Tracker]]: A plugin tracks occurrences and numbers in your notes
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins to edit other file types.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins to edit other file types.md
@@ -13,13 +13,13 @@ Plugins enabling Obsidian to edit files other than markdown `.md`.
 
 ## Plugins in this category
 
-- [[ini-obsidian|ini Editor]]: Edit ini files in Obsidian
-- [[txt-as-md-obsidian|txt as md]]: Edit txt files as if they were markdown
 - [[csv-obsidian|CSV Editor]]: Edit CSV files in Obsidian
-- [[mdx-as-md-obsidian|mdx as md]]: Edit mdx files as if they were markdown
-- [[obsidian-org-mode|Org Mode]]: Add Org Mode support to Obsidian.
-- [[obsidian-fountain|Fountain]]: Fountain Support for Obsidian
 - [[obsidian-excalidraw-plugin|Excalidraw]]: An Obsidian plugin to edit and view Excalidraw drawings
+- [[obsidian-fountain|Fountain]]: Fountain Support for Obsidian
+- [[obsidian-org-mode|Org Mode]]: Add Org Mode support to Obsidian.
+- [[ini-obsidian|ini Editor]]: Edit ini files in Obsidian
+- [[mdx-as-md-obsidian|mdx as md]]: Edit mdx files as if they were markdown
+- [[txt-as-md-obsidian|txt as md]]: Edit txt files as if they were markdown
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins to export markdown content.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins to export markdown content.md
@@ -15,9 +15,9 @@ Plugins to convert from [[Markdown]].
 
 - [[obsidian-export-to-tex|Export To TeX]]: Export vault files in a format amenable to pasting into a tex document
 - [[obsidian-jsonifier|JSONifier]]: Select text that you want to JSON.stringify(), or JSON.parse(). Select text and use the keystroke and the transformation will be copied to your clipboard. Paste it wherever you want.
-- [[obsidian-static-file-server|Static File Server]]: Host obsidian subfolders as static file servers.
-- [[obsidian-pandoc|Obsidian Pandoc]]: This is a Pandoc export plugin for Obsidian. It provides commands to export to formats like DOCX, ePub and PDF.
 - [[mochi-cards-exporter|Mochi Cards Exporter]]: Export Markdown notes to Mochi cards from within obsidian
+- [[obsidian-pandoc|Obsidian Pandoc]]: This is a Pandoc export plugin for Obsidian. It provides commands to export to formats like DOCX, ePub and PDF.
+- [[obsidian-static-file-server|Static File Server]]: Host obsidian subfolders as static file servers.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins to handle images.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins to handle images.md
@@ -13,10 +13,10 @@ Plugins to handle image files.
 
 ## Plugins in this category
 
-- [[obsidian-gallery|Gallery]]: Main Gallery to tag / filter / add notes to images. Display blocks to embed images inside notes. Display block to an image information
-- [[obsidian-image-toolkit|Obsidian Image Toolkit]]: This plugin provides some image viewing toolkit.
 - [[obsidian-banners|Banners]]: Add banner images to your notes!
 - [[copy-url-in-preview|Copy Image and URL in Preview]]: Copy Image and Copy URL context menu in preview mode
+- [[obsidian-gallery|Gallery]]: Main Gallery to tag / filter / add notes to images. Display blocks to embed images inside notes. Display block to an image information
+- [[obsidian-image-toolkit|Obsidian Image Toolkit]]: This plugin provides some image viewing toolkit.
 - [[oz-image-plugin|Ozan's Image in Editor Plugin]]: View Images, Transclusions, iFrames and PDF Files within the Editor without a necessity to switch to Preview.
 
 ## Related categories

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins to manage files and attachments.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins to manage files and attachments.md
@@ -13,14 +13,14 @@ Handle attachments, files, and folders
 
 ## Plugins in this category
 
+- [[obsidian-file-link|Better File Link]]: A plugin to add better external file links to notes.
+- [[consistent-attachments-and-links|Consistent attachments and links]]: This plugin ensures the consistency of attachments and links
+- [[copy-url-in-preview|Copy Image and URL in Preview]]: Copy Image and Copy URL context menu in preview mode
+- [[obsidian-daily-named-folder|Daily Named Folder]]: Like daily notes, but nested in a named daily folder. Better for attachment management. Includes more flexible naming.
+- [[luhman|Luhman]]: Commands for handling a zettelkasten with Luhmann-style IDs as filenames
 - [[obsidian-advanced-new-file|Obsidian Advanced New File]]: This is a plugin for choosing folder on note creation.
 - [[open-with|Open with]]: This Plugin allows you to add multiple other programs to open notes with.
-- [[obsidian-daily-named-folder|Daily Named Folder]]: Like daily notes, but nested in a named daily folder. Better for attachment management. Includes more flexible naming.
-- [[obsidian-file-link|Better File Link]]: A plugin to add better external file links to notes.
 - [[quick-explorer|Quick Explorer]]: Perform file explorer operations (and see your current file path) from the title bar, using the mouse or keyboard
-- [[luhman|Luhman]]: Commands for handling a zettelkasten with Luhmann-style IDs as filenames
-- [[copy-url-in-preview|Copy Image and URL in Preview]]: Copy Image and Copy URL context menu in preview mode
-- [[consistent-attachments-and-links|Consistent attachments and links]]: This plugin ensures the consistency of attachments and links
 - [[unique-attachments|Unique attachments]]: Rename attachments, making their names unique (based on hashing of file content)
 
 ## Related categories

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins to manage internal and external links.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins to manage internal and external links.md
@@ -13,31 +13,31 @@ Plugins to manage external or internal links.
 
 ## Plugins in this category
 
-- [[url-into-selection|Paste URL into selection]]: Paste URL "into" selected text.
 - [[mrj-crosslink-between-notes|Add links to current note]]: This plugin adds a command which allows to add a link to the current note at the bottom of selected notes
+- [[obsidian-advanced-uri|Advanced URI]]: Advanced modes for Obsidian URI
+- [[alx-folder-note|AidenLx's Folder Note]]: Add description, summary and more info to folders with folder notes.
+- [[obsidian-auto-link-title|Auto Link Title]]: This plugin automatically fetches the titles of links from the web
+- [[block-reference-count|Block Reference Counts]]: Shows the count of block references next to the block-id
 - [[convert-url-to-iframe|Convert url to preview (iframe)]]: Convert an url (ex, youtube) into an iframe (preview)
-- [[obsidian-link-indexer|Link indexer]]: Generate index notes with links based on various conditions
-- [[find-unlinked-files|Find unlinked files]]: Find files that are not linked anywhere and would otherwise be lost in your vault. In other words: files with no backlinks.
+- [[copy-url-in-preview|Copy Image and URL in Preview]]: Copy Image and Copy URL context menu in preview mode
 - [[obsidian-dangling-links|Dangling links panel]]: This plugin shows any dangling links in your vault.
 - [[extract-url|Extract url content]]: Extract url converting content into markdown
-- [[obsidian-advanced-uri|Advanced URI]]: Advanced modes for Obsidian URI
-- [[obsidian-auto-link-title|Auto Link Title]]: This plugin automatically fetches the titles of links from the web
-- [[obsidian-open-link-with|Open Link With]]: Open external link with specific browser in Obsidian
-- [[obsidian-rich-links|Obsidian Rich Links]]: Rich Links plugin for Obsidian.
-- [[tag-page-preview|Tag Page Preview]]: Clicking a tag opens a dialog listing pages that use that tag
-- [[hover-external-link|Hover External Link]]: Hover on external links to see the destination URL.
-- [[obsidian-pluck|Pluck]]: Quickly create notes in Obsidian from web pages.
-- [[copy-url-in-preview|Copy Image and URL in Preview]]: Copy Image and Copy URL context menu in preview mode
-- [[block-reference-count|Block Reference Counts]]: Shows the count of block references next to the block-id
-- [[folder-note-core|Folder Note Core]]: Provide core features and API for folder notes
-- [[alx-folder-note|AidenLx's Folder Note]]: Add description, summary and more info to folders with folder notes.
-- [[zoottelkeeper-obsidian-plugin|Zoottelkeeper Plugin]]: This plugin automatically creates, maintains and tags MOCs for all your folders.
+- [[find-unlinked-files|Find unlinked files]]: Find files that are not linked anywhere and would otherwise be lost in your vault. In other words: files with no backlinks.
 - [[folder-note-plugin|Folder Note]]: Click a folder node to show a note describing the folder.
-- [[link-headers-directly|Link Headers Directly]]: When a header is linked, preview mode will show only the header, and not the note name.
+- [[folder-note-core|Folder Note Core]]: Provide core features and API for folder notes
+- [[hover-external-link|Hover External Link]]: Hover on external links to see the destination URL.
 - [[obsidian-link-archive|Link Archive]]: This plugin archives links in your note so they're available to you even if the original site goes down or gets removed.
-- [[obsidian-link-converter|Obsidian Link Converter]]: Scan all your links in the vault and convert them to your desired format.
-- [[supercharged-links-obsidian|Supercharged Links]]: Add properties and menu options to links and style them!
+- [[link-headers-directly|Link Headers Directly]]: When a header is linked, preview mode will show only the header, and not the note name.
+- [[obsidian-link-indexer|Link indexer]]: Generate index notes with links based on various conditions
 - [[map-of-content|Map of Content]]: Automatically generate a Map of Content for your vault
+- [[obsidian-link-converter|Obsidian Link Converter]]: Scan all your links in the vault and convert them to your desired format.
+- [[obsidian-rich-links|Obsidian Rich Links]]: Rich Links plugin for Obsidian.
+- [[obsidian-open-link-with|Open Link With]]: Open external link with specific browser in Obsidian
+- [[url-into-selection|Paste URL into selection]]: Paste URL "into" selected text.
+- [[obsidian-pluck|Pluck]]: Quickly create notes in Obsidian from web pages.
+- [[supercharged-links-obsidian|Supercharged Links]]: Add properties and menu options to links and style them!
+- [[tag-page-preview|Tag Page Preview]]: Clicking a tag opens a dialog listing pages that use that tag
+- [[zoottelkeeper-obsidian-plugin|Zoottelkeeper Plugin]]: This plugin automatically creates, maintains and tags MOCs for all your folders.
 
 
 ## Related categories

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins to manage or annotate PDF files.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins to manage or annotate PDF files.md
@@ -13,13 +13,13 @@ Plugins that handle PDF files.
 
 ## Plugins in this category
 
-- [[pdf-to-markdown-plugin|PDF to Markdown]]: Save a PDF's text (headings, paragraphs, lists, etc.) to a Markdown file.
-- [[obsidian-extract-pdf-highlights|PDF Highlights]]: Extract highlights, underlines and annotations from your PDFs into Obsidian
-- [[better-pdf-plugin|Better PDF Plugin]]: Goal of this Plugin in to implement a native PDF handling workflow
 - [[obsidian-annotator|Annotator]]: This is a sample plugin for Obsidian. It allows you to open and annotate PDF and EPUB files.
-- [[oz-image-plugin|Ozan's Image in Editor Plugin]]: View Images, Transclusions, iFrames and PDF Files within the Editor without a necessity to switch to Preview.
-- [[obsidian-markmind|Obsidian markmind]]: This is a mindmap，outline and pdf annotate tool for obsidian.
+- [[better-pdf-plugin|Better PDF Plugin]]: Goal of this Plugin in to implement a native PDF handling workflow
 - [[obsidian-extract-pdf-annotations|Extract PDF Annotations]]: Extract PDF Annotations (Notes and Highlights) and sort them by topics
+- [[obsidian-markmind|Obsidian markmind]]: This is a mindmap，outline and pdf annotate tool for obsidian.
+- [[oz-image-plugin|Ozan's Image in Editor Plugin]]: View Images, Transclusions, iFrames and PDF Files within the Editor without a necessity to switch to Preview.
+- [[obsidian-extract-pdf-highlights|PDF Highlights]]: Extract highlights, underlines and annotations from your PDFs into Obsidian
+- [[pdf-to-markdown-plugin|PDF to Markdown]]: Save a PDF's text (headings, paragraphs, lists, etc.) to a Markdown file.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins to navigate notes.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins to navigate notes.md
@@ -13,19 +13,19 @@ publish: true
 
 ## Plugins in this category
 
-- [[mrj-jump-to-link|Jump to link]]: This plugin allows open a link in current document or regex based navigation in editor mode using hotkey
-- [[darlal-switcher-plus|Quick Switcher++]]: Enhanced Quick Switcher, search open panels, and symbols.
+- [[obsidian-another-quick-switcher|Another Quick Switcher]]: This is an Obsidian plugin which is another choice of Quick switcher.
 - [[obsidian-reveal-active-file|Automatically Reveal Active File]]: This plugin will reveal the active file in the navigation when a file is opened.
-- [[pane-relief|Pane Relief]]: Per-pane history, hotkeys for pane movement + navigation, and more
+- [[breadcrumbs|Breadcrumbs]]: Visualise & navigate your vault's structure
+- [[calendar|Calendar]]: Calendar view of your daily notes
 - [[obsidian-collapse-all-plugin|Collapse All]]: This plugin adds a button to collapse or expand all folders in the file explorer.
-- [[homepage|Homepage]]: Open a specified note on startup.
 - [[file-explorer-markdown-titles|File Explorer Markdown Titles]]: Shows the first markdown header of a note in the file explorer
 - [[obsidian-go-to-line|Go to Line]]: This Plugin provides a go to Line Command
-- [[calendar|Calendar]]: Calendar view of your daily notes
-- [[breadcrumbs|Breadcrumbs]]: Visualise & navigate your vault's structure
-- [[obsidian-zoom|Zoom]]: Zoom into heading and lists.
-- [[obsidian-another-quick-switcher|Another Quick Switcher]]: This is an Obsidian plugin which is another choice of Quick switcher.
+- [[homepage|Homepage]]: Open a specified note on startup.
+- [[mrj-jump-to-link|Jump to link]]: This plugin allows open a link in current document or regex based navigation in editor mode using hotkey
+- [[pane-relief|Pane Relief]]: Per-pane history, hotkeys for pane movement + navigation, and more
+- [[darlal-switcher-plus|Quick Switcher++]]: Enhanced Quick Switcher, search open panels, and symbols.
 - [[reveal-active-file-button|Reveal Active File Button]]: Add a button to the top of the File Explorer, to reveal the active file.
+- [[obsidian-zoom|Zoom]]: Zoom into heading and lists.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins with custom codeblock syntax.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins with custom codeblock syntax.md
@@ -13,20 +13,20 @@ Plugins that add specific renderers to Obsidian.
 
 ## Plugins in this category
 
-- [[dataview|Dataview]]: Complex data views for the data-obsessed.
-- [[obsidian-kroki|Kroki]]: Render Kroki Diagrams
-- [[obsidian-wavedrom|Wavedrom]]: This is very rough and quick integration of WaveDrom into obsidian
-- [[music-code-blocks|Music Sheet Code Blocks]]: Plugin which renders music notation from code blocks. Uses the `music-abc` language.
-- [[drawio-obsidian|Diagrams]]: Draw.io diagrams for Obsidian. This plugin introduces diagrams that can be included within notes or as stand-alone files. Diagrams are created as SVG files (although .drawio extensions are also supported).
-- [[obsidian-plantuml|PlantUML]]: Render PlantUML Diagrams
-- [[scales-chords|Scales and Chords]]: Use this plugin to capture musical tab notation in your Obsidian vault.  Chords will become clickable links to modal images (provided by scales-chords.com)
 - [[obsidian-5e-statblocks|5e Statblocks]]: Create 5e styled statblocks in Obsidian.md
-- [[initiative-tracker|Initiative Tracker]]: TTRPG Initiative Tracker for Obsidian.md
-- [[obsidian-markdown-furigana|Markdown Furigana]]: Simple Markdown to Furigana Rendering Plugin for Obsidian.
-- [[obsidian-query2table|query2table]]: Represent files returned by a query as a table of their YAML frontmatter
 - [[obsidian-admonition|Admonition]]: Admonition block-styled content for Obsidian.md
+- [[dataview|Dataview]]: Complex data views for the data-obsessed.
+- [[drawio-obsidian|Diagrams]]: Draw.io diagrams for Obsidian. This plugin introduces diagrams that can be included within notes or as stand-alone files. Diagrams are created as SVG files (although .drawio extensions are also supported).
+- [[initiative-tracker|Initiative Tracker]]: TTRPG Initiative Tracker for Obsidian.md
+- [[obsidian-kroki|Kroki]]: Render Kroki Diagrams
+- [[obsidian-markdown-furigana|Markdown Furigana]]: Simple Markdown to Furigana Rendering Plugin for Obsidian.
+- [[music-code-blocks|Music Sheet Code Blocks]]: Plugin which renders music notation from code blocks. Uses the `music-abc` language.
 - [[obsidian-pikt|Pikt]]: A plugin to render Pikchr codeblocks.
+- [[obsidian-plantuml|PlantUML]]: Render PlantUML Diagrams
 - [[obsidian-react-components|React Components]]: This is a plugin for Obsidian. It allows you to write and use React components with Jsx inside your Obsidian notes.
+- [[scales-chords|Scales and Chords]]: Use this plugin to capture musical tab notation in your Obsidian vault.  Chords will become clickable links to modal images (provided by scales-chords.com)
+- [[obsidian-wavedrom|Wavedrom]]: This is very rough and quick integration of WaveDrom into obsidian
+- [[obsidian-query2table|query2table]]: Represent files returned by a query as a table of their YAML frontmatter
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins with custom views.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins with custom views.md
@@ -14,30 +14,30 @@ Plugins that change or add new views, modify how notes are displayed or add popo
 ## Plugins in this category
 
 
-- [[obsidian-mind-map|Mind Map]]: A plugin to preview notes as Markmap mind maps
-- [[obsidian-comments|Comments]]: Add, track and easily navigate between a note's Comments
-- [[obsidian-timelines|Timelines]]: Create a timeline view of all notes with the specified combination of tags
-- [[obsidian-daily-stats|Daily Stats]]: Track your daily word count across all notes in your vault.
-- [[obsidian-gallery|Gallery]]: Main Gallery to tag / filter / add notes to images. Display blocks to embed images inside notes. Display block to an image information
-- [[obsidian-dice-roller|Dice Roller]]: Inline dice rolling for Obsidian.md
-- [[obsidian-kanban|Kanban]]: Create markdown-backed Kanban boards in Obsidian.
-- [[obsidian-metatable|Metatable]]: Displays the full frontmatter as a table.
 - [[obsidian-2hop-links-plugin|2Hop Links Plugin]]: Add links to other pages at the bottom of the editor.
 - [[obsidian-5e-statblocks|5e Statblocks]]: Create 5e styled statblocks in Obsidian.md
-- [[obsidian-zoom|Zoom]]: Zoom into heading and lists.
 - [[better-fn|Better footnote]]: Footnote popover for Obsidian
-- [[obsidian-habit-tracker|Habit Tracker]]: This plguin creates a simple Month view for visualizing your punch records.
-- [[obsidian-timeline|Timeline]]: Used to build great timelines
 - [[breadcrumbs|Breadcrumbs]]: Visualise & navigate your vault's structure
+- [[obsidian-card-view-mode|Card View Mode]]: Enable to view your notes as cards.
+- [[obsidian-comments|Comments]]: Add, track and easily navigate between a note's Comments
+- [[obsidian-daily-stats|Daily Stats]]: Track your daily word count across all notes in your vault.
+- [[obsidian-dice-roller|Dice Roller]]: Inline dice rolling for Obsidian.md
+- [[obsidian-focus-mode|Focus Mode]]: Add Focus Mode to Obsidian.
+- [[obsidian-view-mode-by-frontmatter|Force note view mode by front matter]]: This plugin allows to force the view mode (preview or source) for a note by using front matter
+- [[obsidian-fullscreen-plugin|Fullscreen Focus Mode]]: This plugin allows viewing a single document in fullscreen focus mode
+- [[obsidian-gallery|Gallery]]: Main Gallery to tag / filter / add notes to images. Display blocks to embed images inside notes. Display block to an image information
+- [[obsidian-habit-tracker|Habit Tracker]]: This plguin creates a simple Month view for visualizing your punch records.
 - [[hover-external-link|Hover External Link]]: Hover on external links to see the destination URL.
+- [[obsidian-kanban|Kanban]]: Create markdown-backed Kanban boards in Obsidian.
+- [[obsidian-map-view|Map View]]: An interactive map view.
+- [[obsidian-metatable|Metatable]]: Displays the full frontmatter as a table.
+- [[obsidian-mind-map|Mind Map]]: A plugin to preview notes as Markmap mind maps
 - [[obsidian-image-toolkit|Obsidian Image Toolkit]]: This plugin provides some image viewing toolkit.
 - [[oz-image-plugin|Ozan's Image in Editor Plugin]]: View Images, Transclusions, iFrames and PDF Files within the Editor without a necessity to switch to Preview.
 - [[obsidian-stille|Stille]]: Focus on your writing, a section at a time.
-- [[obsidian-card-view-mode|Card View Mode]]: Enable to view your notes as cards.
-- [[obsidian-focus-mode|Focus Mode]]: Add Focus Mode to Obsidian.
-- [[obsidian-fullscreen-plugin|Fullscreen Focus Mode]]: This plugin allows viewing a single document in fullscreen focus mode
-- [[obsidian-view-mode-by-frontmatter|Force note view mode by front matter]]: This plugin allows to force the view mode (preview or source) for a note by using front matter
-- [[obsidian-map-view|Map View]]: An interactive map view.
+- [[obsidian-timeline|Timeline]]: Used to build great timelines
+- [[obsidian-timelines|Timelines]]: Create a timeline view of all notes with the specified combination of tags
+- [[obsidian-zoom|Zoom]]: Zoom into heading and lists.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Refactoring and auto-formatting plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Refactoring and auto-formatting plugins.md
@@ -13,19 +13,19 @@ Plugins that help you refactor and reformat your notes. These plugins offer addi
 
 ## Plugins in this category
 
-- [[note-refactor-obsidian|Note Refactor]]: Extract note content into new notes and split notes
-- [[markdown-prettifier|Markdown prettifier]]: Tries to fix and reformat ugly Markdown and adds things like 'modified date' etc.
-- [[footlinks|Footlinks]]: Extracts links from the main text to footer.
-- [[obsidian-plugin-prettier|Prettier Format]]: Opinionated formatting for your notes.
-- [[obsidian-tidy-footnotes|Tidy Footnotes]]: Tidy your footnotes seamlessly.
-- [[easy-typing-obsidian|Easy Typing]]: Autoformat your note as typing.(Auto captalize, autospace)
-- [[obsidian-title-index|Obsidian title index]]: obsidian-title-index
-- [[obsidian-linter|Linter]]: Enforces consistent markdown styling.
-- [[obsidian-regex-pipeline|Regex Pipeline]]: Allows users setup custom regex rules to automatically format notes
-- [[number-headings-obsidian|Number Headings]]: Automatically number or re-number headings in an Obsidian document
-- [[tag-wrangler|Tag Wrangler]]: Rename, merge, toggle, and search tags from the tag pane
-- [[obsidian-task-archiver|Obsidian Task Archiver]]: Move completed tasks to an archive with a date tree
 - [[completed-area|Completed Area]]: Move completed to-do items to a seperate completed area.
+- [[easy-typing-obsidian|Easy Typing]]: Autoformat your note as typing.(Auto captalize, autospace)
+- [[footlinks|Footlinks]]: Extracts links from the main text to footer.
+- [[obsidian-linter|Linter]]: Enforces consistent markdown styling.
+- [[markdown-prettifier|Markdown prettifier]]: Tries to fix and reformat ugly Markdown and adds things like 'modified date' etc.
+- [[note-refactor-obsidian|Note Refactor]]: Extract note content into new notes and split notes
+- [[number-headings-obsidian|Number Headings]]: Automatically number or re-number headings in an Obsidian document
+- [[obsidian-task-archiver|Obsidian Task Archiver]]: Move completed tasks to an archive with a date tree
+- [[obsidian-title-index|Obsidian title index]]: obsidian-title-index
+- [[obsidian-plugin-prettier|Prettier Format]]: Opinionated formatting for your notes.
+- [[obsidian-regex-pipeline|Regex Pipeline]]: Allows users setup custom regex rules to automatically format notes
+- [[tag-wrangler|Tag Wrangler]]: Rename, merge, toggle, and search tags from the tag pane
+- [[obsidian-tidy-footnotes|Tidy Footnotes]]: Tidy your footnotes seamlessly.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Search and query plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Search and query plugins.md
@@ -13,21 +13,21 @@ Querying
 
 ## Plugins in this category
 
-- [[mrj-text-expand|Text {{expand}}]]: Search and paste/transclude links to located files.
-- [[searchpp|Search++]]: Allow inserting text context search results on the active note, the plugin is based on the plugin mrj-text-expand-witb-text of MrJackphil.
-- [[smart-random-note|Smart Random Note]]: A smart random note plugin
-- [[neo4j-graph-view|Neo4j Graph View]]: An Obsidian plugin for advanced graph visualization and querying using Neo4j.
-- [[obsidian-query2table|query2table]]: Represent files returned by a query as a table of their YAML frontmatter
-- [[search-on-internet|Search on Internet]]: Add context menu items to search the internet within Obsidian.
-- [[vantage-obsidian|Vantage - Advanced search builder]]: Build advanced search queries in Obsidian.
-- [[obsidian-query-language|Obsidian Query Language]]: This plugin allows you to query notes and represent data within Obsidian
+- [[obsidian-core-search-assistant-plugin|Core Search Assistant]]: Enhance built-in search: keyboard interface, card preview, bigger preview
 - [[dataview|Dataview]]: Complex data views for the data-obsessed.
-- [[obsidian-spotlight|Spotlight]]: Block that features random notes or block of a note from vault / in a specified project or with a certain combination of tags.
+- [[neo4j-graph-view|Neo4j Graph View]]: An Obsidian plugin for advanced graph visualization and querying using Neo4j.
+- [[obsidian-query-language|Obsidian Query Language]]: This plugin allows you to query notes and represent data within Obsidian
+- [[obsidian-power-search|Power Search]]: Searches Anki Notes based on current line
 - [[obsidian-related-notes-finder|Related Notes Finder]]: An Obsidian plugin that adds extra features for finding related notes.
 - [[obsidian-relative-find|Relative Find]]: This Plugin lets you search relative to your Cursor Position.
-- [[obsidian-core-search-assistant-plugin|Core Search Assistant]]: Enhance built-in search: keyboard interface, card preview, bigger preview
 - [[obsidian-search-everywhere-plugin|Search Everywhere]]: Search Everywhere with pressing Double Shift like in IntelliJ
-- [[obsidian-power-search|Power Search]]: Searches Anki Notes based on current line
+- [[search-on-internet|Search on Internet]]: Add context menu items to search the internet within Obsidian.
+- [[searchpp|Search++]]: Allow inserting text context search results on the active note, the plugin is based on the plugin mrj-text-expand-witb-text of MrJackphil.
+- [[smart-random-note|Smart Random Note]]: A smart random note plugin
+- [[obsidian-spotlight|Spotlight]]: Block that features random notes or block of a note from vault / in a specified project or with a certain combination of tags.
+- [[mrj-text-expand|Text {{expand}}]]: Search and paste/transclude links to located files.
+- [[vantage-obsidian|Vantage - Advanced search builder]]: Build advanced search queries in Obsidian.
+- [[obsidian-query2table|query2table]]: Represent files returned by a query as a table of their YAML frontmatter
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Side bar plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Side bar plugins.md
@@ -15,13 +15,13 @@ Plugins that add panes to your sidebar.
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
-- [[juggl|Juggl]]: Adds a completely interactive, stylable and expandable graph view to Obsidian.
 - [[calendar|Calendar]]: Calendar view of your daily notes
 - [[customizable-sidebar|Customizable Sidebar]]: This Plugin allows to add any Command to Obsidian's Sidebar Ribbon.
-- [[obsidian-hide-sidebars-when-narrow|Hide Sidebars When Narrow]]: Automatically hides the sidebars when your window is narrow.
-- [[window-collapse|Window Collapse]]: This plugins provides an easy way to collapse the sidebars without going fullscreen.
-- [[obsidian-sidebar-expand-on-hover|Sidebar Expand on Hover]]: This Obsidian plugin expands or collapses the sidebars based on mouse hovering on the ribbons.
 - [[obsidian-daily-stats|Daily Stats]]: Track your daily word count across all notes in your vault.
+- [[obsidian-hide-sidebars-when-narrow|Hide Sidebars When Narrow]]: Automatically hides the sidebars when your window is narrow.
+- [[juggl|Juggl]]: Adds a completely interactive, stylable and expandable graph view to Obsidian.
+- [[obsidian-sidebar-expand-on-hover|Sidebar Expand on Hover]]: This Obsidian plugin expands or collapses the sidebars based on mouse hovering on the ribbons.
+- [[window-collapse|Window Collapse]]: This plugins provides an easy way to collapse the sidebars without going fullscreen.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Status bar plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Status bar plugins.md
@@ -13,15 +13,15 @@ Plugins that add an item to the status bar.
 
 ## Plugins in this category
 
-- [[obsidian-reading-time|Reading Time]]: Add the current note's reading time to Obsidian's status bar.
-- [[obsidian-hider|Hider]]: Hide UI elements such as tooltips, status, titlebar and more
-- [[youhavebeenstaring-plugin|YouHaveBeenStaring]]: This plugin tells you in the status bar for how long you've been staring at your obsidian vault. Well - at least how long your vault is open.
-- [[obsidian-show-file-path|Show Current File Path]]: Show the full path of the currently open file in the status bar
-- [[obsidian-vault-statistics-plugin|Vault Statistics]]: Status bar item with vault statistics such as number of notes, files, attachments, and links.
-- [[obsidian-grandfather|Grandfather]]: A simple plugin to display the time and date on the status bar
-- [[obsidian-statusbar-pomo|Status Bar Pomodoro Timer]]: Adds a pomodoro timer to your status bar.
-- [[obsidian-cursor-location-plugin|Cursor Location]]: This displays the location of the cursor (character and line number).
 - [[better-word-count|Better Word Count]]: Counts the words of selected text in the editor.
+- [[obsidian-cursor-location-plugin|Cursor Location]]: This displays the location of the cursor (character and line number).
+- [[obsidian-grandfather|Grandfather]]: A simple plugin to display the time and date on the status bar
+- [[obsidian-hider|Hider]]: Hide UI elements such as tooltips, status, titlebar and more
+- [[obsidian-reading-time|Reading Time]]: Add the current note's reading time to Obsidian's status bar.
+- [[obsidian-show-file-path|Show Current File Path]]: Show the full path of the currently open file in the status bar
+- [[obsidian-statusbar-pomo|Status Bar Pomodoro Timer]]: Adds a pomodoro timer to your status bar.
+- [[obsidian-vault-statistics-plugin|Vault Statistics]]: Status bar item with vault statistics such as number of notes, files, attachments, and links.
+- [[youhavebeenstaring-plugin|YouHaveBeenStaring]]: This plugin tells you in the status bar for how long you've been staring at your obsidian vault. Well - at least how long your vault is open.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Style and Appearance Plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Style and Appearance Plugins.md
@@ -13,25 +13,25 @@ Plugins that change the appearance or style of Obsidian's User Interface.
 
 ## Plugins in this category
 
-- [[obsidian-system-dark-mode|System Dark Mode]]: Automatically use the operating system's setting to switch between light and dark mode.
-- [[obsidian-icons-plugin|Icons Plugin]]: Add icons to your Obsidian notes.
-- [[theme-picker|Theme Picker]]: Quickly preview installed themes
-- [[obsidian-reset-font-size|Reset Font Size]]: Adds button and command to reset the font size back to its default value.
-- [[obsidian-contextual-typography|Contextual Typography]]: This plugin adds a data-tag-name attribute to all top-level divs in preview mode containing the child's tag name, allowing contextual typography styling.
-- [[obsidian-highlightpublicnotes-plugin|Highlight Public Notes]]: This plugin warns that a note is public (based on a frontmatter attribute) by colorizing the note red.
-- [[obsidian-codemirror-options|CodeMirror Options]]: Enhance Obsidian's desktop edit mode with features such as WYSIWYG / Live Preview, Syntax Highlighting, and more.
-- [[cm-show-whitespace-obsidian|Show Whitespace]]: Show whitespace in the editor
-- [[css-snippets|css snippets]]: Load and manage css snippets
-- [[obsidian-icon-folder|Icon Folder]]: This plugin allows to add an emoji in front of a folder or icon.
-- [[obsidian-icon-swapper|Icon Swapper]]: Allows swapping out Obsidian's default icons.
-- [[obsidian-budget-wysiwyg|Budget WYSIWYG]]: This is a plugin that automatically switches between preview mode and source mode based on if you are typing or not.
-- [[obsidian-electron-window-tweaker|Electron Window Tweaker]]: Tweak various Electron window settings.
 - [[open-note-to-window-title|Active note to window title]]: Allows template-based customization of the app window title
 - [[block-reference-count|Block Reference Counts]]: Shows the count of block references next to the block-id
+- [[obsidian-budget-wysiwyg|Budget WYSIWYG]]: This is a plugin that automatically switches between preview mode and source mode based on if you are typing or not.
+- [[obsidian-codemirror-options|CodeMirror Options]]: Enhance Obsidian's desktop edit mode with features such as WYSIWYG / Live Preview, Syntax Highlighting, and more.
+- [[obsidian-contextual-typography|Contextual Typography]]: This plugin adds a data-tag-name attribute to all top-level divs in preview mode containing the child's tag name, allowing contextual typography styling.
+- [[obsidian-electron-window-tweaker|Electron Window Tweaker]]: Tweak various Electron window settings.
 - [[obsidian-embedded-code-title|Embedded Code Title]]: This is an Obsidian plugin which can embeds title to code blocks.
-- [[obsidian-relative-line-numbers|Relative Line Numbers]]: Enables relative line numbers in editor mode
+- [[obsidian-highlightpublicnotes-plugin|Highlight Public Notes]]: This plugin warns that a note is public (based on a frontmatter attribute) by colorizing the note red.
+- [[obsidian-icon-folder|Icon Folder]]: This plugin allows to add an emoji in front of a folder or icon.
+- [[obsidian-icon-swapper|Icon Swapper]]: Allows swapping out Obsidian's default icons.
+- [[obsidian-icons-plugin|Icons Plugin]]: Add icons to your Obsidian notes.
 - [[obsidian-indent-lines|Indentation Lines]]: Creates connection-lines for ordered and unordered lists regardless of nesting etc.
 - [[obsidian-prominent-starred-files|Prominent Starred Files]]: Prominently display starred notes in the file explorer
+- [[obsidian-relative-line-numbers|Relative Line Numbers]]: Enables relative line numbers in editor mode
+- [[obsidian-reset-font-size|Reset Font Size]]: Adds button and command to reset the font size back to its default value.
+- [[cm-show-whitespace-obsidian|Show Whitespace]]: Show whitespace in the editor
+- [[obsidian-system-dark-mode|System Dark Mode]]: Automatically use the operating system's setting to switch between light and dark mode.
+- [[theme-picker|Theme Picker]]: Quickly preview installed themes
+- [[css-snippets|css snippets]]: Load and manage css snippets
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Tag management plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Tag management plugins.md
@@ -15,11 +15,11 @@ Plugins to manage tags.
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
-- [[tag-wrangler|Tag Wrangler]]: Rename, merge, toggle, and search tags from the tag pane
-- [[tag-page-preview|Tag Page Preview]]: Clicking a tag opens a dialog listing pages that use that tag
-- [[obsidian-tagfolder|TagFolder]]: Show tags as folder
 - [[obsidian-frontmatter-tag-suggest|Frontmatter Tag Suggest]]: Autocompletes tags in the frontmatter tags field
 - [[tag-word-cloud|Tag & Word Cloud]]: Show a cloud of your tags/words in a note
+- [[tag-page-preview|Tag Page Preview]]: Clicking a tag opens a dialog listing pages that use that tag
+- [[tag-wrangler|Tag Wrangler]]: Rename, merge, toggle, and search tags from the tag pane
+- [[obsidian-tagfolder|TagFolder]]: Show tags as folder
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Task management plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Task management plugins.md
@@ -13,31 +13,31 @@ publish: true
 
 ## Plugins in this category
 
-- [[slated-obsidian|Slated]]: Task Management - schedule, move, and repeat tasks
-- [[todoist-sync-plugin|Todoist Sync Plugin]]: Materialize Todoist tasks within Obsidian notes.
-- [[obsidian-day-planner|Day Planner]]: A plugin to help you plan your day and setup pomodoro timers
-- [[completed-area|Completed Area]]: Move completed to-do items to a seperate completed area.
-- [[obsidian-rollover-daily-todos|Rollover Daily Todos]]: This Obsidian.md plugin rolls over incomplete TODOs from the previous daily note to today's daily note. (https://obsidian.md)
-- [[completed-task-display|Completed Task Display]]: Provides a button in the ribbon to hide or display completed tasks
+- [[obsidian-amazingmarvin-plugin|Amazing Marvin]]: This is a plugin for Obsidian (https://obsidian.md) for Amazing Marvin (https://app.amazingmarvin.com/)
+- [[obsidian-apple-reminders-plugin|Apple Reminders]]: 
+- [[card-board|CardBoard]]: Display markdown tasks on kanban-style boards.
 - [[obsidian-checklist-plugin|Checklist]]: Combines checklists across pages into users sidebar
-- [[obsidian-plugin-todo|Obsidian TODO | Text-based GTD]]: Text-based GTD in Obsidian. Collects all outstanding TODOs from your vault and presents them in lists Today, Scheduled, Inbox and Someday/Maybe.
-- [[todo-txt|Todo.txt support]]: Native support for todo.txt files
+- [[completed-area|Completed Area]]: Move completed to-do items to a seperate completed area.
+- [[completed-task-display|Completed Task Display]]: Provides a button in the ribbon to hide or display completed tasks
+- [[obsidian-day-planner|Day Planner]]: A plugin to help you plan your day and setup pomodoro timers
 - [[obsidian-kanban|Kanban]]: Create markdown-backed Kanban boards in Obsidian.
-- [[obsidian-tasks-plugin|Tasks]]: Task management for Obsidian
-- [[tq-obsidian|tq]]: File-based Task Management
-- [[obsidian-statusbar-pomo|Status Bar Pomodoro Timer]]: Adds a pomodoro timer to your status bar.
+- [[obsidian-plugin-todo|Obsidian TODO | Text-based GTD]]: Text-based GTD in Obsidian. Collects all outstanding TODOs from your vault and presents them in lists Today, Scheduled, Inbox and Someday/Maybe.
+- [[obsidian-task-archiver|Obsidian Task Archiver]]: Move completed tasks to an archive with a date tree
+- [[imdone-obsidian-plugin|Open cards in imdone from obsidian.]]: This plugin allows imdone users to open their imdone board from a document in their obsidian vault that contains imdone cards.
+- [[obsidian-overdue|Overdue]]: Marks items as \[\[Overdue]] if they are not checked off by their due date
 - [[obsidian-random-todo|Random To-Do]]: Open a random file containing your custom to-do marker, or a random marker at its position
 - [[obsidian-reminder-plugin|Reminder]]: Reminder plugin for Obsidian. This plugin adds feature to manage TODOs with reminder.
-- [[imdone-obsidian-plugin|Open cards in imdone from obsidian.]]: This plugin allows imdone users to open their imdone board from a document in their obsidian vault that contains imdone cards.
-- [[obsidian-amazingmarvin-plugin|Amazing Marvin]]: This is a plugin for Obsidian (https://obsidian.md) for Amazing Marvin (https://app.amazingmarvin.com/)
-- [[obsidian-task-archiver|Obsidian Task Archiver]]: Move completed tasks to an archive with a date tree
-- [[obsidian-apple-reminders-plugin|Apple Reminders]]: 
-- [[things-logbook|Things Logbook]]: Sync your Things.app Logbook with Daily Notes
-- [[obsidian-overdue|Overdue]]: Marks items as \[\[Overdue]] if they are not checked off by their due date
+- [[obsidian-rollover-daily-todos|Rollover Daily Todos]]: This Obsidian.md plugin rolls over incomplete TODOs from the previous daily note to today's daily note. (https://obsidian.md)
+- [[slated-obsidian|Slated]]: Task Management - schedule, move, and repeat tasks
+- [[obsidian-statusbar-pomo|Status Bar Pomodoro Timer]]: Adds a pomodoro timer to your status bar.
 - [[obsidian-task-collector|Task Collector (TC)]]: Manage completed tasks within a document
-- [[todoist-text|Todoist Text]]: This obsidian plugin integrates your Todoist tasks with markdown checkboxes.
+- [[obsidian-tasks-plugin|Tasks]]: Task management for Obsidian
 - [[obsidian-things-link|Things Link]]: Seamlessly create Things tasks and projects from Obsidian
-- [[card-board|CardBoard]]: Display markdown tasks on kanban-style boards.
+- [[things-logbook|Things Logbook]]: Sync your Things.app Logbook with Daily Notes
+- [[todo-txt|Todo.txt support]]: Native support for todo.txt files
+- [[todoist-sync-plugin|Todoist Sync Plugin]]: Materialize Todoist tasks within Obsidian notes.
+- [[todoist-text|Todoist Text]]: This obsidian plugin integrates your Todoist tasks with markdown checkboxes.
+- [[tq-obsidian|tq]]: File-based Task Management
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Template plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Template plugins.md
@@ -13,14 +13,14 @@ Plugins to apply templates beyond what [[Obsidian Core Plugins#Templates]] offer
 
 ## Plugins in this category
 
+- [[obsidian-filename-heading-sync|Filename Heading Sync]]: Obsidian plugin for keeping the filename with the first heading of a file in sync
+- [[liquid-templates|Liquid Templates]]: Empower your template with LiquidJS tags
+- [[page-heading-from-links|Page Heading From Links]]: Inserts a heading into blank pages from the filename
+- [[podcast-note|Podcast Note]]: Podcast Note lets you automatically add podcast information to your notes.
+- [[quickadd|QuickAdd]]: Quickly add new pages or content to your vault.
 - [[templater-obsidian|Templater]]: Create and use templates
 - [[obsidian-temple|Temple]]: A plugin for templating in Obsidian, powered by Nunjucks.
 - [[obsidian-metatemplates|metatemplates]]: Generate notes from templates using YAML front-matter
-- [[page-heading-from-links|Page Heading From Links]]: Inserts a heading into blank pages from the filename
-- [[obsidian-filename-heading-sync|Filename Heading Sync]]: Obsidian plugin for keeping the filename with the first heading of a file in sync
-- [[liquid-templates|Liquid Templates]]: Empower your template with LiquidJS tags
-- [[podcast-note|Podcast Note]]: Podcast Note lets you automatically add podcast information to your notes.
-- [[quickadd|QuickAdd]]: Quickly add new pages or content to your vault.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Theme settings plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Theme settings plugins.md
@@ -15,11 +15,11 @@ Plugins developed to adjust the settings of [[🗂️ Themes|Obsidian Themes]]. 
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
-- [[obsidian-style-settings|Style Settings]]: Offers controls for adjusting theme, plugin, and snippet CSS variables.
-- [[obsidian-minimal-settings|Minimal Theme Settings]]: Change the colors, fonts and features of Minimal Theme.
 - [[obsidian-advanced-appearance|Advanced Appearance]]: Change colors, fonts and other cosmetic settings.
-- [[obsidian-hider|Hider]]: Hide UI elements such as tooltips, status, titlebar and more
 - [[discordian-plugin|Discordian Theme]]: Discordian plugin for tweaking Discordian theme
+- [[obsidian-hider|Hider]]: Hide UI elements such as tooltips, status, titlebar and more
+- [[obsidian-minimal-settings|Minimal Theme Settings]]: Change the colors, fonts and features of Minimal Theme.
+- [[obsidian-style-settings|Style Settings]]: Offers controls for adjusting theme, plugin, and snippet CSS variables.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Third-Party Integration Plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Third-Party Integration Plugins.md
@@ -13,56 +13,56 @@ Plugins to integrate with other services or applications.
 
 ## Plugins in this category
 
-- [[todoist-sync-plugin|Todoist Sync Plugin]]: Materialize Todoist tasks within Obsidian notes.
-- [[obsidian-discordrpc|Discord Rich Presence]]: Update your Discord Status to show your friends what you are working on in Obsidian. With Discord Rich Presence.
-- [[obsidian-youglish-plugin|Youglish Plugin]]: Use YouTube to improve your pronunciation. YouGlish gives you fast, unbiased answers about how words is spoken by real people and in context.
-- [[flashcards-obsidian|Flashcards]]: Anki integration
-- [[obsidian-to-anki-plugin|Obsidian_to_Anki]]: This is an Anki integration plugin! Designed for efficient bulk exporting.
-- [[obsidian-apple-reminders-plugin|Apple Reminders]]: 
-- [[obsidian-imgur-plugin|Imgur Plugin]]: This plugin uploads images from your clipboard to imgur.com and embeds uploaded image to your note
-- [[things-logbook|Things Logbook]]: Sync your Things.app Logbook with Daily Notes
-- [[notetweet|NoteTweet]]: This plugin allows you to post tweets directly from Obsidian.
-- [[obsidian-leaflet-plugin|Obsidian Leaflet]]: Interactive maps inside your notes
-- [[DEVONlink-obsidian|DEVONlink - Open or reveal notes in DEVONthink]]: Open or reveal the current note in DEVONthink.
-- [[imdone-obsidian-plugin|Open cards in imdone from obsidian.]]: This plugin allows imdone users to open their imdone board from a document in their obsidian vault that contains imdone cards.
-- [[obsidian-languagetool-plugin|LanguageTool Integration]]: Spelling and grammar checks with the LanguageTool API
-- [[obsidian-readwise|Readwise Community]]: Sync Readwise highlights into your notes
-- [[obsidian-kindle-plugin|Kindle Highlights]]: Sync your Kindle book highlights using your Amazon login or uploading your My Clippings file
-- [[beeminder-word-count-plugin|Beeminder Word Count Plugin]]: This lets you post word counts directly from obsidian file to Beeminder.
-- [[obsidian-image-auto-upload-plugin|Image auto upload Plugin]]: This plugin uploads images from your clipboard by PicGo
-- [[readwise-mirror|Readwise Mirror]]: Mirror your Readwise library directly to an Obsidian vault
-- [[obsidian-gist|Gist]]: This is a plugin to display the GitHub Gist.
-- [[obsidian-pandoc|Obsidian Pandoc]]: This is a Pandoc export plugin for Obsidian. It provides commands to export to formats like DOCX, ePub and PDF.
 - [[obsidian-amazingmarvin-plugin|Amazing Marvin]]: This is a plugin for Obsidian (https://obsidian.md) for Amazing Marvin (https://app.amazingmarvin.com/)
+- [[obsidian-ankibridge|AnkiBridge]]: Yet Another Anki Bridge
+- [[obsidian-annotator|Annotator]]: This is a sample plugin for Obsidian. It allows you to open and annotate PDF and EPUB files.
+- [[obsidian-apple-reminders-plugin|Apple Reminders]]: 
+- [[beeminder-word-count-plugin|Beeminder Word Count Plugin]]: This lets you post word counts directly from obsidian file to Beeminder.
+- [[DEVONlink-obsidian|DEVONlink - Open or reveal notes in DEVONthink]]: Open or reveal the current note in DEVONthink.
+- [[obsidian-discordrpc|Discord Rich Presence]]: Update your Discord Status to show your friends what you are working on in Obsidian. With Discord Rich Presence.
+- [[flashcards-obsidian|Flashcards]]: Anki integration
+- [[obsidian-gist|Gist]]: This is a plugin to display the GitHub Gist.
+- [[obsidian-habitica-integration|Habitica Sync]]: This plugin helps integrate Habitica user tasks and stats into Obsidian
+- [[obsidian-hackernews|HackerNews]]: Periodically fetches and displays top stories from HackerNews.
+- [[obsidian-hypothesis-plugin|Hypothes.is]]: Sync your Hypothesis highlights
+- [[obsidian-image-auto-upload-plugin|Image auto upload Plugin]]: This plugin uploads images from your clipboard by PicGo
+- [[obsidian-imgur-plugin|Imgur Plugin]]: This plugin uploads images from your clipboard to imgur.com and embeds uploaded image to your note
+- [[obsidian-jupyter|Jupyter plugin]]: This plugin allows code blocks to be executed as Jupyter notebooks.
+- [[obsidian-kindle-plugin|Kindle Highlights]]: Sync your Kindle book highlights using your Amazon login or uploading your My Clippings file
+- [[obsidian-languagetool-plugin|LanguageTool Integration]]: Spelling and grammar checks with the LanguageTool API
 - [[obsidian-map-view|Map View]]: An interactive map view.
+- [[marginnote-companion|MarginNote Companion]]: An Obsidian plugin to bridge MarginNote 3 and Obsidian
+- [[metadata-extractor|Metadata Extractor]]: Metadata export on a schedule for integration with third-party apps like launchers.
+- [[mochi-cards-exporter|Mochi Cards Exporter]]: Export Markdown notes to Mochi cards from within obsidian
+- [[netwik|Netwik]]: This plugin provides access to global network of notes. Anyone can create, view or edit notes. All changes will be synchronized between all participants
+- [[notetweet|NoteTweet]]: This plugin allows you to post tweets directly from Obsidian.
+- [[ObsidianAnkiSync|Obsidian Anki Sync]]: Obsidian plugin to make flashcards and sync them to Anki.
+- [[obsidian-graphviz|Obsidian Graphviz]]: Render Graphviz Diagrams
+- [[obsidian-leaflet-plugin|Obsidian Leaflet]]: Interactive maps inside your notes
+- [[obsidian-pandoc|Obsidian Pandoc]]: This is a Pandoc export plugin for Obsidian. It provides commands to export to formats like DOCX, ePub and PDF.
+- [[obsidian-trello|Obsidian Trello]]: Connect an existing or new Trello card to an Obsidian note. Once connected, see basic info, add and view comments, and check off checklist items.
+- [[obsidian-webhooks|Obsidian Webhooks]]: Plugin that connects your notes to the internet of things through webhooks!
+- [[obsidian-wordnet-plugin|Obsidian42 - WordNet Dictionary]]: WordNet is a large lexical database of English developed by Princeton University.
+- [[obsidian-to-anki-plugin|Obsidian_to_Anki]]: This is an Anki integration plugin! Designed for efficient bulk exporting.
+- [[obsimian-exporter|Obsimian Exporter]]: Exports data from Obsidian APIs, feeding the Obsimian simulation framework for testing plugins.
+- [[imdone-obsidian-plugin|Open cards in imdone from obsidian.]]: This plugin allows imdone users to open their imdone board from a document in their obsidian vault that contains imdone cards.
 - [[open-vscode|Open vault in VSCode]]: Ribbon button and command to open vault as a Visual Studio Code workspace
 - [[phone-to-roam-to-obsidian|Phone to Roam to Obsidian]]: An Obsidian client for phonetoroam.com
-- [[obsidian-wordnet-plugin|Obsidian42 - WordNet Dictionary]]: WordNet is a large lexical database of English developed by Princeton University.
-- [[readwise-official|Readwise Official]]: Official Readwise <-> Obsidian integration
-- [[obsidian-toggl-integration|Toggl Track Integration]]: Manage timers and generate time reports using Toggl Track without leaving Obsidian.
-- [[ObsidianAnkiSync|Obsidian Anki Sync]]: Obsidian plugin to make flashcards and sync them to Anki.
-- [[mochi-cards-exporter|Mochi Cards Exporter]]: Export Markdown notes to Mochi cards from within obsidian
-- [[obsidian-trello|Obsidian Trello]]: Connect an existing or new Trello card to an Obsidian note. Once connected, see basic info, add and view comments, and check off checklist items.
-- [[obsidian-annotator|Annotator]]: This is a sample plugin for Obsidian. It allows you to open and annotate PDF and EPUB files.
-- [[obsidian-hackernews|HackerNews]]: Periodically fetches and displays top stories from HackerNews.
-- [[obsidian-pocket|Pocket integration]]: Access your Pocket reading list entries and create notes for them easily
-- [[obsimian-exporter|Obsimian Exporter]]: Exports data from Obsidian APIs, feeding the Obsimian simulation framework for testing plugins.
-- [[metadata-extractor|Metadata Extractor]]: Metadata export on a schedule for integration with third-party apps like launchers.
-- [[uri-commands|URI Commands]]: Execute URIs from the Obsidian command palette.
-- [[obsidian-wikipedia|Wikipedia]]: Grabs information from Wikipedia for a topic and brings it into Obsidian notes
-- [[obsidian-vale|Vale]]: A Vale client for Obsidian.
-- [[obsidian-hypothesis-plugin|Hypothes.is]]: Sync your Hypothesis highlights
-- [[marginnote-companion|MarginNote Companion]]: An Obsidian plugin to bridge MarginNote 3 and Obsidian
-- [[obsidian-habitica-integration|Habitica Sync]]: This plugin helps integrate Habitica user tasks and stats into Obsidian
-- [[obsidian-webhooks|Obsidian Webhooks]]: Plugin that connects your notes to the internet of things through webhooks!
-- [[obsidian-tweet-to-markdown|Tweet to Markdown]]: Save tweets as Markdown files, along with their images, polls, etc.
-- [[netwik|Netwik]]: This plugin provides access to global network of notes. Anyone can create, view or edit notes. All changes will be synchronized between all participants
-- [[obsidian-jupyter|Jupyter plugin]]: This plugin allows code blocks to be executed as Jupyter notebooks.
 - [[obsidian-plotly|Plotly]]: Obsidian plugin, which allow user to embed Plotly charts into markdown notes.
-- [[obsidian-ankibridge|AnkiBridge]]: Yet Another Anki Bridge
-- [[obsidian-tressel|Tressel Sync for Obsidian]]: Official Tressel plugin to sync/export your tweets and threads into Obsidian
-- [[obsidian-graphviz|Obsidian Graphviz]]: Render Graphviz Diagrams
+- [[obsidian-pocket|Pocket integration]]: Access your Pocket reading list entries and create notes for them easily
 - [[obsidian-power-search|Power Search]]: Searches Anki Notes based on current line
+- [[obsidian-readwise|Readwise Community]]: Sync Readwise highlights into your notes
+- [[readwise-mirror|Readwise Mirror]]: Mirror your Readwise library directly to an Obsidian vault
+- [[readwise-official|Readwise Official]]: Official Readwise <-> Obsidian integration
+- [[things-logbook|Things Logbook]]: Sync your Things.app Logbook with Daily Notes
+- [[todoist-sync-plugin|Todoist Sync Plugin]]: Materialize Todoist tasks within Obsidian notes.
+- [[obsidian-toggl-integration|Toggl Track Integration]]: Manage timers and generate time reports using Toggl Track without leaving Obsidian.
+- [[obsidian-tressel|Tressel Sync for Obsidian]]: Official Tressel plugin to sync/export your tweets and threads into Obsidian
+- [[obsidian-tweet-to-markdown|Tweet to Markdown]]: Save tweets as Markdown files, along with their images, polls, etc.
+- [[uri-commands|URI Commands]]: Execute URIs from the Obsidian command palette.
+- [[obsidian-vale|Vale]]: A Vale client for Obsidian.
+- [[obsidian-wikipedia|Wikipedia]]: Grabs information from Wikipedia for a topic and brings it into Obsidian notes
+- [[obsidian-youglish-plugin|Youglish Plugin]]: Use YouTube to improve your pronunciation. YouGlish gives you fast, unbiased answers about how words is spoken by real people and in context.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Time Management Plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Time Management Plugins.md
@@ -16,11 +16,11 @@ publish: true
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
+- [[obsidian-flexible-pomo|Flexible Pomodoro For Obsidian]]: Adds a pomodoro timer to your status bar. This pomodoro has additional options such as early log and extend.
 - [[obsidian-pomodoro-plugin|Pomodoro Plugin]]: This is a simple pomodoro plugin for Obsidian.
 - [[obsidian-statusbar-pomo|Status Bar Pomodoro Timer]]: Adds a pomodoro timer to your status bar.
-- [[obsidian-toggl-integration|Toggl Track]]: Manage timers and generate time reports using Toggl Track without leaving Obsidian.
-- [[obsidian-flexible-pomo|Flexible Pomodoro For Obsidian]]: Adds a pomodoro timer to your status bar. This pomodoro has additional options such as early log and extend.
 - [[obsidian-stopwatch-plugin|Stopwatch Plugin]]: Display stopwatch on Obsidian!
+- [[obsidian-toggl-integration|Toggl Track]]: Manage timers and generate time reports using Toggl Track without leaving Obsidian.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Toolbar plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Toolbar plugins.md
@@ -15,8 +15,8 @@ Plugins that add toolbars.
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
-- [[cmenu-plugin|cMenu]]: cMenu is a plugin that adds a minimal text editor modal for a smoother writing/editing experience ✍🏽.
 - [[table-editor-obsidian|Advanced Tables]]: Improved table navigation, formatting, manipulation, and formulas
+- [[cmenu-plugin|cMenu]]: cMenu is a plugin that adds a minimal text editor modal for a smoother writing/editing experience ✍🏽.
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Uncategorized plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Uncategorized plugins.md
@@ -13,362 +13,362 @@ Plugins which have not yet been categorized by the community.
 
 ## Plugins in this category
 
-- [[recent-files-obsidian|Recent Files]]: List files by most recently opened
-- [[cm-editor-syntax-highlight-obsidian|Editor Syntax Highlight]]: Show syntax highlighing in code blocks the editor
-- [[code-block-copy|Copy button for code blocks]]: Copy button for code blocks
-- [[workbench-obsidian|Workbench]]: Keep a workbench of knowledge materials.
-- [[obsidian-apply-patterns|Apply Patterns]]: Apply custom patterns of find-and-replace in succession to text.
-- [[copy-note|Enhance Copy Note]]: Augments native Obsidian note copying.
-- [[customizable-menu|Customizable Menu]]: Allows you to add any command to Obsidian's right-click menu.
-- [[simple-embeds|Simple Embeds]]: Replaces links, like Twitter and YouTube, with embeds when previewing a file.
-- [[obsidian-read-it-later|ReadItLater]]: Saves the clipboard to a new notice.
-- [[obsidian-itinerary|Itinerary]]: Make planning your trip or event easier by rendering a calendar from event information found in your notes.
-- [[update-time-on-edit|Update time on edit]]: Keep front matter in sync with the last edit time
-- [[obsidian-local-images|Local images]]: Local Images plugin finds all links to external images in your notes, then downloads and saves images locally, and finally adjusts the image links in your notes to point to the saved image files.
-- [[obsidian-vocabulary-view|Vocabulary View]]: Write down some words with their explanations and preview them in a vocabulary test style
-- [[obsidian42-brat|Obsidian42 - BRAT]]: Easily install a beta version of a plugin for testing.
-- [[snippet-commands-obsidian|Snippet Commands]]: Registers custom css snippets as commands (which you can bind hotkeys to)
-- [[key-promoter|Key Promoter]]: Learn keyboard shortcuts by showing them when using the mouse
-- [[obsidian-livesync|Self-hosted LiveSync]]: Community implementation of self-hosted livesync. Reflect your vault changes to some other devices immediately. Please make sure to disable other synchronize solutions to avoid content corruption or duplication.
-- [[lumberjack-obsidian|Lumberjack 🪓 🪵]]: Log your thoughts! Lumberjack adds URL commands to help you axe inefficiency and get right to writing.
-- [[mysnippets-plugin|MySnippets]]: MySnippets is a plugin that adds a status bar menu allowing the user to quickly toggle their snippets on and off 🖌.
-- [[meld-calc|Meld Calc]]: Do math
-- [[tabout|Tabout]]: Easily "tab out" of Links or other Markdown Formatting Characters.
-- [[quote-of-the-day|Quote of the Day]]: Inserts random quotes in the editor
-- [[obsidian-audio-speed-plugin|Audio Speed Plugin]]: A simple plugin to change the playback rate of audio files during markdown preview.
-- [[obsidian-limelight|Limelight]]: Put a spotlight on your active pane
-- [[prompt|Prompt]]: Shows a random text prompt when triggered
-- [[stenography-obsidian|Stenography]]: Auto Describe your code with machine learning using the Stenography API
-- [[obsidian-oura-plugin|Oura Ring]]: Oura Ring
-- [[obsidian-metacopy|Metacopy]]: This is a plugin that copy the value of a frontmatter key and allowing to create link using various settings.
-- [[obsidian-image-caption|Image Caption]]: Add captions to images.
-- [[obsidian-custom-attachment-location|Custom Attachment Location]]: Customize attachment location with variables($filename, $data, etc) like typora.
-- [[cryptsidian|Cryptsidian]]: Encrypt all files in your Obsidian.md Vault with a password.
-- [[obsidian-crypto-lookup|Crypto Lookup]]: A plugin for Obsidian which uses the Cryptonator API to pull back prices for crypto in a target currency
-- [[obsidian-auto-split|Auto Split]]: Open notes with side-by-side editor & preview
-- [[obsidian-word-sprint|Word Sprint]]: Word Sprint for Obsidian plugin for your writing projects like Nanowrimo
-- [[copy-publish-url|Publish and GitHub URL]]: Copy or open the URL of the corresponding note on your Publish site. You can also open its Git commit history on GitHub.
-- [[obsidian-bible-reference|Bible Reference]]: Taking Bible Study note in Obsidian.md application easily. Automatically suggesting Bible Verses as references. 
-- [[obsidian-sentence-navigator|Sentence Navigator]]: Manipulate sentences as a unit of movement. Select, move and delete by whole sentences.
-- [[language-translator|Language Translator]]: Translates given text to desired language
-- [[auto-class|Auto Class]]: Automatically apply CSS classes to the markdown view based on a note's path and tags.
-- [[obsidian-cloudinary-uploader|Obsidian Cloudinary Uploader]]: This plugin uploads the images in your clipboard to Cloudinary as unsigned uploads
-- [[rss-reader|RSS Reader]]: Read RSS Feeds from within obsidian
-- [[mousewheel-image-zoom|Mousewheel Image zoom]]: This plugin enables you to increase/decrease the size of an image by scrolling
-- [[obsidian-lineup-builder|Lineup Builder]]: Build football lineups in Obsidian.
-- [[obsidian-structured-plugin|Structured Plugin]]: Structured plugin. Create hierarchy in notes using . 
-- [[cooklang-obsidian|CookLang Editor]]: Edit and display CookLang recipes in Obsidian
-- [[highlightr-plugin|Highlightr]]: A minimal and aesthetically pleasing highlighting menu that makes color-coded highlighting much easier with a configurable assortment of highlight colors 🎨.
-- [[remotely-save|Remotely Save]]: Yet another unofficial plugin allowing users to synchronize notes between local device and the cloud service.
-- [[obsidian-notes-from-template|From Template]]: Create new notes from Templates - for each Template, provides a Command to trigger it, and a form to fill in any variables in the template
-- [[obsidian-dialogue-plugin|Dialogue]]: Create dialogues in Markdown.
-- [[obsidian-title-serial-number-plugin|Title Serial Number Plugin]]: This plugin adds serial numbers to your markdown title.
-- [[obsidian-theme-design-utilities|Theme Design Utilities]]: Some Utilities and Quality-of-Life Features for Designers of Obsidian Themes.
-- [[image-window|Second Window]]: Allow images & notes to be viewed in new Obsidian windows.
-- [[obsidian-tts|Text to Speech]]: Text to speech for Obsidian. Hear your notes.
-- [[link-favicon|Link Favicons]]: See the favicon for a linked website. 
-- [[get-info-plugin|Get Info]]: Get Info is a plugin that tucks a menu inside your status bar and shows helpful information for your chosen file 📄.
-- [[matter|Matter]]: The official Matter <> Obsidian plugin
-- [[obsidian-regex-replace|Regex Find/Replace]]: Find and replace text using regular expressions.
-- [[obsidian-wordpress|WordPress]]: A plugin for publishing Obsidian documents to WordPress.
-- [[obsidian-icon-shortcodes|Icon Shortcodes]]: Insert emoji and custom icons with shortcodes
-- [[obsidian-advanced-slides|Advanced Slides]]: Create markdown-based presentations in Obsidian
-- [[obsidian-emotion-picker|Emotion Picker]]: A plugin for Obsidian.md that lets you choose an emotion from a list to insert into a note.
-- [[quoth|Quoth]]: More flexible embedding. Embed precise selections, inline embeds, optionally include author and title.
-- [[obsidian-metronome-plugin|Metronome]]: Add interactive metronomes to your notes.
-- [[obsidian-plaintext|Plaintext]]: Allow opening specified files as plaintext (RAW mode).
-- [[obsidian-native-scrollbars|Native Scrollbars]]: Enables native OS scrollbars throughout obsidian
-- [[obsidian-wrap-with-shortcuts|Wrap with shortcuts]]: Wrap selected text in custom tags with shortcuts. E.g.: underline, sub, ruby(フリガナ)
-- [[obsidian-tomorrows-daily-note|Tomorrow's Daily Note]]: An obsidian plugin that creates tomorrow's daily note for preemtive planning.
-- [[obsidian-rant|Rant-Lang]]: Thin wrapper around the Rant language Rust crate
-- [[obsidian-timestamper|TimeStamper]]: Insert customized time/date stamp.
-- [[obsidian-import-json|JSON/CSV Importer]]: This plugin imports a JSON/CSV file (or text block) and creates notes from a Handlebars template file
-- [[import-foundry|Import Foundry VTT journal entries]]: Imports your journal entries from your selected Foundry VTT world into Obsidian.md
-- [[obsidian-attachment-name-formatting|Attachment Name Formatting]]: Obsidian plugin for formatting attachments name (filename attachmentType indexNumber.xxx)
-- [[obsidian-completr|Completr]]: This plugin provides advanced auto-completion functionality for LaTeX, Frontmatter and standard writing.
-- [[obsidian-binary-file-manager-plugin|Binary File Manager]]: Detects new binary files in the vault and create markdown files with metadata.
-- [[obsidian-local-file-interface-plugin|Local File Interface]]: Provides commands for moving files in and out of the vault
-- [[obsidian-siteswap|Siteswap]]: Visualize Juggling Pattern Siteswap via the JugglingLab gif server.
-- [[obsidian-tweaks|ObsidianTweaks]]: Adds some convenient tweaks including improved toggling and ergonomic commands
-- [[obsidian-wordle|Wordle]]: Creates a view where you can play Wordle. No longer actively maintained.
-- [[obsidian-memos|Obsidian Memos]]: A plugin for capturing ideas in Obsidian
-- [[para-shortcuts|PARA Shortcuts]]: This plugin serves usefull commands to setup and manage your knowledge using the PARA method.
 - [[13th-age-statblocks|13th Age Statblocks]]: Render 13th Age statblocks in Obsidian.
+- [[obsidian-account-linker|Account Linker]]: Plugin for describing external service accounts in the front matter
+- [[actions-uri|Actions URI]]: Adds additional `x-callback-url` endpoints to the app for common actions — it's a clean, super-charged addition to Obsidian URI.
+- [[obsidian-markdown-file-suffix|Addional Markdown suffix (.mdx/.svx).]]: Use additional files like .mdx / .svx as if they were markdown.
+- [[obsidian-advanced-codeblock|Advanced Codeblock]]: Give additioinal features to  code blocks.
+- [[obsidian-advanced-slides|Advanced Slides]]: Create markdown-based presentations in Obsidian
+- [[obsidian-advanced-new-folder|Advanced new folder]]: This is a plugin that creates a new folder anywhere you want in the vault
+- [[obsidian-agile-task-notes|Agile Task Notes]]: Import your tasks from your TFS (Azure or Jira) to take notes on them and make todo-lists!
+- [[alx-folder-note-folderv|AidenLx's Folder Note - folderv component]]: Optional `folderv` Component for alx-folder-note
+- [[obsidian-alias-from-heading|Alias from heading]]: Implicitly add an alias matching the first heading in a document.
+- [[aosr|Aosr]]: Another obsidian spaced repetition
+- [[obsidian-apply-patterns|Apply Patterns]]: Apply custom patterns of find-and-replace in succession to text.
+- [[obsidian-asciidoc-blocks|AsciiDoc Blocks Plugin]]: A plugin to render asciidoc blocks in Obsidian, initially asciidoc tables.
+- [[obsidian-attachment-name-formatting|Attachment Name Formatting]]: Obsidian plugin for formatting attachments name (filename attachmentType indexNumber.xxx)
+- [[obsidian-audio-speed-plugin|Audio Speed Plugin]]: A simple plugin to change the playback rate of audio files during markdown preview.
+- [[auto-card-link|Auto Card Link]]: Automatically fetches metadata from a url and makes it as a card-styled link
+- [[auto-class|Auto Class]]: Automatically apply CSS classes to the markdown view based on a note's path and tags.
+- [[obsidian-auto-hide|Auto Hide]]: Collapse sidebars when clicking on the editor/viewer panel
+- [[auto-note-mover|Auto Note Mover]]: Auto Note Mover will automatically move the active notes to their respective folders according to the rules.
+- [[obsidian-auto-split|Auto Split]]: Open notes with side-by-side editor & preview
+- [[auto-moc|AutoMOC]]: Looks for missing linked mentions or notes with a specific tag and imports them into the current note.
+- [[obsidian-awesome-flashcard|Awesome Flashcard]]: Handy Anki integration for Obsidian.
+- [[obsidian-bbcode|BBCode Convertor]]: Convert Markdown files to BBCode
+- [[obsidian-bellboy|Bellboy]]: Opinionated file structure manager.
+- [[obsidian-better-codeblock|Better CodeBlock]]: Add title, line number to Obsidian code block
+- [[obsidian-better-command-palette|Better Command Palette]]: A command palette that does all of the things you want it to do.
+- [[better-inline-fields|Better Inline Fields]]: Obsidian plugin to enhance Dataview style inline fields
+- [[obsidian-bible-linker|Bible Linker]]: Link multiple bible verses easily
+- [[obsidian-bible-reference|Bible Reference]]: Taking Bible Study note in Obsidian.md application easily. Automatically suggesting Bible Verses as references. 
+- [[obsidian-binary-file-manager-plugin|Binary File Manager]]: Detects new binary files in the vault and create markdown files with metadata.
+- [[blockquote-levels|Blockquote Levels]]: Adds commands for increasing/decreasing the blockquote level of the current line or selection.
+- [[obsidian-book-search-plugin|Book Search]]: Helps you find books and create notes.
+- [[booksidian-plugin|Booksidian]]: Connect Obsidian to your Goodreads.
+- [[obsidian-bulk-rename-plugin|Bulk Rename]]: Purpose of this plugin rename files based on pattern
+- [[obsidian-buttondown-plugin|Buttondown]]: Send your notes to your buttondown.email account as email drafts.
+- [[obsidian-calibre-plugin|Calibre]]: This plugin allows you to access your calibre libraries and read books directly in Obsidian.
+- [[obsidian-card-view-switcher-plugin|Card View Switcher]]: Quick switcher with card view
+- [[obsidian-chat-view|Chat View]]: Chat View enables you to create elegant Chat UIs in your Obsidian markdown files. It also supports the WebVTT format.
+- [[obsidian-checkbox3states-plugin|Checkbox 3 states]]: This is a simple plugin for add a third state to checkbox list.
+- [[obsidian-chorded-hotkeys|Chorded Hotkeys]]: Type multiple letters at the same time to trigger text insertion, template insertion, or command execution.
+- [[chronology|Chronology]]: Provides a calendar and a timeline of the notes creation and modification
+- [[code-block-plugin|Code Block]]: This plugin converts text into code blocks with automatic language detection.
+- [[obsidian-codeblock-labels|Code Block Labels]]: Adds labels to fenced code blocks
+- [[obsidian-colorful-tag|Colorful Tag]]: Make your tag more beautiful and powerful!
+- [[obsidian-command-palette-minus-plugin|Command Palette--]]: Command palette without unwanted commands
+- [[cmdr|Commander]]: Customize your workspace by adding commands everywhere, create Macros and supercharge your mobile toolbar.
+- [[obsidian-completr|Completr]]: This plugin provides advanced auto-completion functionality for LaTeX, Frontmatter and standard writing.
+- [[control-characters|Control Characters]]: Show control/non-printing characters in edit mode
+- [[cooklang-obsidian|CookLang Editor]]: Edit and display CookLang recipes in Obsidian
+- [[obsidian-copy-search-url|Copy Search URL]]: Adds a button to the search view for copying the Obsidian search URL.
+- [[copy-as-html|Copy as HTML]]: This is a simple plugin that converts the selected markdown to HTML and copies it to the clipboard.
+- [[code-block-copy|Copy button for code blocks]]: Copy button for code blocks
+- [[copy-document-as-html|Copy document as HTML]]: Copy the current document to clipboard as HTML, including images
+- [[creases|Creases]]: Tools for efficiently folding markdown sections in Obsidian
+- [[obsidian-crypto-lookup|Crypto Lookup]]: A plugin for Obsidian which uses the Cryptonator API to pull back prices for crypto in a target currency
+- [[cryptsidian|Cryptsidian]]: Encrypt all files in your Obsidian.md Vault with a password.
+- [[obsidian-custom-attachment-location|Custom Attachment Location]]: Customize attachment location with variables($filename, $data, etc) like typora.
+- [[custom-sort|Custom File Explorer sorting]]: Allows for manual and automatic, config-driven reordering and sorting of files and folders in File Explorer
+- [[obsidian-custom-frames|Custom Frames]]: A plugin that turns web apps into panes using iframes with custom styling. Also comes with presets for Google Keep, Todoist and more.
+- [[customizable-menu|Customizable Menu]]: Allows you to add any command to Obsidian's right-click menu.
+- [[dbfolder|DB Folder]]: Folder with the capability to store and retrieve data from a folder like database
+- [[obsidian-daily-note-outline|Daily Note Outline]]: Add a custom view which shows outline of multiple daily notes with headings, links, tags and list items
+- [[obsidian-daily-notes-viewer|Daily Notes Viewer]]: Help you to view some recent daily notes on one page.
+- [[obsidian-daily-notes-opener|Daily notes opener]]: Easily open daily/periodic notes in new pane, and much more!
+- [[obsidian-dashing-cursor|Dashing cursor]]: Enables dashing cursor that follows the page scroll
+- [[obsidian-day-and-night|Day and Night]]: An Obsidian plugin to automatically toggle themes between day theme and night theme on a set time schedule.
+- [[new-tab-default-page|Default New Tab Page]]: Open a note of your choice when creating a new tab, like in the browser.
+- [[obsidian-desmos|Desmos]]: Embed Desmos graphs into your notes
+- [[obsidian-diagrams-net|Diagrams.net]]: Enable diagrams.net (previously draw.io) type diagrams, with the diagrams.net embedded editor.
+- [[obsidian-dialogue-plugin|Dialogue]]: Create dialogues in Markdown.
+- [[digitalgarden|Digital Garden]]: Publish your notes to a digital garden for others to enjoy.
+- [[obsidian-dirtreeist|Dirtreeist]]: Render a directory Structure Diagram from a markdown lists in codeblock.
+- [[obsidian-divide-and-conquer|Divide & Conquer]]: Provides commands for bulk enabling/disabling of plugins. Useful for debugging when you have many plugins.
+- [[obsidian-douban-plugin|Douban]]: This is a plugin that can import movies/books/musics/notes/games info data from Douban for Obsidian .
+- [[obsidian-doubleshift|Doubleshift]]: Open the command palette by pressing Shift (or any other key) twice like in IntelliJ and create your own shortcuts
+- [[obsidian-drag-n-drop-plugin|Drag-n-Drop for blocks]]: Allow moving/copying/and creation embeds for blocks with drag-n-drop just like Logseq or Roam
+- [[duplicate-line|Duplicate Line]]: To duplicate a line or several following selected lines. multicursor can be used too
+- [[obsidian-dynamic-background|Dynamic Background]]: Adding dynamic effects and/or static wallpapers for Obsidian background
+- [[obsidian-dynamic-embed|Dynamic Embed]]: Dynamicly interpreted inline embeds.
 - [[obsidian-dynamic-highlights|Dynamic Highlights]]: Dynamically highlight text based on cursor selection or search query with full regex, mobile, and live preview support
+- [[dynamic-rtl|Dynamic RTL]]: Dynamic RTL/LTR direction per line/paragraph, dependant on language!
+- [[obsidian-dynbedded|Dynbedded]]: Dynamic Embeds for Obsidian.md
+- [[edit-gemini|Edit Gemini]]: Allows the user to edit and create .gmi files.
+- [[editing-toolbar|Editing Toolbar]]: The Obsidian Editing Toolbar is modified from cmenu, which provides more powerful customization settings and has many built-in editing commands to be a MS Word-like toolbar editing experience.
+- [[cm-editor-syntax-highlight-obsidian|Editor Syntax Highlight]]: Show syntax highlighing in code blocks the editor
+- [[embed-code-file|Embed Code File]]: This is a plugin for Obsidian that allows for embedding code files.
+- [[obsidian-embedded-note-paths|Embedded Note Paths]]: Inserts the note file path above each note.
+- [[obsidian-emotion-picker|Emotion Picker]]: A plugin for Obsidian.md that lets you choose an emotion from a list to insert into a note.
+- [[copy-note|Enhance Copy Note]]: Augments native Obsidian note copying.
+- [[enlightenment-obsidian|Enlightenment ✨]]: Pay attention to what you're paying attention to. Enlightenment adds a 'zen mode' for Preview, hiding the contents of your notes except for what's underneath your pointer.
+- [[obsidian-etherpad-plugin|Etherpad]]: Etherpad Integration
+- [[excalibrain|ExcaliBrain]]: A clean, intuitive and editable graph view for Obsidian
+- [[obsidian-excel-to-markdown-table|Excel to Markdown Table]]: An Obsidian plugin to paste data from Microsoft Excel, Google Sheets, Apple Numbers and LibreOffice Calc as Markdown tables in Obsidian editor.
+- [[execute-code|Execute Code]]: Allows to execute code snippets within a note.
+- [[obsidian-expand-bullet|Expand Bullet]]: A plugin for transforming bullet content into note.
+- [[obsidian-export-image|Export Image plugin]]: Easily convert your article to image.
+- [[obsidian-file-cleaner|File Cleaner]]: Help you to clean empty files and unused attachments in the vault.
+- [[obsidian-file-cooker|File Cooker]]: Deal multi notes from Search results、current file、Dataview query string...
+- [[OA-file-hider|File Hider]]: An Obsidian plugin that allows hiding files and folders in the built-in file explorer
+- [[obsidian-file-info-plugin|File Info Panel]]: Plugin for Obsidian that creates a File Information view that displays the active file's date created, date modified, file size, and links to open the file in its native application and to open the file's folder.  It also has writing statistics (character, word, sentence, and paragraph counts) and a word frequency analysis.
+- [[obsidian-filename-emoji-remover|Filename Emoji Remover]]: This is a simple plugin to automatically remove emojis from filenames. Main purpose is to get rid of Dropbox sync issues for Readwise imported content.
+- [[fleeting-notes-obsidian|Fleeting Notes Sync]]: This is a plugin to sync Fleeting Notes with Obsidian
+- [[obsidian-focus-plugin|Focus and Highlight]]: A plugin for Obsidian (https://obsidian.md) that will highlight and focus on the currently selected heading
+- [[obsidian-folder-focus-mode|Folder Focus Mode]]: Focus file explorer on chosen folder and its files and subdirectories, while hiding all the other elements.
+- [[obsidian-folder-index|Folder Index]]: This Plugin will automatically generate a TOC for the current Folder.
+- [[obsidian-footnote-indicator|Footnote & Citation Indicator]]: Counts footnotes & Pandoc citations, indicates their presence in the gutter.
+- [[obsidian-format-code|Format code]]: This plugin introduces commands to format code (internally uses prettier)
+- [[obsidian-notes-from-template|From Template]]: Create new notes from Templates - for each Template, provides a Command to trigger it, and a form to fill in any variables in the template
+- [[obsidian-front-matter-title-plugin|Front Matter Title]]: Lets you define a title in frontmatter to be displayed as the filename
+- [[frontmatter-links|Frontmatter Links]]: Renders links in a note's frontmatter as links.
+- [[get-info-plugin|Get Info]]: Get Info is a plugin that tucks a menu inside your status bar and shows helpful information for your chosen file 📄.
+- [[obsidian-mkdocs-publisher|Github Publisher]]: Github Publisher is a plugin that help you to send file in a configured Github Repository, based on a frontmatter entry state.
+- [[obsidian-gitlab-issues|Gitlab Issues]]: Import issues from Gitlab into Obsidian.
+- [[google-calendar|Google Calendar]]: Interact with your Google Calendar from Inside Obsidian
+- [[obsidian-google-lookup|Google Calendar and Contacts Lookup]]: Import contact and calendar event information from your Google account
+- [[obsidian-google-tasks|Google Tasks]]: Interact with your Google Tasks from Inside Obsidian
+- [[obsidian-group-snippets|Group Snippets]]: Create folder of snippets to activate them in one click !
+- [[obsidian-html-plugin|HTML Reader]]: This is a HTML file reader plugin for Obsidian. Can open document with ".html" and ".htm" file extensions.
+- [[habit-tracker|Habit Tracker]]: Track your Habits.
+- [[hard-breaks|Hard Breaks]]: Turn soft line breaks in Markdown into hard line breaks
+- [[obsidian-heading-shifter|Heading Shifter]]: Easily Shift and Change markdown headings.
+- [[highlightr-plugin|Highlightr]]: A minimal and aesthetically pleasing highlighting menu that makes color-coded highlighting much easier with a configurable assortment of highlight colors 🎨.
+- [[obsidian-hover-editor|Hover Editor]]: Transform the Page Preview hover popover into a fully working editor instance
+- [[obsidian-icon-shortcodes|Icon Shortcodes]]: Insert emoji and custom icons with shortcodes
+- [[obsidian-image-caption|Image Caption]]: Add captions to images.
+- [[obsidian-image-gallery|Image Gallery]]: A zero setup masonry image gallery for Obsidian
+- [[insert-unsplash-image|Image Inserter]]: This plugin helps users easily search and insert images to editors from Unsplash.
+- [[import-foundry|Import Foundry VTT journal entries]]: Imports your journal entries from your selected Foundry VTT world into Obsidian.md
+- [[influx|Influx]]: An alternative backlinks plugin, which displays relevant and formatted excerpts from notes with linked mentions, based on the position of mentions in the notes' hierarchical structure (bullet level indentation).
+- [[obsidian-text-expander-js|Inline Scripts]]: Type text shortcuts which are then replaced with JavaScript generated text.
+- [[insert-heading-link|Insert Heading Link]]: Add a Link to a Heading
+- [[obsidian-itinerary|Itinerary]]: Make planning your trip or event easier by rendering a calendar from event information found in your notes.
+- [[obsidian-import-json|JSON/CSV Importer]]: This plugin imports a JSON/CSV file (or text block) and creates notes from a Handlebars template file
+- [[janitor|Janitor]]: Performs cleanup tasks on the Obsidian vault
+- [[obsidian-jira-issue|Jira Issue]]: This plugin allows you to track the progress of Atlassian Jira issues from your Obsidian notes.
 - [[obsidian-koreader-plugin|KOReader Highlights]]: This is a plugin for Obsidian. This plugin syncs highlights and notes taken in KOReader.
+- [[key-promoter|Key Promoter]]: Learn keyboard shortcuts by showing them when using the mouse
+- [[keyboard-analyzer|Keyboard Analyzer]]: See and analyse your keyboard hotkeys and shortcuts
+- [[obsidian-kindle-export|Kindle]]: Send .md as .mobi to Kindle
+- [[obsidian-kobo-highlights-importer-plugin|Kobo Highlights Importer]]: Import highlights from your Kobo device
+- [[kr-book-info-plugin|KoreanBook Info Plugin]]: A plugin that crawls Yes24 to get book information.
+- [[language-translator|Language Translator]]: Translates given text to desired language
+- [[lapel|Lapel]]: Dress up your editor with decorations that mark each of your headings 🤵
+- [[obsidian-latex-suite|Latex Suite]]: Make typesetting LaTeX math as fast as handwriting through snippets, text expansion, and editor enhancements
+- [[obsidian-limelight|Limelight]]: Put a spotlight on your active pane
+- [[obsidian-lineup-builder|Lineup Builder]]: Build football lineups in Obsidian.
+- [[obsidian-link-embed|Link Embed]]: This plugin allows you to convert URLs in your notes into embedded previews.
+- [[link-favicon|Link Favicons]]: See the favicon for a linked website. 
+- [[link-info-server|Link Server]]: This plugin will open a reverse proxy server at port 3333 to get wikiLink information Obsidian API.
+- [[linkify|Linkify]]: Converts matching text into links.
+- [[obsidian-list-callouts|List Callouts]]: Create simple callouts in lists.
+- [[obsidian-list-modified|List Modified]]: A simple obsidian plugin that links all modified files meeting certain criteria to a daily note
+- [[literate-haskell|Literate Haskell]]: An obsidian plugin for integrating `.lhs` files into your PKM.
+- [[obsidian-local-file-interface-plugin|Local File Interface]]: Provides commands for moving files in and out of the vault
+- [[local-quotes|Local Quotes]]: Collect your quotes from all over the repository and embed them in different locations with refresh delays.
+- [[obsidian-local-rest-api|Local REST API]]: Get, change or otherwise interact with your notes in Obsidian via a REST API.
+- [[obsidian-local-images|Local images]]: Local Images plugin finds all links to external images in your notes, then downloads and saves images locally, and finally adjusts the image links in your notes to point to the saved image files.
+- [[obsidian-lock-screen-plugin|Lock Screen]]: Protect your vault with a lock screen.
+- [[lumberjack-obsidian|Lumberjack 🪓 🪵]]: Log your thoughts! Lumberjack adds URL commands to help you axe inefficiency and get right to writing.
+- [[obsidian-mark-and-select|Mark and Select]]: More flexible ways to select texts in Obsidian Editor
+- [[obsidian-markbase|Markbase for Obsidian]]: Official Markbase plugin to share your Obsidian notes online in your own digital garden
+- [[markdown-table-editor|Markdown Table Editor]]: An Obsidian plugin to provide an editor for Markdown tables. It can open CSV, Microsoft Excel/Google Sheets data as Markdown tables from Obsidian Markdown editor.
+- [[markdown-shortcuts|Markdown shortcuts]]: Allows to write markdown from shortcuts (example: >h1 -> #).
+- [[mathlinks|MathLinks]]: Render MathJax in your links
+- [[mathpad|Mathpad]]: Computer Algebra System and Calculator for Onsidian
+- [[matter|Matter]]: The official Matter <> Obsidian plugin
+- [[obsidian-media-db-plugin|Media DB Plugin]]: A plugin that can query multiple APIs for movies, series, anime, games, music and wiki articles, and import them into your vault.
+- [[obsidian-meeting-notes|Meeting notes]]: (https://obsidian.md) Plugin to automatically create a meeting note if a new file is created in a meeting folder.
+- [[meld-calc|Meld Calc]]: Do math
+- [[obsidian-meta-bind-plugin|Meta Bind Plugin]]: This plugin can create input fields inside your notes and bind them to metadata fields.
+- [[obsidian-metacopy|Metacopy]]: This is a plugin that copy the value of a frontmatter key and allowing to create link using various settings.
+- [[metadata-menu|Metadata Menu]]: For data quality enthousiasts (and dataview lovers): manage the metadata of your notes.
+- [[obsidian-metronome-plugin|Metronome]]: Add interactive metronomes to your notes.
+- [[microblog-publish-plugin|Micro.publish]]: Publish notes to Micro.blog
+- [[obsidian-min-width|Min Width]]: Set the Minimum Width of the Active Pane in Obsidian
+- [[mousewheel-image-zoom|Mousewheel Image zoom]]: This plugin enables you to increase/decrease the size of an image by scrolling
+- [[multi-column-markdown|Multi-Column Markdown]]: This plugin adds functionality to create markdown documents with multiple columns of content viewable within Obsidian's preview mode
+- [[mysnippets-plugin|MySnippets]]: MySnippets is a plugin that adds a status bar menu allowing the user to quickly toggle their snippets on and off 🖌.
+- [[obsidian-native-scrollbars|Native Scrollbars]]: Enables native OS scrollbars throughout obsidian
+- [[heycalmdown-navigate-cursor-history|Navigate Cursor History]]: This plugin remembers the recent 50 cursor positions history and allows you to jump to them back and forth like VSCode
+- [[obsidian-new-note-new-window|New Note New Window]]: Plugin for easily opening new notes in a floating window.
+- [[ninja-cursor|Ninja Cursor]]: The plugin which enhance cursor visibility.
+- [[no-dupe-leaves|No dupe leaves]]: Don't reopen notes that are already open
+- [[obsidian-note-autocreator|Note Auto Creator]]: Automatically create notes when links are created to them.
+- [[obsidian-note-content-pusher|Note Content Pusher]]: An Obsidian plugin to automatically create notes with some specified content when you link to a note that doesn't yet exist.
+- [[obisidian-note-linker|Note Linker]]: Automatically find and link notes in Obsidian
+- [[note-synchronizer|Note Synchronizer]]: This is a plugin for synchornizing Obsidian notes to other note-based softwares like Anki, following more strictly the principles of Zettelkasten and treating each Obsidian file as a note.
+- [[obsidian-notion-video|Notion Video]]: embed your notion video in obsidian
+- [[notion-like-tables|Notion-Like Tables]]: Your premiere tool for creating and managing tabular data in Obsidian.md
+- [[novel-word-count|Novel word count]]: Displays a word count (and more!) for each file, folder and vault in the File Explorer pane.
+- [[nuke-orphans|Nuke Orphans]]: Plugin that trashes orphaned files and attachments
+- [[obsidian-attendance|Obsidian Attendance]]: This plugin helps you track attendance.
+- [[obsidian-badge|Obsidian Badge]]: This is a plugin to show badge for Obsidian.
+- [[obsidian-camera|Obsidian Camera]]: Camera plugin for Obsidian
+- [[obsidian-chevereto-image-uploader|Obsidian Chevereto Image Uploader]]: This plugin uploads the image in your clipboard to chevereto automatically when pasting.
+- [[obsidian-circuitjs|Obsidian CircuitJS]]: Integrating CircuitJS and Obsidian
+- [[obsidian-cloudinary-uploader|Obsidian Cloudinary Uploader]]: This plugin uploads the images in your clipboard to Cloudinary as unsigned uploads
+- [[obsidian-columns|Obsidian Columns]]: Allows you to create columns in Obsidian Markdown
+- [[obsidian-enhancing-export|Obsidian Enhancing Export]]: This is a enhancing export plugin for Obsidian. It allows to export to formats like Html, DOCX, ePub and PDF or Markdown(Hugo) etc.
+- [[obsidian-functionplot|Obsidian Functionplot]]: A plugin for displaying mathematical graphs in obsidian.md.
+- [[obsidian-ghost-publish|Obsidian Ghost Publish]]: Single click to publish to Ghost
+- [[obsidian-golinks|Obsidian GoLinks]]: This is a plugin for Obsidian that renders go/links as clickable links.
+- [[obsidian-handlebars|Obsidian Handlebars Template Plugin]]: This is a plugin for Obsidian that adds support for handlebars template blocks in notes.
+- [[obsidian-math-plus|Obsidian Math+]]: This is an Obsidian plugin for taking math notes using Excalidraw.
+- [[obsidian-memos|Obsidian Memos]]: A plugin for capturing ideas in Obsidian
+- [[obsidian-mtg|Obsidian MtG]]: A plugin for managing Magic: The Gathering decks and card lists as Obsidian notes
+- [[obsidian-ocr|Obsidian OCR]]: Add ocr capabilities to obsidian
+- [[obsidian-things3-sync|Obsidian Things3 Sync]]: A plugin for sync between Obsidian and Things3, create Todo and sync Todo status
+- [[ava|Obsidian ava]]: AI-enhanced reflection in Obsidian
+- [[obsidian-better-internal-link-inserter|Obsidian better Internal Link Inserter]]: Allow to use the selected word as an alias in link suggestion.
+- [[obsidian-better-internal-link-inserter|Obsidian better Internal Link Inserter]]: Allow to use the selected word as an alias in link suggestion.
+- [[obsidian-jtab|Obsidian jTab]]: Adds the ability to show guitar chords and tabs directly in your notes using jTab.
+- [[obsidian-matrix|Obsidian matrix]]: Utility to easily create LaTeX matrices
+- [[obsidian-to-notion|Obsidian shared to Notion]]: This is a  plugin for Obsidian. This plugin share obsidian md  file to notion with notion api
+- [[obsidian-to-flomo|Obsidian to Flomo]]: Quickly share content to Flomo.
+- [[obsidian42-brat|Obsidian42 - BRAT]]: Easily install a beta version of a plugin for testing.
+- [[obsidian42-strange-new-worlds|Obsidian42 - Strange New Worlds]]: Revealing networked thought and the strange new worlds created by your vault
+- [[obsidian-tweaks|ObsidianTweaks]]: Adds some convenient tweaks including improved toggling and ergonomic commands
+- [[obsius-publish|Obsius Publish]]: Make single notes instantly available on the web.
+- [[obsidian-old-note-admonitor|Old Note Admonitor]]: This Obsidian plugin shows warnings if the note has not been updated for over specific days
+- [[omnisearch|Omnisearch]]: A search engine that just works
+- [[onyx-boox-extractor|Onyx Boox Annotation & Highlight Extractor]]: This plugin extracts annotations and highlights files exported from Onyx Boox tablets, and converts them to reference, literature and permanent notes fitting to the Zettelkasten method.
+- [[obsidian-open-file-by-magic-date|Open File by Magic Date]]: Define a Moment.js date pattern that specifies the file that is most important to you (eg: your daily/weekly/monthly note). Will create the file if it doesn't exist.
+- [[open-related-url|Open Related Url]]: Opens URLs found in a note's YAML frontmatter
+- [[obsidian-open-in-other-editor|Open in other editor]]: Open current active file in gVim or VScode.
+- [[list-style|Ordered List Style]]: Set ordered list style inline in Obsidian.md. Alphabetic lists, roman numeral lists, etc.
+- [[obsidian-oura-plugin|Oura Ring]]: Oura Ring
+- [[para-shortcuts|PARA Shortcuts]]: This plugin serves usefull commands to setup and manage your knowledge using the PARA method.
+- [[tasks-packrat-plugin|Packrat]]: Process completed recurring Tasks
+- [[page-gallery|Page Gallery]]: Creates an embeddable gallery based on selected page contents.
+- [[obsidian-pandoc-reference-list|Pandoc Reference List]]: Displays a formatted reference in the sidebar for each pandoc citekey present in the current document.
+- [[obsidian-party|Party🎉]]: An implementation of party.js for Obsidian. Create confetti, sparkles and even custom effects in your notes!
+- [[obsidian-paste-png-to-jpeg|Paste image Png to Jpeg]]: Screenshot png to jpeg and compress and rename
+- [[obsidian-paste-image-rename|Paste image rename]]: Rename pasted images and all the other attchments added to the vault
+- [[obsidian-path-finder|Path Finder]]: A plugin that can find the shortest path between two notes. Not sure who will want to use it...
+- [[obsidian-path-title|Path Title]]: Adds path (or optional replacement) to the filename title of each pane
+- [[pinboard-sync|Pinboard Sync]]: Syncs Pinboard.in links with Daily Notes
+- [[obsidian-plaintext|Plaintext]]: Allow opening specified files as plaintext (RAW mode).
+- [[obsidian-plugin-update-tracker|Plugin Update Tracker]]: Know when installed plugins have updates and evaluate the risk of upgrading
+- [[plugins-galore|Plugins Galore]]: This is an Obsidian plugin to allow easily sideloading other plugins.
+- [[podnotes|PodNotes]]: Helps you write notes on podcasts.
+- [[postgresql-obsidian|PostgreSQL Obsidian]]: An Obsidian plugin to upload your notes' metadata to your database.
+- [[obsidian-pretty-bibtex|Pretty BibTeX]]: Shows raw BibTeX bibliography entries in a prettier way
+- [[obsidian-projects|Projects]]: Project management for Obsidian.
+- [[prompt|Prompt]]: Shows a random text prompt when triggered
+- [[copy-publish-url|Publish and GitHub URL]]: Copy or open the URL of the corresponding note on your Publish site. You can also open its Git commit history on GitHub.
+- [[quick-snippets-and-navigation|Quick snippets and navigation]]: Keyboard navigation up/down for headings - Quick switcher extensions - Copy code block via keyboard shortcut - Configurable code block and callout snippets
+- [[obsidian-quickshare|QuickShare]]: Securely share your Obsidian notes with one click. Notes are end-to-end encrypted. No API keys or configuration required.
+- [[obsidian-quiet-outline|Quiet Outline]]: Make outline quiet and more powerful, including no-auto-expand, rendering heading as markdown, and search support.
+- [[quote-of-the-day|Quote of the Day]]: Inserts random quotes in the editor
+- [[quoth|Quoth]]: More flexible embedding. Embed precise selections, inline embeds, optionally include author and title.
+- [[rpg-manager|RPG Manager]]: A plugin to manage your Tabletop Role Playing Game campaigns for Obsidian.
+- [[rss-reader|RSS Reader]]: Read RSS Feeds from within obsidian
+- [[obsidian-raindrop-highlights|Raindrop Highlights]]: Sync your Raindrop.io highlights.
+- [[obsidian-rant|Rant-Lang]]: Thin wrapper around the Rant language Rust crate
+- [[obsidian-read-it-later|ReadItLater]]: Saves the clipboard to a new notice.
+- [[readavocado-sync|Readavocado Sync]]: Sync your Readavocado highlights with Obsidian
+- [[recent-files-obsidian|Recent Files]]: List files by most recently opened
+- [[obsidian-redirect|Redirect]]: An Obsidian (https://obsidian.md) plugin for redirecting links based on YAML frontmatter.
+- [[obsidian-regex-replace|Regex Find/Replace]]: Find and replace text using regular expressions.
+- [[obsidian-relativenumber|Relativenumber (relative line numbers)]]: Displays relative line numbers in the editor's gutter.
+- [[obsidian-release-timeline|Release Timeline]]: Release timeline rendered based on notes metadata with a dataview-like syntax.
+- [[obsidian-remember-file-state|Remember File State]]: Remembers cursor position, selection, scrolling, and more for each file
+- [[remotely-save|Remotely Save]]: Yet another unofficial plugin allowing users to synchronize notes between local device and the cloud service.
+- [[repeat-plugin|Repeat]]: Review notes using periodic or spaced repetition.
+- [[obsidian-rewarder|Rewarder]]: Gives you rewards for completing tasks/todos, highly configurable.
+- [[obsidian-sakana-widget|Sakana Widget]]: Add the Sakana! Widget to your own Obsidian!
+- [[obsidian-save-as-gist|Save as Gist]]: Saving your current note as Gist on github
+- [[obsidian-screwdriver|Screwdriver]]: Utility to put any files in and out under your vault.
+- [[script-launcher|Script Launcher]]: This pulgin allows you to launch scripts from the Obsidian app. You can add scripts shortcuts on your bottom bar and launch them with just one click!
+- [[obsidian-scroll-offset|Scroll Offset]]: Preserve minmium distances before and after cursor.
+- [[scroll-speed|Scroll Speed]]: This plugin allows you to change the scroll speed inside Obsidian notes.
+- [[obsidian-scroll-to-top-plugin|Scroll to Top Plugin]]: This is a plugin for Obsidian that adds a button to scroll to the top of the current note.
+- [[image-window|Second Window]]: Allow images & notes to be viewed in new Obsidian windows.
+- [[sekund|Sekund]]: Share your notes. Gather feedback.
+- [[obsidian-livesync|Self-hosted LiveSync]]: Community implementation of self-hosted livesync. Reflect your vault changes to some other devices immediately. Please make sure to disable other synchronize solutions to avoid content corruption or duplication.
+- [[obsidian-sentence-navigator|Sentence Navigator]]: Manipulate sentences as a unit of movement. Select, move and delete by whole sentences.
+- [[obsidian-sequence-hotkeys|Sequence Hotkeys]]: This plugin allows you to set hotkeys with key sequences instead of a single chord.
+- [[settings-search|Settings Search]]: Globally search settings in Obsidian.md
+- [[obsidian-share-as-gist|Share as Gist]]: Shares an Obsidian note as a GitHub.com gist
+- [[obsidian-shortcut-launcher|Shortcut Launcher]]: Trigger shortcuts in Apple's Shortcuts app from Obsidian with custom commands.
+- [[obsidian-sidebar-toggler|Sidebar Toggler]]: Finer control of the Obsidian sidebars. To be used with an external window manager.
+- [[simple-dice-roller|Simple Dice Roller]]: A plug and play solution that allows you to average and simulate dice formulas.
+- [[simple-embeds|Simple Embeds]]: Replaces links, like Twitter and YouTube, with embeds when previewing a file.
+- [[obsidian-simple-mention|Simple Mention]]: Get highlighted mentions and mention suggestions. Find all occurrences of a mention
+- [[simple-note-quiz|Simple Note Quiz]]: Start a simple quiz on your current note
+- [[obsidian-siteswap|Siteswap]]: Visualize Juggling Pattern Siteswap via the JugglingLab gif server.
+- [[smort-obsidian|Smort]]: Add Smort.io articles to Obsidian. Smort.io lets you easily edit, annotate and share articles.
+- [[snippet-commands-obsidian|Snippet Commands]]: Registers custom css snippets as commands (which you can bind hotkeys to)
+- [[obsidian-snippet-downloader|Snippet Downloader]]: A obsidian's plugin to help to manage css snippets (download / update) from repository 
 - [[obsidian-snippetor|Snippetor]]: Create and tweak common snippets (starting with custom tasks)
 - [[obsidian-sortable|Sortable]]: Wiki-like table sorting.
-- [[link-info-server|Link Server]]: This plugin will open a reverse proxy server at port 3333 to get wikiLink information Obsidian API.
-- [[weather-fetcher|Weather Fetcher]]: Fetch and insert current weather into the editor of Obsidian.
-- [[obsidian-lock-screen-plugin|Lock Screen]]: Protect your vault with a lock screen.
-- [[pinboard-sync|Pinboard Sync]]: Syncs Pinboard.in links with Daily Notes
-- [[obsidian-shortcut-launcher|Shortcut Launcher]]: Trigger shortcuts in Apple's Shortcuts app from Obsidian with custom commands.
-- [[obsidian-file-info-plugin|File Info Panel]]: Plugin for Obsidian that creates a File Information view that displays the active file's date created, date modified, file size, and links to open the file in its native application and to open the file's folder.  It also has writing statistics (character, word, sentence, and paragraph counts) and a word frequency analysis.
-- [[obsidian-topic-linking|Topic Linking]]: Convert PDF files and web links to Markdown, and create topics from Markdown
-- [[multi-column-markdown|Multi-Column Markdown]]: This plugin adds functionality to create markdown documents with multiple columns of content viewable within Obsidian's preview mode
-- [[copy-as-html|Copy as HTML]]: This is a simple plugin that converts the selected markdown to HTML and copies it to the clipboard.
-- [[simple-note-quiz|Simple Note Quiz]]: Start a simple quiz on your current note
-- [[obsidian-local-rest-api|Local REST API]]: Get, change or otherwise interact with your notes in Obsidian via a REST API.
-- [[obsidian-codeblock-labels|Code Block Labels]]: Adds labels to fenced code blocks
-- [[obsidian-better-command-palette|Better Command Palette]]: A command palette that does all of the things you want it to do.
-- [[obsidian-relativenumber|Relativenumber (relative line numbers)]]: Displays relative line numbers in the editor's gutter.
-- [[obsidian-save-as-gist|Save as Gist]]: Saving your current note as Gist on github
-- [[obsidian-divide-and-conquer|Divide & Conquer]]: Provides commands for bulk enabling/disabling of plugins. Useful for debugging when you have many plugins.
-- [[obsidian-excel-to-markdown-table|Excel to Markdown Table]]: An Obsidian plugin to paste data from Microsoft Excel, Google Sheets, Apple Numbers and LibreOffice Calc as Markdown tables in Obsidian editor.
-- [[auto-note-mover|Auto Note Mover]]: Auto Note Mover will automatically move the active notes to their respective folders according to the rules.
-- [[insert-heading-link|Insert Heading Link]]: Add a Link to a Heading
-- [[settings-search|Settings Search]]: Globally search settings in Obsidian.md
-- [[obsidian-footnote-indicator|Footnote & Citation Indicator]]: Counts footnotes & Pandoc citations, indicates their presence in the gutter.
-- [[alx-folder-note-folderv|AidenLx's Folder Note - folderv component]]: Optional `folderv` Component for alx-folder-note
-- [[obsidian-chevereto-image-uploader|Obsidian Chevereto Image Uploader]]: This plugin uploads the image in your clipboard to chevereto automatically when pasting.
-- [[sekund|Sekund]]: Share your notes. Gather feedback.
-- [[obsidian-command-palette-minus-plugin|Command Palette--]]: Command palette without unwanted commands
-- [[obsidian-remember-file-state|Remember File State]]: Remembers cursor position, selection, scrolling, and more for each file
-- [[markdown-shortcuts|Markdown shortcuts]]: Allows to write markdown from shortcuts (example: >h1 -> #).
-- [[digitalgarden|Digital Garden]]: Publish your notes to a digital garden for others to enjoy.
-- [[obsidian-daily-notes-opener|Daily notes opener]]: Easily open daily/periodic notes in new pane, and much more!
-- [[obsidian-advanced-new-folder|Advanced new folder]]: This is a plugin that creates a new folder anywhere you want in the vault
-- [[obsidian-mark-and-select|Mark and Select]]: More flexible ways to select texts in Obsidian Editor
-- [[obsidian-bible-linker|Bible Linker]]: Link multiple bible verses easily
-- [[obsidian-circuitjs|Obsidian CircuitJS]]: Integrating CircuitJS and Obsidian
-- [[creases|Creases]]: Tools for efficiently folding markdown sections in Obsidian
-- [[obsidian-kobo-highlights-importer-plugin|Kobo Highlights Importer]]: Import highlights from your Kobo device
-- [[obsidian-dynamic-embed|Dynamic Embed]]: Dynamicly interpreted inline embeds.
-- [[obsidian-steemit|Steemit]]: A plugin for publishing Obsidian documents to Steemit.
-- [[obsidian-kindle-export|Kindle]]: Send .md as .mobi to Kindle
-- [[obsidian-textgenerator-plugin|Text Generator]]: Text generation using OpenAI
-- [[markdown-table-editor|Markdown Table Editor]]: An Obsidian plugin to provide an editor for Markdown tables. It can open CSV, Microsoft Excel/Google Sheets data as Markdown tables from Obsidian Markdown editor.
-- [[obsidian-file-cleaner|File Cleaner]]: Help you to clean empty files and unused attachments in the vault.
-- [[obsidian-card-view-switcher-plugin|Card View Switcher]]: Quick switcher with card view
-- [[novel-word-count|Novel word count]]: Displays a word count (and more!) for each file, folder and vault in the File Explorer pane.
-- [[heycalmdown-navigate-cursor-history|Navigate Cursor History]]: This plugin remembers the recent 50 cursor positions history and allows you to jump to them back and forth like VSCode
-- [[obsidian-matrix|Obsidian matrix]]: Utility to easily create LaTeX matrices
-- [[waypoint|Waypoint]]: Easily generate dynamic content maps in your folder notes. Enables folders to show up in the graph view and removes the need for messy tags!
-- [[obsidian-hover-editor|Hover Editor]]: Transform the Page Preview hover popover into a fully working editor instance
-- [[obsidian-screwdriver|Screwdriver]]: Utility to put any files in and out under your vault.
-- [[obsidian-version-history-diff|Version History Diff]]: Diff the version history of the core Sync and File Recovery plugins and Git. Adds a command to open the core Sync version history as well.
-- [[obsidian-format-code|Format code]]: This plugin introduces commands to format code (internally uses prettier)
-- [[obsidian-buttondown-plugin|Buttondown]]: Send your notes to your buttondown.email account as email drafts.
-- [[lapel|Lapel]]: Dress up your editor with decorations that mark each of your headings 🤵
-- [[obsidian-desmos|Desmos]]: Embed Desmos graphs into your notes
-- [[obsidian-custom-frames|Custom Frames]]: A plugin that turns web apps into panes using iframes with custom styling. Also comes with presets for Google Keep, Todoist and more.
-- [[obsidian-etherpad-plugin|Etherpad]]: Etherpad Integration
-- [[obsidian-quiet-outline|Quiet Outline]]: Make outline quiet and more powerful, including no-auto-expand, rendering heading as markdown, and search support.
-- [[obsidian-daily-notes-viewer|Daily Notes Viewer]]: Help you to view some recent daily notes on one page.
-- [[obsidian-zotero-desktop-connector|Zotero Integration]]: Insert and import citations, bibliographies, notes, and PDF annotations from Zotero.
-- [[obsidian-telegraph-publish|Telegraph Publish]]: 
-- [[obsidian-path-title|Path Title]]: Adds path (or optional replacement) to the filename title of each pane
-- [[obsidian-jira-issue|Jira Issue]]: This plugin allows you to track the progress of Atlassian Jira issues from your Obsidian notes.
-- [[smort-obsidian|Smort]]: Add Smort.io articles to Obsidian. Smort.io lets you easily edit, annotate and share articles.
-- [[control-characters|Control Characters]]: Show control/non-printing characters in edit mode
-- [[obsidian-asciidoc-blocks|AsciiDoc Blocks Plugin]]: A plugin to render asciidoc blocks in Obsidian, initially asciidoc tables.
-- [[fleeting-notes-obsidian|Fleeting Notes Sync]]: This is a plugin to sync Fleeting Notes with Obsidian
-- [[obsidian-chat-view|Chat View]]: Chat View enables you to create elegant Chat UIs in your Obsidian markdown files. It also supports the WebVTT format.
-- [[obsidian-doubleshift|Doubleshift]]: Open the command palette by pressing Shift (or any other key) twice like in IntelliJ and create your own shortcuts
-- [[obsidian-list-modified|List Modified]]: A simple obsidian plugin that links all modified files meeting certain criteria to a daily note
-- [[obsidian-latex-suite|Latex Suite]]: Make typesetting LaTeX math as fast as handwriting through snippets, text expansion, and editor enhancements
-- [[obsidian-better-codeblock|Better CodeBlock]]: Add title, line number to Obsidian code block
-- [[obsidian-wordnik|Wordnik Definitions]]: Grabs information from Wordnik for a topic and brings it into Obsidian notes
-- [[typing-speed|Typing speed]]: This is a plugin for showing the current typing speed in the status bar
-- [[obsidian-google-tasks|Google Tasks]]: Interact with your Google Tasks from Inside Obsidian
-- [[obsidian-jtab|Obsidian jTab]]: Adds the ability to show guitar chords and tabs directly in your notes using jTab.
-- [[obsidian-book-search-plugin|Book Search]]: Helps you find books and create notes.
-- [[obsidian-paste-image-rename|Paste image rename]]: Rename pasted images and all the other attchments added to the vault
-- [[obsidian-scroll-offset|Scroll Offset]]: Preserve minmium distances before and after cursor.
-- [[obsius-publish|Obsius Publish]]: Make single notes instantly available on the web.
-- [[obsidian-snippet-downloader|Snippet Downloader]]: A obsidian's plugin to help to manage css snippets (download / update) from repository 
-- [[execute-code|Execute Code]]: Allows to execute code snippets within a note.
-- [[obsidian-badge|Obsidian Badge]]: This is a plugin to show badge for Obsidian.
-- [[kr-book-info-plugin|KoreanBook Info Plugin]]: A plugin that crawls Yes24 to get book information.
-- [[obsidian-drag-n-drop-plugin|Drag-n-Drop for blocks]]: Allow moving/copying/and creation embeds for blocks with drag-n-drop just like Logseq or Roam
-- [[obsidian-link-embed|Link Embed]]: This plugin allows you to convert URLs in your notes into embedded previews.
-- [[obsidian-columns|Obsidian Columns]]: Allows you to create columns in Obsidian Markdown
-- [[obsidian-mkdocs-publisher|Github Publisher]]: Github Publisher is a plugin that help you to send file in a configured Github Repository, based on a frontmatter entry state.
-- [[obsidian-notion-video|Notion Video]]: embed your notion video in obsidian
-- [[obsidian-math-plus|Obsidian Math+]]: This is an Obsidian plugin for taking math notes using Excalidraw.
-- [[obsidian-todoist-link|Todoist Link]]: Create Todoist tasks and projects from Obsidian with bidirectional links.
-- [[obsidian-rewarder|Rewarder]]: Gives you rewards for completing tasks/todos, highly configurable.
-- [[obsidian-calibre-plugin|Calibre]]: This plugin allows you to access your calibre libraries and read books directly in Obsidian.
-- [[omnisearch|Omnisearch]]: A search engine that just works
-- [[plugins-galore|Plugins Galore]]: This is an Obsidian plugin to allow easily sideloading other plugins.
-- [[auto-card-link|Auto Card Link]]: Automatically fetches metadata from a url and makes it as a card-styled link
-- [[notion-like-tables|Notion-Like Tables]]: Your premiere tool for creating and managing tabular data in Obsidian.md
-- [[auto-moc|AutoMOC]]: Looks for missing linked mentions or notes with a specific tag and imports them into the current note.
-- [[obsidian-paste-png-to-jpeg|Paste image Png to Jpeg]]: Screenshot png to jpeg and compress and rename
-- [[obsidian-folder-index|Folder Index]]: This Plugin will automatically generate a TOC for the current Folder.
-- [[obsidian-filename-emoji-remover|Filename Emoji Remover]]: This is a simple plugin to automatically remove emojis from filenames. Main purpose is to get rid of Dropbox sync issues for Readwise imported content.
-- [[obsidian-epub-plugin|ePub Reader]]: This is an ePub reader plugin for Obsidian. Can open document with ".epub" file extension.
-- [[obsidian-pandoc-reference-list|Pandoc Reference List]]: Displays a formatted reference in the sidebar for each pandoc citekey present in the current document.
-- [[obsidian-enhancing-export|Obsidian Enhancing Export]]: This is a enhancing export plugin for Obsidian. It allows to export to formats like Html, DOCX, ePub and PDF or Markdown(Hugo) etc.
-- [[enlightenment-obsidian|Enlightenment ✨]]: Pay attention to what you're paying attention to. Enlightenment adds a 'zen mode' for Preview, hiding the contents of your notes except for what's underneath your pointer.
-- [[obsidian-release-timeline|Release Timeline]]: Release timeline rendered based on notes metadata with a dataview-like syntax.
-- [[obsidian-folder-focus-mode|Folder Focus Mode]]: Focus file explorer on chosen folder and its files and subdirectories, while hiding all the other elements.
-- [[obsidian-bbcode|BBCode Convertor]]: Convert Markdown files to BBCode
-- [[obsidian-upcoming|Upcoming]]: Open upcoming and/or past daily notes in their own panes, tabs, or windows.
-- [[nuke-orphans|Nuke Orphans]]: Plugin that trashes orphaned files and attachments
-- [[obsidian-front-matter-title-plugin|Front Matter Title]]: Lets you define a title in frontmatter to be displayed as the filename
-- [[obsidian-bellboy|Bellboy]]: Opinionated file structure manager.
-- [[obsidian-functionplot|Obsidian Functionplot]]: A plugin for displaying mathematical graphs in obsidian.md.
-- [[obsidian-note-autocreator|Note Auto Creator]]: Automatically create notes when links are created to them.
-- [[local-quotes|Local Quotes]]: Collect your quotes from all over the repository and embed them in different locations with refresh delays.
-- [[obsidian-state-switcher|Yaml Manager]]: Keep you away from directly operating of yaml front matter
-- [[obsidian-media-db-plugin|Media DB Plugin]]: A plugin that can query multiple APIs for movies, series, anime, games, music and wiki articles, and import them into your vault.
-- [[obsidian-sequence-hotkeys|Sequence Hotkeys]]: This plugin allows you to set hotkeys with key sequences instead of a single chord.
-- [[tasks-packrat-plugin|Packrat]]: Process completed recurring Tasks
-- [[excalibrain|ExcaliBrain]]: A clean, intuitive and editable graph view for Obsidian
-- [[obsidian-expand-bullet|Expand Bullet]]: A plugin for transforming bullet content into note.
-- [[dbfolder|DB Folder]]: Folder with the capability to store and retrieve data from a folder like database
-- [[obsidian-advanced-codeblock|Advanced Codeblock]]: Give additioinal features to  code blocks.
-- [[booksidian-plugin|Booksidian]]: Connect Obsidian to your Goodreads.
-- [[simple-dice-roller|Simple Dice Roller]]: A plug and play solution that allows you to average and simulate dice formulas.
-- [[obsidian-camera|Obsidian Camera]]: Camera plugin for Obsidian
-- [[obsidian-markbase|Markbase for Obsidian]]: Official Markbase plugin to share your Obsidian notes online in your own digital garden
-- [[obsidian-user-plugins|User Plugins]]: Use js files or snippets to code your own quick and dirty plugins
-- [[obsidian-better-internal-link-inserter|Obsidian better Internal Link Inserter]]: Allow to use the selected word as an alias in link suggestion.
-- [[obsidian-ghost-publish|Obsidian Ghost Publish]]: Single click to publish to Ghost
-- [[obsidian-timestamp-notes|Timestamp Notes]]: This plugin allows side-by-side notetaking with videos. Annotate your notes with timestamps to directly control the video and remember where each note comes from.
-- [[linkify|Linkify]]: Converts matching text into links.
-- [[braincache|braincache]]: Create flashcards from obsidian notes
-- [[obsidian-share-as-gist|Share as Gist]]: Shares an Obsidian note as a GitHub.com gist
-- [[code-block-plugin|Code Block]]: This plugin converts text into code blocks with automatic language detection.
-- [[obsidian-google-lookup|Google Calendar and Contacts Lookup]]: Import contact and calendar event information from your Google account
-- [[obsidian-stack-overflow|Stack Overflow Answers]]: Copy and Paste Stack Overflow answers directly into Obsidian.
-- [[obsidian-redirect|Redirect]]: An Obsidian (https://obsidian.md) plugin for redirecting links based on YAML frontmatter.
-- [[zotero-bridge|Zotero Bridge]]: Zotero integration
-- [[wielder|Wielder]]: Clojure inside Obsidian
-- [[obsidian-to-notion|Obsidian shared to Notion]]: This is a  plugin for Obsidian. This plugin share obsidian md  file to notion with notion api
-- [[obsidian-image-gallery|Image Gallery]]: A zero setup masonry image gallery for Obsidian
-- [[obsidian-thumbnails|Thumbnails]]: Insert video thumbnails into your notes
-- [[obsidian-table-to-csv-exporter|Table to CSV Exporter]]: This plugin allows for exporting tables from a pane in reading mode into CSV files.
-- [[obsidian-task-progress-bar|Task Progress Bar]]: A task progress bar plugin for tasks in Obsidian.
-- [[scroll-speed|Scroll Speed]]: This plugin allows you to change the scroll speed inside Obsidian notes.
-- [[obsidian-translator|Translator]]: This is a plugin for Obsidian to translate selected text.
-- [[obsidian-echarts|obsidian echarts]]: obsidian echarts
-- [[obsidian-diagrams-net|Diagrams.net]]: Enable diagrams.net (previously draw.io) type diagrams, with the diagrams.net embedded editor.
-- [[obsidian-weread-plugin|Weread Plugin]]: This is obsidian plugin for Tencent weread.
-- [[postgresql-obsidian|PostgreSQL Obsidian]]: An Obsidian plugin to upload your notes' metadata to your database.
-- [[obsidian-better-internal-link-inserter|Obsidian better Internal Link Inserter]]: Allow to use the selected word as an alias in link suggestion.
-- [[zotero-link|Zotero Link]]: Insert link to Zotero items from Obsidian interface using Zotero Bridge
-- [[obsidian-golinks|Obsidian GoLinks]]: This is a plugin for Obsidian that renders go/links as clickable links.
-- [[habit-tracker|Habit Tracker]]: Track your Habits.
-- [[typing-transformer-obsidian|Typing Transformer]]: Improved, configurable auto formatting as typing
-- [[obsidian-list-callouts|List Callouts]]: Create simple callouts in lists.
-- [[obsidian-text-expander-js|Inline Scripts]]: Type text shortcuts which are then replaced with JavaScript generated text.
-- [[metadata-menu|Metadata Menu]]: For data quality enthousiasts (and dataview lovers): manage the metadata of your notes.
-- [[obsidian-plugin-time-diff|TimeDiff plugin]]: Plugin which calculates and displays diff in hours and minutes between two dates in `timediff` markdown block
-- [[obsidian-trim-whitespace|Trim Whitespace]]: Trims unnecessary whitespace from your Obsidian documents
-- [[ninja-cursor|Ninja Cursor]]: The plugin which enhance cursor visibility.
-- [[cmdr|Commander]]: Customize your workspace by adding commands everywhere, create Macros and supercharge your mobile toolbar.
-- [[obsidian-attendance|Obsidian Attendance]]: This plugin helps you track attendance.
-- [[OA-file-hider|File Hider]]: An Obsidian plugin that allows hiding files and folders in the built-in file explorer
-- [[obsidian-sidebar-toggler|Sidebar Toggler]]: Finer control of the Obsidian sidebars. To be used with an external window manager.
-- [[obsidian-path-finder|Path Finder]]: A plugin that can find the shortest path between two notes. Not sure who will want to use it...
-- [[obsidian-focus-plugin|Focus and Highlight]]: A plugin for Obsidian (https://obsidian.md) that will highlight and focus on the currently selected heading
-- [[obsidian-file-cooker|File Cooker]]: Deal multi notes from Search results、current file、Dataview query string...
-- [[hard-breaks|Hard Breaks]]: Turn soft line breaks in Markdown into hard line breaks
-- [[open-related-url|Open Related Url]]: Opens URLs found in a note's YAML frontmatter
-- [[podnotes|PodNotes]]: Helps you write notes on podcasts.
-- [[obsidian-meeting-notes|Meeting notes]]: (https://obsidian.md) Plugin to automatically create a meeting note if a new file is created in a meeting folder.
-- [[obsidian-plugin-tagged-documents-viewer|Tagged Documents Viewer]]: Opens a modal with scrollable content of all documents that contain a specific tag or tags.
-- [[better-inline-fields|Better Inline Fields]]: Obsidian plugin to enhance Dataview style inline fields
-- [[no-dupe-leaves|No dupe leaves]]: Don't reopen notes that are already open
-- [[obsidian-open-file-by-magic-date|Open File by Magic Date]]: Define a Moment.js date pattern that specifies the file that is most important to you (eg: your daily/weekly/monthly note). Will create the file if it doesn't exist.
-- [[obsidian-heading-shifter|Heading Shifter]]: Easily Shift and Change markdown headings.
-- [[obsidian-group-snippets|Group Snippets]]: Create folder of snippets to activate them in one click !
-- [[obsidian-raindrop-highlights|Raindrop Highlights]]: Sync your Raindrop.io highlights.
-- [[obisidian-note-linker|Note Linker]]: Automatically find and link notes in Obsidian
-- [[obsidian-dashing-cursor|Dashing cursor]]: Enables dashing cursor that follows the page scroll
-- [[obsidian-embedded-note-paths|Embedded Note Paths]]: Inserts the note file path above each note.
-- [[obsidian-quickshare|QuickShare]]: Securely share your Obsidian notes with one click. Notes are end-to-end encrypted. No API keys or configuration required.
-- [[rpg-manager|RPG Manager]]: A plugin to manage your Tabletop Role Playing Game campaigns for Obsidian.
-- [[literate-haskell|Literate Haskell]]: An obsidian plugin for integrating `.lhs` files into your PKM.
-- [[embed-code-file|Embed Code File]]: This is a plugin for Obsidian that allows for embedding code files.
-- [[obsidian-bulk-rename-plugin|Bulk Rename]]: Purpose of this plugin rename files based on pattern
-- [[obsidian-agile-task-notes|Agile Task Notes]]: Import your tasks from your TFS (Azure or Jira) to take notes on them and make todo-lists!
-- [[new-tab-default-page|Default New Tab Page]]: Open a note of your choice when creating a new tab, like in the browser.
-- [[obsidian-open-in-other-editor|Open in other editor]]: Open current active file in gVim or VScode.
-- [[obsidian-simple-mention|Simple Mention]]: Get highlighted mentions and mention suggestions. Find all occurrences of a mention
-- [[obsidian-auto-hide|Auto Hide]]: Collapse sidebars when clicking on the editor/viewer panel
-- [[janitor|Janitor]]: Performs cleanup tasks on the Obsidian vault
-- [[script-launcher|Script Launcher]]: This pulgin allows you to launch scripts from the Obsidian app. You can add scripts shortcuts on your bottom bar and launch them with just one click!
-- [[obsidian-party|Party🎉]]: An implementation of party.js for Obsidian. Create confetti, sparkles and even custom effects in your notes!
-- [[obsidian-day-and-night|Day and Night]]: An Obsidian plugin to automatically toggle themes between day theme and night theme on a set time schedule.
-- [[obsidian-tikzjax|TikZJax]]: Render LaTeX and TikZ diagrams in your notes
-- [[todoist-completed-tasks-plugin|Todoist completed tasks]]: Fetches completed tasks from todoist API and adds them to the Obsidian note.
-- [[quick-snippets-and-navigation|Quick snippets and navigation]]: Keyboard navigation up/down for headings - Quick switcher extensions - Copy code block via keyboard shortcut - Configurable code block and callout snippets
-- [[google-calendar|Google Calendar]]: Interact with your Google Calendar from Inside Obsidian
-- [[obsidian-copy-search-url|Copy Search URL]]: Adds a button to the search view for copying the Obsidian search URL.
-- [[simple-time-tracker|Super Simple Time Tracker]]: Multi-purpose time trackers for your notes!
-- [[blockquote-levels|Blockquote Levels]]: Adds commands for increasing/decreasing the blockquote level of the current line or selection.
-- [[obsidian-system-theme|System Theme]]: Plugin to automatically update to system theme.
-- [[custom-sort|Custom File Explorer sorting]]: Allows for manual and automatic, config-driven reordering and sorting of files and folders in File Explorer
-- [[obsidian-table-generator|Table Generator]]: A plugin for generate markdown table quickly like Typora.
-- [[aosr|Aosr]]: Another obsidian spaced repetition
-- [[obsidian-meta-bind-plugin|Meta Bind Plugin]]: This plugin can create input fields inside your notes and bind them to metadata fields.
-- [[microblog-publish-plugin|Micro.publish]]: Publish notes to Micro.blog
-- [[obsidian-sakana-widget|Sakana Widget]]: Add the Sakana! Widget to your own Obsidian!
-- [[obsidian-min-width|Min Width]]: Set the Minimum Width of the Active Pane in Obsidian
-- [[onyx-boox-extractor|Onyx Boox Annotation & Highlight Extractor]]: This plugin extracts annotations and highlights files exported from Onyx Boox tablets, and converts them to reference, literature and permanent notes fitting to the Zettelkasten method.
-- [[chronology|Chronology]]: Provides a calendar and a timeline of the notes creation and modification
-- [[duplicate-line|Duplicate Line]]: To duplicate a line or several following selected lines. multicursor can be used too
-- [[obsidian-toggle-list|ToggleList]]: Toggle the list/checklist with custom states/prefixes and suffixes
 - [[squiggle|Squiggle]]: Enables running squiggle code snippets within a note.
-- [[obsidian-theme-toggler|Theme Toggler]]: Toggle the theme in Obsidian's panels.
-- [[influx|Influx]]: An alternative backlinks plugin, which displays relevant and formatted excerpts from notes with linked mentions, based on the position of mentions in the notes' hierarchical structure (bullet level indentation).
-- [[obsidian-week-planner|Week Planner]]: Week Planner plugin for Obsidian. This plugin defines commands for creating planning documents and moving tasks between them.
-- [[obsidian-html-plugin|HTML Reader]]: This is a HTML file reader plugin for Obsidian. Can open document with ".html" and ".htm" file extensions.
-- [[dynamic-rtl|Dynamic RTL]]: Dynamic RTL/LTR direction per line/paragraph, dependant on language!
-- [[mathlinks|MathLinks]]: Render MathJax in your links
-- [[note-synchronizer|Note Synchronizer]]: This is a plugin for synchornizing Obsidian notes to other note-based softwares like Anki, following more strictly the principles of Zettelkasten and treating each Obsidian file as a note.
-- [[url-namer|URL Namer]]: This plugin retrieves the HTML titles to name the raw URL links.
-- [[obsidian-douban-plugin|Douban]]: This is a plugin that can import movies/books/musics/notes/games info data from Douban for Obsidian .
-- [[insert-unsplash-image|Image Inserter]]: This plugin helps users easily search and insert images to editors from Unsplash.
-- [[keyboard-analyzer|Keyboard Analyzer]]: See and analyse your keyboard hotkeys and shortcuts
-- [[obsidian-plugin-update-tracker|Plugin Update Tracker]]: Know when installed plugins have updates and evaluate the risk of upgrading
-- [[update-relative-links|Update Relative Links]]: Update relative links.
-- [[readavocado-sync|Readavocado Sync]]: Sync your Readavocado highlights with Obsidian
-- [[repeat-plugin|Repeat]]: Review notes using periodic or spaced repetition.
-- [[actions-uri|Actions URI]]: Adds additional `x-callback-url` endpoints to the app for common actions — it's a clean, super-charged addition to Obsidian URI.
-- [[obsidian-projects|Projects]]: Project management for Obsidian.
-- [[obsidian-dynamic-background|Dynamic Background]]: Adding dynamic effects and/or static wallpapers for Obsidian background
-- [[obsidian-note-content-pusher|Note Content Pusher]]: An Obsidian plugin to automatically create notes with some specified content when you link to a note that doesn't yet exist.
-- [[tag-summary-plugin|Tag Summary]]: This plugin creates summaries with paragraphs or blocks of text that share the same tag(s).
-- [[obsidian-alias-from-heading|Alias from heading]]: Implicitly add an alias matching the first heading in a document.
-- [[obsidian-ocr|Obsidian OCR]]: Add ocr capabilities to obsidian
-- [[obsidian-gitlab-issues|Gitlab Issues]]: Import issues from Gitlab into Obsidian.
-- [[obsidian-account-linker|Account Linker]]: Plugin for describing external service accounts in the front matter
-- [[symbols-prettifier|Symbols Prettifier]]: This plugin allows you to prettify the symbols with actual symbols you commonly type, like arrows.
-- [[obsidian-mtg|Obsidian MtG]]: A plugin for managing Magic: The Gathering decks and card lists as Obsidian notes
-- [[obsidian-markdown-file-suffix|Addional Markdown suffix (.mdx/.svx).]]: Use additional files like .mdx / .svx as if they were markdown.
-- [[editing-toolbar|Editing Toolbar]]: The Obsidian Editing Toolbar is modified from cmenu, which provides more powerful customization settings and has many built-in editing commands to be a MS Word-like toolbar editing experience.
-- [[floating-toc|floating toc]]: This is a floating Toc plugin that  hovers a table of content  containing a header level on the notes sidebar.
-- [[obsidian-checkbox3states-plugin|Checkbox 3 states]]: This is a simple plugin for add a third state to checkbox list.
+- [[obsidian-stack-overflow|Stack Overflow Answers]]: Copy and Paste Stack Overflow answers directly into Obsidian.
 - [[status-bar-quote|Status Bar Quote]]: Show your favorite quote in obsidian status bar
-- [[qmd-as-md-obsidian|qmd as md]]: This plugin provides an initial support for viewing files with .qmd extension. QMD files contain a combination of markdown and executable code cells and are a format supported by Quarto open source publishing system.
-- [[obsidian-to-flomo|Obsidian to Flomo]]: Quickly share content to Flomo.
-- [[obsidian-things3-sync|Obsidian Things3 Sync]]: A plugin for sync between Obsidian and Things3, create Todo and sync Todo status
-- [[mathpad|Mathpad]]: Computer Algebra System and Calculator for Onsidian
-- [[list-style|Ordered List Style]]: Set ordered list style inline in Obsidian.md. Alphabetic lists, roman numeral lists, etc.
+- [[obsidian-steemit|Steemit]]: A plugin for publishing Obsidian documents to Steemit.
+- [[stenography-obsidian|Stenography]]: Auto Describe your code with machine learning using the Stenography API
+- [[obsidian-structured-plugin|Structured Plugin]]: Structured plugin. Create hierarchy in notes using . 
+- [[simple-time-tracker|Super Simple Time Tracker]]: Multi-purpose time trackers for your notes!
+- [[symbols-prettifier|Symbols Prettifier]]: This plugin allows you to prettify the symbols with actual symbols you commonly type, like arrows.
+- [[obsidian-system-theme|System Theme]]: Plugin to automatically update to system theme.
+- [[obsidian-table-generator|Table Generator]]: A plugin for generate markdown table quickly like Typora.
+- [[obsidian-table-to-csv-exporter|Table to CSV Exporter]]: This plugin allows for exporting tables from a pane in reading mode into CSV files.
+- [[tabout|Tabout]]: Easily "tab out" of Links or other Markdown Formatting Characters.
+- [[tag-summary-plugin|Tag Summary]]: This plugin creates summaries with paragraphs or blocks of text that share the same tag(s).
+- [[obsidian-plugin-tagged-documents-viewer|Tagged Documents Viewer]]: Opens a modal with scrollable content of all documents that contain a specific tag or tags.
+- [[obsidian-task-progress-bar|Task Progress Bar]]: A task progress bar plugin for tasks in Obsidian.
+- [[obsidian-telegraph-publish|Telegraph Publish]]: 
+- [[obsidian-textgenerator-plugin|Text Generator]]: Text generation using OpenAI
+- [[obsidian-tts|Text to Speech]]: Text to speech for Obsidian. Hear your notes.
+- [[obsidian-theme-design-utilities|Theme Design Utilities]]: Some Utilities and Quality-of-Life Features for Designers of Obsidian Themes.
+- [[obsidian-theme-toggler|Theme Toggler]]: Toggle the theme in Obsidian's panels.
+- [[obsidian-thumbnails|Thumbnails]]: Insert video thumbnails into your notes
+- [[obsidian-tikzjax|TikZJax]]: Render LaTeX and TikZ diagrams in your notes
+- [[obsidian-plugin-time-diff|TimeDiff plugin]]: Plugin which calculates and displays diff in hours and minutes between two dates in `timediff` markdown block
+- [[obsidian-timestamper|TimeStamper]]: Insert customized time/date stamp.
+- [[obsidian-timestamp-notes|Timestamp Notes]]: This plugin allows side-by-side notetaking with videos. Annotate your notes with timestamps to directly control the video and remember where each note comes from.
+- [[obsidian-title-serial-number-plugin|Title Serial Number Plugin]]: This plugin adds serial numbers to your markdown title.
+- [[obsidian-todoist-link|Todoist Link]]: Create Todoist tasks and projects from Obsidian with bidirectional links.
+- [[todoist-completed-tasks-plugin|Todoist completed tasks]]: Fetches completed tasks from todoist API and adds them to the Obsidian note.
+- [[obsidian-toggle-list|ToggleList]]: Toggle the list/checklist with custom states/prefixes and suffixes
+- [[obsidian-tomorrows-daily-note|Tomorrow's Daily Note]]: An obsidian plugin that creates tomorrow's daily note for preemtive planning.
+- [[obsidian-topic-linking|Topic Linking]]: Convert PDF files and web links to Markdown, and create topics from Markdown
+- [[obsidian-translator|Translator]]: This is a plugin for Obsidian to translate selected text.
 - [[obsidian-trash-explorer|Trash Explorer]]: Restore and delete files from the Obsidian .trash folder
+- [[obsidian-trim-whitespace|Trim Whitespace]]: Trims unnecessary whitespace from your Obsidian documents
+- [[typing-transformer-obsidian|Typing Transformer]]: Improved, configurable auto formatting as typing
+- [[typing-speed|Typing speed]]: This is a plugin for showing the current typing speed in the status bar
+- [[url-namer|URL Namer]]: This plugin retrieves the HTML titles to name the raw URL links.
+- [[obsidian-upcoming|Upcoming]]: Open upcoming and/or past daily notes in their own panes, tabs, or windows.
+- [[update-relative-links|Update Relative Links]]: Update relative links.
+- [[update-time-on-edit|Update time on edit]]: Keep front matter in sync with the last edit time
+- [[obsidian-user-plugins|User Plugins]]: Use js files or snippets to code your own quick and dirty plugins
+- [[obsidian-version-history-diff|Version History Diff]]: Diff the version history of the core Sync and File Recovery plugins and Git. Adds a command to open the core Sync version history as well.
 - [[vika-sync|Vika Sync]]: Sync your note to vika
-- [[obsidian-new-note-new-window|New Note New Window]]: Plugin for easily opening new notes in a floating window.
-- [[obsidian-awesome-flashcard|Awesome Flashcard]]: Handy Anki integration for Obsidian.
-- [[obsidian-daily-note-outline|Daily Note Outline]]: Add a custom view which shows outline of multiple daily notes with headings, links, tags and list items
-- [[obsidian-colorful-tag|Colorful Tag]]: Make your tag more beautiful and powerful!
-- [[edit-gemini|Edit Gemini]]: Allows the user to edit and create .gmi files.
-- [[obsidian-pretty-bibtex|Pretty BibTeX]]: Shows raw BibTeX bibliography entries in a prettier way
-- [[frontmatter-links|Frontmatter Links]]: Renders links in a note's frontmatter as links.
-- [[ava|Obsidian ava]]: AI-enhanced reflection in Obsidian
-- [[obsidian-scroll-to-top-plugin|Scroll to Top Plugin]]: This is a plugin for Obsidian that adds a button to scroll to the top of the current note.
-- [[obsidian-old-note-admonitor|Old Note Admonitor]]: This Obsidian plugin shows warnings if the note has not been updated for over specific days
-- [[obsidian-export-image|Export Image plugin]]: Easily convert your article to image.
-- [[page-gallery|Page Gallery]]: Creates an embeddable gallery based on selected page contents.
-- [[obsidian42-strange-new-worlds|Obsidian42 - Strange New Worlds]]: Revealing networked thought and the strange new worlds created by your vault
-- [[obsidian-dynbedded|Dynbedded]]: Dynamic Embeds for Obsidian.md
-- [[copy-document-as-html|Copy document as HTML]]: Copy the current document to clipboard as HTML, including images
-- [[obsidian-chorded-hotkeys|Chorded Hotkeys]]: Type multiple letters at the same time to trigger text insertion, template insertion, or command execution.
-- [[obsidian-dirtreeist|Dirtreeist]]: Render a directory Structure Diagram from a markdown lists in codeblock.
-- [[obsidian-handlebars|Obsidian Handlebars Template Plugin]]: This is a plugin for Obsidian that adds support for handlebars template blocks in notes.
+- [[obsidian-vocabulary-view|Vocabulary View]]: Write down some words with their explanations and preview them in a vocabulary test style
+- [[waypoint|Waypoint]]: Easily generate dynamic content maps in your folder notes. Enables folders to show up in the graph view and removes the need for messy tags!
+- [[weather-fetcher|Weather Fetcher]]: Fetch and insert current weather into the editor of Obsidian.
+- [[obsidian-week-planner|Week Planner]]: Week Planner plugin for Obsidian. This plugin defines commands for creating planning documents and moving tasks between them.
+- [[obsidian-weread-plugin|Weread Plugin]]: This is obsidian plugin for Tencent weread.
+- [[wielder|Wielder]]: Clojure inside Obsidian
+- [[obsidian-word-sprint|Word Sprint]]: Word Sprint for Obsidian plugin for your writing projects like Nanowrimo
+- [[obsidian-wordpress|WordPress]]: A plugin for publishing Obsidian documents to WordPress.
+- [[obsidian-wordle|Wordle]]: Creates a view where you can play Wordle. No longer actively maintained.
+- [[obsidian-wordnik|Wordnik Definitions]]: Grabs information from Wordnik for a topic and brings it into Obsidian notes
+- [[workbench-obsidian|Workbench]]: Keep a workbench of knowledge materials.
+- [[obsidian-wrap-with-shortcuts|Wrap with shortcuts]]: Wrap selected text in custom tags with shortcuts. E.g.: underline, sub, ruby(フリガナ)
+- [[obsidian-state-switcher|Yaml Manager]]: Keep you away from directly operating of yaml front matter
+- [[zotero-bridge|Zotero Bridge]]: Zotero integration
+- [[obsidian-zotero-desktop-connector|Zotero Integration]]: Insert and import citations, bibliographies, notes, and PDF annotations from Zotero.
+- [[zotero-link|Zotero Link]]: Insert link to Zotero items from Obsidian interface using Zotero Bridge
+- [[braincache|braincache]]: Create flashcards from obsidian notes
+- [[obsidian-epub-plugin|ePub Reader]]: This is an ePub reader plugin for Obsidian. Can open document with ".epub" file extension.
+- [[floating-toc|floating toc]]: This is a floating Toc plugin that  hovers a table of content  containing a header level on the notes sidebar.
+- [[obsidian-echarts|obsidian echarts]]: obsidian echarts
+- [[qmd-as-md-obsidian|qmd as md]]: This plugin provides an initial support for viewing files with .qmd extension. QMD files contain a combination of markdown and executable code cells and are a format supported by Quarto open source publishing system.
 
 
 %% Hub footer: Please don't edit anything below this line %%

--- a/02 - Community Expansions/02.01 Plugins by Category/Vim-related Plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Vim-related Plugins.md
@@ -13,13 +13,13 @@ Plugins related to [[Vim]] mode
 
 ## Plugins in this category
 
-- [[obsidian-vimrc-support|Vimrc Support]]: Auto-load a startup file with Obsidian Vim commands.
 - [[mrj-add-codemirror-matchbrackets|Add Codemirror's matchbrackets.js]]: This plugins adds matchbrackets.js which allows to use `di[` or `ya(` commands in Vim mode
-- [[obsidian-vim-im-switch-plugin|Vim Input Method Switch]]: Switch input method with fcitx-remote when Vim keymap is enabled.
-- [[obsidian-relative-line-numbers|Relative Line Numbers]]: Enables relative line numbers in editor mode
 - [[improved-vimcursor|Improved VimCursor]]: An improved experience with the cursor in obsidian
+- [[obsidian-relative-line-numbers|Relative Line Numbers]]: Enables relative line numbers in editor mode
 - [[vim-im-select|Vim IM Select]]: Support auto select the apposite input method in different vim mode
+- [[obsidian-vim-im-switch-plugin|Vim Input Method Switch]]: Switch input method with fcitx-remote when Vim keymap is enabled.
 - [[obsidian-vim-multibyte-char-search|Vim Multibyte Char Search]]: Search multibyte characters by the first character of corresponding ASCII encoding of input method. For example, for Chinese, search by the first character of Pinyin.
+- [[obsidian-vimrc-support|Vimrc Support]]: Auto-load a startup file with Obsidian Vim commands.
 
 ## Related categories
 


### PR DESCRIPTION
## Edited
Alphabetized the plugin list on all plugin category pages.

## Added
**sort_lists.py** a script to programatically sort markdown lists within a heading.

It is written to work pretty generically on the first markdown list within a heading on a page, so we could re-apply this concept to other sets of pages and headings.

I imagine this could be added to the github actions at the end.