### PR TITLE
Fix add_footers script.

### DIFF
--- a/.github/scripts/add_footer.py
+++ b/.github/scripts/add_footer.py
@@ -49,19 +49,18 @@ def add_footer(top_directory: str, debug: bool = True) -> None:
                 ensure_footer_in_file(absolute_path, relative_path)
 
 
-def ensure_footer_in_file(root_path: str, markdown_file_path: str) -> None:
-    relative_path = relpath(markdown_file_path, root_path)
+def ensure_footer_in_file(absolute_path: str, relative_path: str) -> None:
     footer_contents = render_footer(relative_path)
     footer_comment_regex = get_footer_comment_regex()
 
-    result = regex_replace_in_file(markdown_file_path, footer_comment_regex, footer_contents)
+    result = regex_replace_in_file(absolute_path, footer_comment_regex, footer_contents)
 
     log_fmt = "[%-10s] - \"%s\""
     if result is None:
-        append_to_file(markdown_file_path, footer_contents)
-        print(log_fmt % ('ADDED', markdown_file_path))
+        append_to_file(absolute_path, footer_contents)
+        print(log_fmt % ('ADDED', relative_path))
     elif result:
-        print(log_fmt % ('REPLACED', markdown_file_path))
+        print(log_fmt % ('REPLACED', relative_path))
     # else:
     #     # Unchanged.
     #     print(log_fmt % ('UNCHANGED', relative_path))

--- a/.github/scripts/tests/test_add_footer.py
+++ b/.github/scripts/tests/test_add_footer.py
@@ -83,13 +83,13 @@ def add_footer_to_markdown_test(input: str, relative_path:str) -> str:
     comment = add_footer.get_footer_comment_regex()
 
     with TemporaryDirectory() as tmproot:
-        path = f"{tmproot}/{relative_path}"
-        Path(dirname(path)).mkdir(parents=True, exist_ok=True)
-        utils.write_file(path, input)
+        absolute_path = f"{tmproot}/{relative_path}"
+        Path(dirname(absolute_path)).mkdir(parents=True, exist_ok=True)
+        utils.write_file(absolute_path, input)
 
-        add_footer.ensure_footer_in_file(tmproot, path)
+        add_footer.ensure_footer_in_file(absolute_path, relative_path)
 
-        return str(utils.read_file(path))
+        return str(utils.read_file(absolute_path))
 
 def verify_footer_addition(input: str, output: str) -> None:
 


### PR DESCRIPTION
While pairing with Clare we discovered a bug in the previous PR #572  when we tried to run it in the github actions.

The first line of ensure_footer_in_file was trying to calculate a relative path, based on an already relative path. which introduced the ../../github/scripts into the paths which we do not want in the templates.

This also alters the call to regex_replace_in_file to pass the absolute_path to the file, not the relative path, which fixes the read_file error.
