### PR TITLE
As a result of 556, no need to add footers to Roundup anymore

### DIFF
--- a/.github/scripts/add_footer.py
+++ b/.github/scripts/add_footer.py
@@ -11,7 +11,7 @@ from jinja2.environment import Template
 
 # These are directories and files to exclude
 # By adding a dir/file, this script will ignore them and never change them!
-DIRECTORIES_TO_EXCLUDE = ['.git', '.github', '.idea', 'venv', '01 Templates', 'DO NOT COMMIT']
+DIRECTORIES_TO_EXCLUDE = ['.git', '.github', '.idea', 'venv', '01 Templates', 'DO NOT COMMIT', 'Obsidian Roundup',]
 FILES_TO_EXCLUDE = ['.DS_Store', '.gitignore', 'Hub Tree Structure.md']
 
 


### PR DESCRIPTION
## Test
I removed the footer from one of the roundup files and ensured it was added back.

## Edited
Edit add_footer.py
No need to add footers to roundup updates anymore.

## Added

## Checklist
- [ ] before creating a new note, I searched the vault
- [ ] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
