### PR TITLE
Fix typo in vault.md

### DIFF
--- a/03 - Showcases & Templates/Vaults/🗂️ Vaults.md
+++ b/03 - Showcases & Templates/Vaults/🗂️ Vaults.md
@@ -50,7 +50,7 @@ After that, the interesting bit comes from the *why* you organized things the wa
 
 ### Starter vaults or kits
 
-Unfortunately, we can't host starter vaults or kits in the community vault itself, or it would be caos! We recommend hosting your vault externally (GitHub is recommended) and providing a link as described in [[#Contribution steps]].
+Unfortunately, we can't host starter vaults or kits in the community vault itself, or it would be chaos! We recommend hosting your vault externally (GitHub is recommended) and providing a link as described in [[#Contribution steps]].
 
 ### Contribution steps
 


### PR DESCRIPTION
## Edited
Update caos typo to chaos

## Added
N/A

## Checklist
- [ ] before creating a new note, I searched the vault
- [ ] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
