### PR TITLE
Fix 404 link in docs

### DIFF
--- a/04 - Guides, Workflows, & Courses/for Vim users.md
+++ b/04 - Guides, Workflows, & Courses/for Vim users.md
@@ -19,7 +19,7 @@ This site is for all information valuable to users familiar with vim, that want 
 
 ## Example vimrcs
 - [obsidian.vimrc and usage infos](https://bauer.codes/notes/Obsidian#Obsidian+vim+window+controls) by pmbauer
-- [obsidian.vimrc](https://github.com/chrisgrieser/dotfiles/blob/main/Obsidian%20vim/obsidian.vimrc) by [[chrisgrieser|pseudometa]]
+- [obsidian.vimrc](https://github.com/chrisgrieser/.config/blob/main/obsidian/obsidian.vimrc) by [[chrisgrieser|pseudometa]]
 
 %% Hub footer: Please don't edit anything below this line %%
 


### PR DESCRIPTION
## Edited
<!-- Add a brief description here -->

## Added
<!-- Add a brief description here-->

## Checklist
- [X] before creating a new note, I searched the vault
- [X] new notes have the `.md` extension
- [X] (if applicable) attached images have descriptive file names
- [X] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
