### PR TITLE
added markdown-to-jira plugin to categories

### DIFF
--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins to convert content into markdown.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins to convert content into markdown.md
@@ -23,6 +23,7 @@ Plugins to convert to [[Markdown]].
 - [[pdf-to-markdown-plugin|PDF to Markdown]]: Save a PDF's text (headings, paragraphs, lists, etc.) to a Markdown file.
 - [[obsidian-pluck|Pluck]]: Quickly create notes in Obsidian from web pages.
 - [[wikilinks-to-mdlinks-obsidian|Wikilinks to MDLinks (Markdown Links)]]: A plugin that converts wikilinks to markdown links and vice versa
+- [[obsidian-md-to-jira|Markdown to Jira Converter]]: This is a markdown to jira markup and backwards converter plugin for Obsidian (https://obsidian.md)
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins to export markdown content.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins to export markdown content.md
@@ -18,6 +18,7 @@ Plugins to convert from [[Markdown]].
 - [[mochi-cards-exporter|Mochi Cards Exporter]]: Export Markdown notes to Mochi cards from within obsidian
 - [[obsidian-pandoc|Obsidian Pandoc]]: This is a Pandoc export plugin for Obsidian. It provides commands to export to formats like DOCX, ePub and PDF.
 - [[obsidian-static-file-server|Static File Server]]: Host obsidian subfolders as static file servers.
+- [[obsidian-md-to-jira|Markdown to Jira Converter]]: This is a markdown to jira markup and backwards converter plugin for Obsidian (https://obsidian.md)
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Uncategorized plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Uncategorized plugins.md
@@ -319,7 +319,6 @@ Plugins which have not yet been categorized by the community.
 - [[markdoc|Markdoc]]: Basic support for Markdoc files
 - [[markdown-table-editor|Markdown Table Editor]]: An Obsidian plugin to provide an editor for Markdown tables. It can open CSV, Microsoft Excel/Google Sheets data as Markdown tables from Obsidian Markdown editor.
 - [[markdown-shortcuts|Markdown shortcuts]]: Allows to write markdown from shortcuts (example: >h1 -> #).
-- [[obsidian-md-to-jira|Markdown to Jira Converter]]: This is a markdown to jira markup and backwards converter plugin for Obsidian (https://obsidian.md)
 - [[marp|Marp]]: Plugin for using Marp on Obsidian.
 - [[marp-slides|Marp Slides]]: Create markdown-based Marp presentations in Obsidian
 - [[material-symbols|Material Symbols]]: This plugin adds the material symbols (outlined) to obsidian


### PR DESCRIPTION
## Edited
- removed markdown-to-jira from uncategorized page

## Added
- added markdown-to-jira to related categorized pages (without creating a new page)

## Checklist
- [x] before creating a new note, I searched the vault
- [ ] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
