### PR TITLE
Create Obsidian Design System Community File.md

### DIFF
--- a/06 - Inbox/Obsidian Design System Community File.md
+++ b/06 - Inbox/Obsidian Design System Community File.md
@@ -1,0 +1,12 @@
+- [Obsidian Design System | Figma Community](https://www.figma.com/community/file/1172227539881210762)
+- [GitHub - jsmorabito/obsidian-design-system-community-file](https://github.com/jsmorabito/obsidian-design-system-community-file)
+
+# Overview
+This is a community built, component and styles library hosted on Figma for Obsidian. It is currently being maintained by [[Johnny ✨]].
+
+# Usage
+Click the "Get a copy" button on this page: [Obsidian Design System | Figma Community](https://www.figma.com/community/file/1172227539881210762) to download a draft of the latest version of the design system.
+
+# Contributing
+- Send draft Figma file with changes to johnny1093#1234 on Discord or e-mail to jmorabito10@gmail.com  
+- Post issues on [GitHub - jsmorabito/obsidian-design-system-community-file](https://github.com/jsmorabito/obsidian-design-system-community-file) with questions, ideas, requests, etc.


### PR DESCRIPTION
proposing to add a page which links to a community Figma file of a community built obsidian design system

## Edited
<!-- Add a brief description here -->

## Added
page which links to a community Figma file of a community built obsidian design system

## Checklist
- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
