### PR TITLE
Add a case_conflict.py to check for case-only file conflicts.

### DIFF
--- a/.github/scripts/case_conflicts.py
+++ b/.github/scripts/case_conflicts.py
@@ -1,0 +1,28 @@
+from collections import defaultdict
+from glob import glob
+
+def main() -> None:
+    found_conflict = False
+    all_markdown_paths = glob("../../*.md") + glob("../../**/*.md")
+
+    paths_by_lower_path = defaultdict(list)
+    for path in all_markdown_paths:
+        paths_by_lower_path[path.lower()].append(path)
+
+    for lower_path, original_paths in paths_by_lower_path.items():
+        #print(f"count={len(original_paths)} - {lower_path}")
+        if len(original_paths) == 1:
+            # No conflict.
+            continue
+
+        found_conflict = True
+        print("Conflict!")
+        for path in original_paths:
+            print(f"\t{path}")
+
+    if found_conflict:
+        exit(1)
+
+if __name__ == '__main__':
+    main()
+

--- a/.github/workflows/check_content.yml
+++ b/.github/workflows/check_content.yml
@@ -42,3 +42,8 @@ jobs:
         run: |
           cd .github/scripts
           ./run_markdownlint.sh
+
+      - name: Check that there are no files whose filename differs only by capitalization.
+        run: |
+          cd .github/scripts
+          python3 ./case_conflicts.py

--- a/.github/workflows/update_hub.yml
+++ b/.github/workflows/update_hub.yml
@@ -45,6 +45,7 @@ jobs:
         run: |
           cd .github/scripts
           python3 ./update_releases.py --all
+          python3 ./case_conflicts.py
           cd ../..
           git add .
           git commit -m "Add new plugins, themes and authors" || echo "nothing to commit"


### PR DESCRIPTION
This is confusing and can cause issues for folks running case insensitive filesystems (happens in windows sometimes).

If there is a conflict, the pages in question are output. And you get an non-zero exit status. E.g.

    Conflict!
            ../../README.md
            ../../Readme.md

Additionally adds this check to the update_hub and check_content github workflows.

Related to #308