### PR TITLE
Maintain the alphabetical order of the uncategorized plugins

### DIFF
--- a/.github/scripts/sort_lists.py
+++ b/.github/scripts/sort_lists.py
@@ -5,6 +5,8 @@ from glob import glob
 from typing import List, Tuple, Optional, Any
 import logging
 
+PLUGIN_LIST_HEADING = '## Plugins in this category'
+
 
 def extract_alias(markdown_link_list_item: str) -> str:
     # Return the alias if we have it, otherwise the page name.
@@ -82,12 +84,11 @@ def getLogger():
 def main() -> None:
     logging.basicConfig(level=logging.INFO)
 
-    heading = '## Plugins in this category'
     for page_path in plugin_page_paths():
-        sort_links_under_heading(page_path, heading)
+        sort_links_under_heading(page_path)
 
 
-def sort_links_under_heading(page_path, heading):
+def sort_links_under_heading(page_path, heading=PLUGIN_LIST_HEADING):
     page_contents = read_file(page_path)
     log = getLogger()
     log.debug(f"Sorting page: {page_path}")

--- a/.github/scripts/sort_lists.py
+++ b/.github/scripts/sort_lists.py
@@ -78,7 +78,7 @@ def extract_list_pos(markdown_text: str, header: str) -> Optional[Tuple[int, int
 def plugin_page_paths() -> List[str]:
     return glob("../../02 - Community Expansions/02.01 Plugins by Category/*.md")
 
-def getLogger():
+def getLogger() -> logging.Logger:
     return logging.getLogger('sort_lists')
 
 def main() -> None:
@@ -88,7 +88,7 @@ def main() -> None:
         sort_links_under_heading(page_path)
 
 
-def sort_links_under_heading(page_path, heading=PLUGIN_LIST_HEADING):
+def sort_links_under_heading(page_path: str, heading: str = PLUGIN_LIST_HEADING) -> None:
     page_contents = read_file(page_path)
     log = getLogger()
     log.debug(f"Sorting page: {page_path}")

--- a/.github/scripts/sort_lists.py
+++ b/.github/scripts/sort_lists.py
@@ -76,18 +76,20 @@ def extract_list_pos(markdown_text: str, header: str) -> Optional[Tuple[int, int
 def plugin_page_paths() -> List[str]:
     return glob("../../02 - Community Expansions/02.01 Plugins by Category/*.md")
 
+def getLogger():
+    return logging.getLogger('sort_lists')
 
 def main() -> None:
     logging.basicConfig(level=logging.INFO)
-    log = logging.getLogger('sort_lists')
 
     heading = '## Plugins in this category'
     for page_path in plugin_page_paths():
-        sort_links_under_heading(page_path, heading, log)
+        sort_links_under_heading(page_path, heading)
 
 
-def sort_links_under_heading(page_path, heading, log):
+def sort_links_under_heading(page_path, heading):
     page_contents = read_file(page_path)
+    log = getLogger()
     log.debug(f"Sorting page: {page_path}")
     log.debug(f"Within heading: {heading}")
     list_pos = extract_list_pos(page_contents, heading)

--- a/.github/scripts/sort_lists.py
+++ b/.github/scripts/sort_lists.py
@@ -83,27 +83,28 @@ def main() -> None:
 
     heading = '## Plugins in this category'
     for page_path in plugin_page_paths():
-        page_contents = read_file(page_path)
-        log.debug(f"Sorting page: {page_path}")
-        log.debug(f"Within heading: {heading}")
+        sort_links_under_heading(page_path, heading, log)
 
-        list_pos = extract_list_pos(page_contents, heading)
-        if list_pos is None:
-            log.warning(f"Could not find heading in page. Skipping {page_path}")
-            continue
 
-        [list_start, list_end] = list_pos
-        original_list = page_contents[list_start:list_end]
+def sort_links_under_heading(page_path, heading, log):
+    page_contents = read_file(page_path)
+    log.debug(f"Sorting page: {page_path}")
+    log.debug(f"Within heading: {heading}")
+    list_pos = extract_list_pos(page_contents, heading)
 
-        log.debug(f"Original List:\n{original_list}")
-        sorted_list = sort_list(original_list)
+    if list_pos is None:
+        log.warning(f"Could not find heading in page. Skipping {page_path}")
+        return
 
-        log.debug(f"Sorted List:\n{sorted_list}")
-        new_page_contents = page_contents[:list_start] + sorted_list + page_contents[list_end:]
-
-        if page_contents != new_page_contents:
-            log.info(f"Sort changed {page_path}")
-        write_file(page_path, new_page_contents)
+    [list_start, list_end] = list_pos
+    original_list = page_contents[list_start:list_end]
+    log.debug(f"Original List:\n{original_list}")
+    sorted_list = sort_list(original_list)
+    log.debug(f"Sorted List:\n{sorted_list}")
+    new_page_contents = page_contents[:list_start] + sorted_list + page_contents[list_end:]
+    if page_contents != new_page_contents:
+        log.info(f"Sort changed {page_path}")
+    write_file(page_path, new_page_contents)
 
 
 if __name__ == '__main__':

--- a/.github/scripts/update_releases.py
+++ b/.github/scripts/update_releases.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-
+import os
 import sys
 import argparse
 from typing import Sequence
@@ -7,6 +7,7 @@ from typing import Sequence
 from authors import AllAuthors
 from obsidian_releases import get_community_plugins
 from plugins import PluginList
+from sort_lists import sort_links_under_heading
 
 from utils import (
     format_link,
@@ -17,6 +18,7 @@ from utils import (
     print_progress_bar,
     write_file,
     add_file_group,
+    get_output_dir,
 )
 from themes import ThemeList, Theme, ThemeDownloadCount, get_community_themes
 
@@ -119,6 +121,11 @@ def update_uncategorized_plugins(valid_plugins: PluginList, overwrite: bool = Tr
         overwrite=overwrite,
         verbose=True,
     )
+
+    # Alphabetize the plugin list
+    file_path = get_output_dir(template, UNCATEGORIZED)
+    absolute_file_path = os.path.abspath(file_path)
+    sort_links_under_heading(absolute_file_path, '## Plugins in this category')
 
 
 def process_authors(themes: ThemeList,

--- a/.github/scripts/update_releases.py
+++ b/.github/scripts/update_releases.py
@@ -125,7 +125,7 @@ def update_uncategorized_plugins(valid_plugins: PluginList, overwrite: bool = Tr
     # Alphabetize the plugin list
     file_path = get_output_dir(template, UNCATEGORIZED)
     absolute_file_path = os.path.abspath(file_path)
-    sort_links_under_heading(absolute_file_path, '## Plugins in this category')
+    sort_links_under_heading(absolute_file_path)
 
 
 def process_authors(themes: ThemeList,


### PR DESCRIPTION
## Edited
Pull in sort_list functions into update_releases.py in order to sort the list after we generate the file with new plugins.