### PR TITLE
Update for Theme Designers.md

### DIFF
--- a/04 - Guides, Workflows, & Courses/for Theme Designers.md
+++ b/04 - Guides, Workflows, & Courses/for Theme Designers.md
@@ -43,6 +43,7 @@ This note collects resources and guides for beginner and expert theme designers 
 - [**Iconify Icon Sets**](https://icon-sets.iconify.design/) Website to search and find icons from multiple icon sets
 - [**URL-encoder for SVG**](https://yoksel.github.io/url-encoder/) Encodes icon's svg code into useful `background-image` url
 - [obsidian-style-settings:](https://github.com/mgmeyers/obsidian-style-settings) allows snippet, theme, and plugin CSS files to define a set of configuration options. It then allows users to see all the tweakable settings in one settings pane.
+- [[Obsidian Design System Community File]] A community built, component and styles library for reference and use while designing for Obsidian
 - Ways to download all of Obsidian's theme source codes to learn from and search through:
   - [obsidian-repos-downloader](https://github.com/claremacrae/obsidian-repos-downloader) - Download every approved Obsidian.md community Plugin and Theme
 


### PR DESCRIPTION
proposing to add link to obsidian design system community file

## Edited
<!-- Add a brief description here -->

## Added
link and description for obsidian design system community file

## Checklist
- [ ] before creating a new note, I searched the vault
- [ ] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
