### PR TITLE
Prevent theme, plugin and author files being created that differ only in case of name

### DIFF
--- a/.github/scripts/tests/test_utils.py
+++ b/.github/scripts/tests/test_utils.py
@@ -1,9 +1,18 @@
 import os.path
 
 import utils
+from themes import Theme
 
 
 def test_get_root_of_vault() -> None:
     root = utils.get_root_of_vault()
     contributing = os.path.join(root, 'CONTRIBUTING.md')
     assert os.path.exists(contributing), contributing
+
+
+def test_get_output_path() -> None:
+    assert utils.get_output_path(Theme.template, 'CONTRIBUTING') == '../../02 - Community Expansions/02.05 All Community Expansions/Themes/CONTRIBUTING.md'
+
+
+def test_get_output_dir() -> None:
+    assert utils.get_output_dir(Theme.template) == '../../02 - Community Expansions/02.05 All Community Expansions/Themes'

--- a/.github/scripts/themes.py
+++ b/.github/scripts/themes.py
@@ -11,7 +11,7 @@ from obsidian_releases import get_community_plugins, THEMES_JSON_FILE
 from core_plugins import CORE_PLUGINS
 from utils import (
     THEME_CSS_FILE,
-    get_output_dir,
+    get_output_path,
     get_theme_css,
     FileGroups,
     add_file_group, get_template, get_json_from_github
@@ -245,7 +245,7 @@ class ThemeDownloadCount:
         Read the theme file from disk, and return the previously-saved download count
         :return: The saved theme download count, or None if this could not be obtained
         """
-        file_name = get_output_dir(template, current_name)
+        file_name = get_output_path(template, current_name)
         if not os.path.exists(file_name):
             # This is a new theme, so we don't yet have a previous download count:
             return None
@@ -261,7 +261,7 @@ class ThemeDownloadCount:
 
     @staticmethod
     def set_theme_download_count(template: Template, current_name: str, new_download_count: int, verbose: bool) -> None:
-        file_name = get_output_dir(template, current_name)
+        file_name = get_output_path(template, current_name)
 
         if not os.path.exists(file_name):
             if verbose:

--- a/.github/scripts/update_releases.py
+++ b/.github/scripts/update_releases.py
@@ -19,7 +19,7 @@ from utils import (
     print_progress_bar,
     write_template_file,
     add_file_group,
-    get_output_dir,
+    get_output_path,
 )
 from themes import ThemeList, Theme, ThemeDownloadCount, get_community_themes
 
@@ -91,7 +91,7 @@ def process_released_themes(overwrite: bool = False, verbose: bool = False) -> T
 
     theme_downloads = ThemeDownloadCount.get_theme_downloads()
 
-    themes_dir = os.path.dirname(get_output_dir(Theme.template, 'nonsense'))
+    themes_dir = os.path.dirname(get_output_path(Theme.template, 'nonsense'))
     collision_preventer = FileNameCaseCollisionsPreventer(themes_dir)
 
     for index, theme in enumerate(theme_list):
@@ -154,7 +154,7 @@ def update_uncategorized_plugins(valid_plugins: PluginList, overwrite: bool = Tr
     )
 
     # Alphabetize the plugin list
-    file_path = get_output_dir(template, UNCATEGORIZED)
+    file_path = get_output_path(template, UNCATEGORIZED)
     absolute_file_path = os.path.abspath(file_path)
     sort_links_under_heading(absolute_file_path)
 
@@ -165,7 +165,7 @@ def process_authors(themes: ThemeList,
                     verbose: bool = False) -> None:
     print("-----\nProcessing authors....\n")
     template = get_template("author")
-    authors_dir = os.path.dirname(get_output_dir(template, 'nonsense'))
+    authors_dir = os.path.dirname(get_output_path(template, 'nonsense'))
     collision_preventer = FileNameCaseCollisionsPreventer(authors_dir)
     all_authors = collate_authors(themes, plugins)
 

--- a/.github/scripts/update_releases.py
+++ b/.github/scripts/update_releases.py
@@ -165,13 +165,15 @@ def process_authors(themes: ThemeList,
                     verbose: bool = False) -> None:
     print("-----\nProcessing authors....\n")
     template = get_template("author")
+    authors_dir = os.path.dirname(get_output_dir(template, 'nonsense'))
+    collision_preventer = FileNameCaseCollisionsPreventer(authors_dir)
     all_authors = collate_authors(themes, plugins)
 
     print("\nCreating author notes....\n")
     file_groups: FileGroups = dict()
     for user, author_info in all_authors.items():
         group = write_template_file(
-            template, user, overwrite=overwrite, verbose=verbose, **author_info
+            template, collision_preventer.get_name(user), overwrite=overwrite, verbose=verbose, **author_info
         )
         add_file_group(file_groups, group, user)
 

--- a/.github/scripts/update_releases.py
+++ b/.github/scripts/update_releases.py
@@ -20,6 +20,7 @@ from utils import (
     write_template_file,
     add_file_group,
     get_output_path,
+    get_output_dir,
 )
 from themes import ThemeList, Theme, ThemeDownloadCount, get_community_themes
 
@@ -91,7 +92,7 @@ def process_released_themes(overwrite: bool = False, verbose: bool = False) -> T
 
     theme_downloads = ThemeDownloadCount.get_theme_downloads()
 
-    themes_dir = os.path.dirname(get_output_path(Theme.template, 'nonsense'))
+    themes_dir = get_output_dir(Theme.template)
     collision_preventer = FileNameCaseCollisionsPreventer(themes_dir)
 
     for index, theme in enumerate(theme_list):
@@ -165,7 +166,7 @@ def process_authors(themes: ThemeList,
                     verbose: bool = False) -> None:
     print("-----\nProcessing authors....\n")
     template = get_template("author")
-    authors_dir = os.path.dirname(get_output_path(template, 'nonsense'))
+    authors_dir = get_output_dir(template)
     collision_preventer = FileNameCaseCollisionsPreventer(authors_dir)
     all_authors = collate_authors(themes, plugins)
 

--- a/.github/scripts/update_releases.py
+++ b/.github/scripts/update_releases.py
@@ -28,6 +28,8 @@ from themes import ThemeList, Theme, ThemeDownloadCount, get_community_themes
 def process_released_plugins(overwrite: bool = False, verbose: bool = False) -> PluginList:
     print("-----\nProcessing plugins....\n")
     template = get_template("plugin")
+    plugins_dir = get_output_dir(template)
+    collision_preventer = FileNameCaseCollisionsPreventer(plugins_dir)
     plugin_list: PluginList = get_community_plugins()
 
     valid_plugins: PluginList = list()
@@ -43,7 +45,7 @@ def process_released_plugins(overwrite: bool = False, verbose: bool = False) -> 
             continue
 
         group = write_template_file(
-            template, plugin.id(), overwrite=overwrite, verbose=verbose, **plugin.data()
+            template, collision_preventer.get_name(plugin.id()), overwrite=overwrite, verbose=verbose, **plugin.data()
         )
         valid_plugins.append(plugin)
 

--- a/.github/scripts/update_releases.py
+++ b/.github/scripts/update_releases.py
@@ -2,7 +2,6 @@
 import os
 import sys
 import argparse
-from pathlib import Path
 from typing import Sequence
 
 from authors import AllAuthors
@@ -21,6 +20,7 @@ from utils import (
     add_file_group,
     get_output_path,
     get_output_dir,
+    FileNameCaseCollisionsPreventer,
 )
 from themes import ThemeList, Theme, ThemeDownloadCount, get_community_themes
 
@@ -57,29 +57,6 @@ def process_released_plugins(overwrite: bool = False, verbose: bool = False) -> 
     print_file_summary(file_groups)
 
     return valid_plugins
-
-
-class FileNameCaseCollisionsPreventer:
-    def __init__(self, directory: str) -> None:
-        self.file_case_lookup = dict()
-        for filename in os.listdir(directory):
-            base_name = Path(filename).stem
-            self.file_case_lookup[base_name.lower()] = base_name
-
-    def get_name(self, current_name: str) -> str:
-        """
-        Prefer the existing capitalisation of any existing filename,
-        to prevent case-conflicts.
-
-        :param current_name: 
-        :return: 
-        """
-        if current_name.lower() in self.file_case_lookup:
-            existing_case = self.file_case_lookup[current_name.lower()]
-            if existing_case != current_name:
-                print(f'Overriding filename {current_name} to {existing_case}')
-                current_name = existing_case
-        return current_name
 
 
 def process_released_themes(overwrite: bool = False, verbose: bool = False) -> ThemeList:

--- a/.github/scripts/utils.py
+++ b/.github/scripts/utils.py
@@ -2,6 +2,7 @@ import os
 import json
 import glob
 import typing
+from pathlib import Path
 from re import sub, search
 from typing import Dict, List, Union, Any
 
@@ -302,3 +303,24 @@ def write_file(absolute_path: str, replacement: str) -> None:
         f.write(replacement)
 
 
+class FileNameCaseCollisionsPreventer:
+    def __init__(self, directory: str) -> None:
+        self.file_case_lookup = dict()
+        for filename in os.listdir(directory):
+            base_name = Path(filename).stem
+            self.file_case_lookup[base_name.lower()] = base_name
+
+    def get_name(self, current_name: str) -> str:
+        """
+        Prefer the existing capitalisation of any existing filename,
+        to prevent case-conflicts.
+
+        :param current_name: 
+        :return: 
+        """
+        if current_name.lower() in self.file_case_lookup:
+            existing_case = self.file_case_lookup[current_name.lower()]
+            if existing_case != current_name:
+                print(f'Overriding filename {current_name} to {existing_case}')
+                current_name = existing_case
+        return current_name

--- a/.github/scripts/utils.py
+++ b/.github/scripts/utils.py
@@ -63,7 +63,7 @@ def get_template_from_directory(directory: str, template_name_with_extensions: s
     return env.get_template(template_name_with_extensions)
 
 
-def get_output_dir(template: Template, file_name: str) -> str:
+def get_output_path(template: Template, file_name: str) -> str:
     template_name, _, _ = template.name.split(".")
     return os.path.join(
         "../..",
@@ -77,7 +77,7 @@ def write_template_file(template: Template,
                         overwrite: bool = False,
                         verbose: bool = False,
                         **kwargs: Any) -> str:
-    file_path = get_output_dir(template, file_name)
+    file_path = get_output_path(template, file_name)
     absolute_file_path = os.path.abspath(file_path)
 
     file_content = render_template_for_file(template, absolute_file_path, **kwargs)

--- a/.github/scripts/utils.py
+++ b/.github/scripts/utils.py
@@ -72,6 +72,10 @@ def get_output_path(template: Template, file_name: str) -> str:
     )
 
 
+def get_output_dir(template: Template) -> str:
+    return os.path.dirname(get_output_path(template, 'nonsense'))
+
+
 def write_template_file(template: Template,
                         file_name: str,
                         overwrite: bool = False,

--- a/.github/scripts/utils.py
+++ b/.github/scripts/utils.py
@@ -64,16 +64,18 @@ def get_template_from_directory(directory: str, template_name_with_extensions: s
 
 
 def get_output_path(template: Template, file_name: str) -> str:
-    template_name, _, _ = template.name.split(".")
     return os.path.join(
-        "../..",
-        OUTPUT_DIR.get(template_name, "08 - Seedbox"),
+        get_output_dir(template),
         "{}.md".format(file_name),
     )
 
 
 def get_output_dir(template: Template) -> str:
-    return os.path.dirname(get_output_path(template, 'nonsense'))
+    template_name, _, _ = template.name.split(".")
+    return os.path.join(
+        "../..",
+        OUTPUT_DIR.get(template_name, "08 - Seedbox"),
+    )
 
 
 def write_template_file(template: Template,


### PR DESCRIPTION
## Changes


- Introduce class `FileNameCaseCollisionsPreventer` in `utils.py` that:
    - builds a list of files in the given directory,
    - and can be used to normalise the names of any output files in that directory
- Updated `.github/scripts/tests/test_utils.py` to use the above, when writing notes for:
    - themes
    - plugins
    - authors
- Also in `utils.py`:
    - Rename `get_output_dir()` to `get_output_path()`
    - Added new `get_output_dir()` that really does return a directory
    - Added tests for the above

This work was done by pairing with @andynu - who was involved in all commits except the last one, where I moved `FileNameCaseCollisionsPreventer ` to `utils.py`.

## Context:

- #308 
- #598
- #607 

## Checklist

Not applicable...


