### PR TITLE
Extract generalized edit functions from sort_lists (3 of 3)

### DIFF
--- a/.github/scripts/tests/test_add_footer.py
+++ b/.github/scripts/tests/test_add_footer.py
@@ -1,4 +1,7 @@
 import re
+from os.path import basename, dirname
+from tempfile import TemporaryFile, TemporaryDirectory
+from pathlib import Path
 
 import add_footer
 import utils
@@ -78,12 +81,15 @@ def add_footer_to_markdown_test(input: str, relative_path:str) -> str:
     :return: The result of adding or updating the footer in input
     """
     comment = add_footer.get_footer_comment_regex()
-    template = utils.get_template_from_directory(JINJA_TEMPLATES_DIR, "footer.md.jinja")
-    debug = False
 
-    # Cast is to force type for 'mypy --strict'
-    return str(add_footer.add_footer_to_markdown(relative_path, input, comment, template, debug))
+    with TemporaryDirectory() as tmproot:
+        path = f"{tmproot}/{relative_path}"
+        Path(dirname(path)).mkdir(parents=True, exist_ok=True)
+        utils.write_file(path, input)
 
+        add_footer.ensure_footer_in_file(tmproot, path)
+
+        return str(utils.read_file(path))
 
 def verify_footer_addition(input: str, output: str) -> None:
 

--- a/.github/scripts/update_issues.py
+++ b/.github/scripts/update_issues.py
@@ -10,7 +10,7 @@ from obsidian_releases import get_community_plugins
 from utils import (
     get_template,
     print_progress_bar,
-    write_file,
+    write_template_file,
 )
 
 from plugins import Plugin
@@ -62,7 +62,7 @@ def process_issues(api_key: str, overwrite: bool = True, verbose: bool = False) 
         "documentation": sorted_documentation,
         "good_first_issue": sorted_good_first_issue
     }
-    write_file(template, "Plugins seeking help", overwrite=overwrite, verbose=verbose, **args)
+    write_template_file(template, "Plugins seeking help", overwrite=overwrite, verbose=verbose, **args)
 
 
 def main(argv: Sequence[str] = sys.argv[1:]) -> None:

--- a/.github/scripts/update_releases.py
+++ b/.github/scripts/update_releases.py
@@ -15,7 +15,7 @@ from utils import (
     FileGroups,
     print_file_summary,
     print_progress_bar,
-    write_file,
+    write_template_file,
     add_file_group,
 )
 from themes import ThemeList, Theme, ThemeDownloadCount, get_community_themes
@@ -38,7 +38,7 @@ def process_released_plugins(overwrite: bool = False, verbose: bool = False) -> 
         if not plugin_is_valid:
             continue
 
-        group = write_file(
+        group = write_template_file(
             template, plugin.id(), overwrite=overwrite, verbose=verbose, **plugin.data()
         )
         valid_plugins.append(plugin)
@@ -70,7 +70,7 @@ def process_released_themes(overwrite: bool = False, verbose: bool = False) -> T
         if not valid:
             continue
 
-        group = write_file(
+        group = write_template_file(
             Theme.template, current_name, overwrite=overwrite, verbose=verbose, **theme.data()
         )
         valid_themes.append(theme)
@@ -110,7 +110,7 @@ def update_uncategorized_plugins(valid_plugins: PluginList, overwrite: bool = Tr
             uncategorized.append(p.data())
 
     template = get_template("category")
-    write_file(
+    write_template_file(
         template,
         UNCATEGORIZED,
         name=UNCATEGORIZED,
@@ -132,7 +132,7 @@ def process_authors(themes: ThemeList,
     print("\nCreating author notes....\n")
     file_groups: FileGroups = dict()
     for user, author_info in all_authors.items():
-        group = write_file(
+        group = write_template_file(
             template, user, overwrite=overwrite, verbose=verbose, **author_info
         )
         add_file_group(file_groups, group, user)

--- a/.github/scripts/update_roundup.py
+++ b/.github/scripts/update_roundup.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from feedparser import FeedParserDict, parse
 from markdownify import markdownify as md
 
-from utils import get_template, write_file
+from utils import get_template, write_template_file
 
 FEED_URL = "https://www.obsidianroundup.org/blog/rss/"
 
@@ -43,7 +43,7 @@ def save_file(entry: FeedParserDict) -> str:
     content = {
         'content': file_contents,
     }
-    write_file(
+    write_template_file(
         template, file_name, overwrite=True, verbose=False, **content,
     )
     return file_name

--- a/.github/scripts/utils.py
+++ b/.github/scripts/utils.py
@@ -70,11 +70,11 @@ def get_output_dir(template: Template, file_name: str) -> str:
     )
 
 
-def write_file(template: Template,
-               file_name: str,
-               overwrite: bool = False,
-               verbose: bool = False,
-               **kwargs: Any) -> str:
+def write_template_file(template: Template,
+                        file_name: str,
+                        overwrite: bool = False,
+                        verbose: bool = False,
+                        **kwargs: Any) -> str:
     file_path = get_output_dir(template, file_name)
     absolute_file_path = os.path.abspath(file_path)
 


### PR DESCRIPTION
This is stacked on top of #572

Remove the duplicate read_file/write_file, use the ones in utils.

Break apart the extract_list_pos into three functions:
- extract_block_pos
- extract_block_pos_without_header
- extract_list_pos

Again, this is a pure refactor and does the same substitutions.