### PR TITLE
Addressing issue 547: Add github footer to roundup files

### DIFF
--- a/.github/scripts/templates/roundup.md.jinja
+++ b/.github/scripts/templates/roundup.md.jinja
@@ -1,0 +1,2 @@
+{{ content }}
+{% include "footer.md.jinja" %}

--- a/.github/scripts/update_roundup.py
+++ b/.github/scripts/update_roundup.py
@@ -1,9 +1,17 @@
 from datetime import datetime
 from feedparser import FeedParserDict, parse
 from markdownify import markdownify as md
+from urllib.parse import quote
 
 FEED_URL = "https://www.obsidianroundup.org/blog/rss/"
 ROUNDUP_FOLDER_PATH = "../../01 - Community/Obsidian Roundup"
+FOOTER = """
+%% Hub footer: Please don't edit anything below this line %%
+
+# This note in GitHub
+
+<span class="git-footer">[Edit In GitHub](https://github.dev/obsidian-community/obsidian-hub/blob/main/01%20-%20Community/Obsidian%20Roundup/{formatted_article_title_url} "git-hub-edit-note") | [Copy this note](https://raw.githubusercontent.com/obsidian-community/obsidian-hub/main/01%20-%20Community/Obsidian%20Roundup/{formatted_article_title_url} "git-hub-copy-note") | [Download this vault](https://github.com/obsidian-community/obsidian-hub/archive/refs/heads/main.zip "git-hub-download-vault") </span>
+"""
 
 def date_conversion(parsed_feed_datetime: FeedParserDict) -> datetime:
     """Converts published_parsed attribute of a feed item into a pythonic datetime object"""
@@ -35,18 +43,20 @@ def generate_file_with_hub_yaml(entry: FeedParserDict) -> str:
     frontmatter: str = f"---\nlink: {entry.link}\nauthor: {entry.author}\npublished: {datetime_from_parsed_feed_datetime(entry)}\npublish: true\n---\n\n"
     return frontmatter+f"# {date_from_parsed_feed_datetime(entry)}: {entry.title[2:]}\n{entry.summary}\n\n"+convert_feed_html(entry.content[0].value)
 
-def save_file(entry: FeedParserDict) -> None:
+def save_file(entry: FeedParserDict) -> str:
     file_contents: str = generate_file_with_hub_yaml(entry)
     file_name = f"{ROUNDUP_FOLDER_PATH}/{get_normalized_file_name(entry)}"
     with open(file_name, 'w', encoding='utf8') as roundup_file:
         roundup_file.write(file_contents)
+    return file_name
 
 def main() -> None:
     parsed_feed = parse(FEED_URL)
     for entry in parsed_feed.entries:
         if is_roundup_post(entry):
-            # print(get_normalized_file_name(entry))
-            save_file(entry)
+            file_path = save_file(entry)
+            with open(file_path, "a") as f:
+                f.write(FOOTER.format(formatted_article_title_url=quote(get_normalized_file_name(entry))))
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/update_roundup.py
+++ b/.github/scripts/update_roundup.py
@@ -5,14 +5,6 @@ from markdownify import markdownify as md
 from utils import get_template, write_file
 
 FEED_URL = "https://www.obsidianroundup.org/blog/rss/"
-ROUNDUP_FOLDER_PATH = "../../01 - Community/Obsidian Roundup"
-FOOTER = """
-%% Hub footer: Please don't edit anything below this line %%
-
-# This note in GitHub
-
-<span class="git-footer">[Edit In GitHub](https://github.dev/obsidian-community/obsidian-hub/blob/main/01%20-%20Community/Obsidian%20Roundup/{formatted_article_title_url} "git-hub-edit-note") | [Copy this note](https://raw.githubusercontent.com/obsidian-community/obsidian-hub/main/01%20-%20Community/Obsidian%20Roundup/{formatted_article_title_url} "git-hub-copy-note") | [Download this vault](https://github.com/obsidian-community/obsidian-hub/archive/refs/heads/main.zip "git-hub-download-vault") </span>
-"""
 
 def date_conversion(parsed_feed_datetime: FeedParserDict) -> datetime:
     """Converts published_parsed attribute of a feed item into a pythonic datetime object"""

--- a/.github/scripts/utils.py
+++ b/.github/scripts/utils.py
@@ -17,7 +17,8 @@ OUTPUT_DIR = {
     "category": "02 - Community Expansions/02.01 Plugins by Category",
     "theme": "02 - Community Expansions/02.05 All Community Expansions/Themes",
     "author": "01 - Community/People",
-    "plugin_issues": "01 - Community/Contributing to the Community"
+    "plugin_issues": "01 - Community/Contributing to the Community",
+    "roundup": "01 - Community/Obsidian Roundup",
 }
 
 # Type aliases:

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .DS_Store
 .AppleDouble
 .LSOverride
+venv/
 
 # Icon must end with two \r
 Icon

--- a/01 - Community/Obsidian Roundup/2022-10-29 Supercharged tags & a new Zotero integration.md
+++ b/01 - Community/Obsidian Roundup/2022-10-29 Supercharged tags & a new Zotero integration.md
@@ -88,7 +88,6 @@ I recently wrote a piece explaining how [I need to consolidate my newsletters an
 The upshot of this for the Obsidian Roundup is ironically that there will be more content available soon™. It's nothing to worry about, but I wanted to share it here so y'all know that changes are coming as soon as I can get this squared away on the "hiring a developer to help me pull this off" side of things. The short version is that there have been a lot of changes in newsletter software (and my life!) since I started the Obsidian Roundup, and I need to start taking advantage of some of those changes for my own sanity. 
 
 💚Also, a few people have asked me, so if you've been interested in chipping in to help defer my newsletter hosting fees and the costs of hiring developers, but aren't really interested in [a subscription](https://www.obsidianroundup.org/#/portal/signup), I do have a ko-fi page where you can [buy me a coffee](https://ko-fi.com/eleanorkonik).
-
 %% Hub footer: Please don't edit anything below this line %%
 
 # This note in GitHub

--- a/01 - Community/Obsidian Roundup/2022-11-26 Weekly Reviews, Zen Mode, & Aggregation.md
+++ b/01 - Community/Obsidian Roundup/2022-11-26 Weekly Reviews, Zen Mode, & Aggregation.md
@@ -45,7 +45,8 @@ _Note: Not all new plugins are available in the community list yet, as they need
 
 * QuickAdd got a big rewrite with a ton of bug fixes, as well as some [new documentation](https://quickadd.obsidian.guide).
 * [Strange New Worlds](https://github.com/TfTHacker/obsidian42-strange-new-worlds) popups will now by default get cut off at 100 files, although the number can be controlled in settings. This should improve speed.
-* Metadata Menu 0.3.7 got a bunch of improvements related to Fileclass views, with a [demo](https://youtu.be/3jukvV7OODg) video.[Frontmatter Links: v1.2.5](https://obsidian.md/plugins?id=frontmatter-links) lets users add front matter links to the graph, works on mobile, and got some styling improvements.
+* Metadata Menu 0.3.7 got a bunch of improvements related to Fileclass views, with a [demo](https://youtu.be/3jukvV7OODg) video.
+* [Frontmatter Links: v1.2.5](https://obsidian.md/plugins?id=frontmatter-links) lets users add front matter links to the graph, works on mobile, and got some styling improvements.
 * [Obsidian Front Matter Title 2.6.0](https://github.com/Snezhig/obsidian-front-matter-title/releases/tag/2.6.0) added alias and suggest features.
 * the [Obsidian Chat View Plugin](https://github.com/adifyr/obsidian-chat-view) now supports markdown and HTML rendering.
 * [Another Quick Switcher](https://github.com/tadashi-aikawa/obsidian-another-quick-switcher) 7.5.0 lets users search links.


### PR DESCRIPTION
## Edited
<!-- Add a brief description here -->

## Added
<!-- Add a brief description here-->

## Checklist
- [ ] before creating a new note, I searched the vault
- [ ] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
