### PR TITLE
Update "How to add your plugin to the community plugin list"

### DIFF
--- a/04 - Guides, Workflows, & Courses/Guides/How to add your plugin to the community plugin list.md
+++ b/04 - Guides, Workflows, & Courses/Guides/How to add your plugin to the community plugin list.md
@@ -23,7 +23,7 @@ This note is based on the instructions of the [obsidian sample plugin readme](ht
 2.  Add the information of your plugin at the end of the list (Don't forget to add a comma after the last plugin!). For your convenience you can copy this template and paste it at the end of the list:
 ```json
   {
-	  "id": "",
+    "id": "",
     "name": "",
     "author": "",
     "description": "",

--- a/04 - Guides, Workflows, & Courses/Guides/How to add your plugin to the community plugin list.md
+++ b/04 - Guides, Workflows, & Courses/Guides/How to add your plugin to the community plugin list.md
@@ -21,23 +21,21 @@ This note is based on the instructions of the [obsidian sample plugin readme](ht
 
 1.  Fork the [obsidian-releases](https://github.com/obsidianmd/obsidian-releases#community-plugins) repo and edit the `community-plugins.json` file. If you prefer to do it from GitHub's web interface, you can follow this instructions, but submit your changes as described in [[How to add content through GitHub]] or [[How to add your plugin to the community plugin list#Submitting your plugin]]. 
 2.  Add the information of your plugin at the end of the list (Don't forget to add a comma after the last plugin!). For your convenience you can copy this template and paste it at the end of the list:
-	```json
-    {
-		"id": ""
-        "name": "",
-        "author": "",
-		"description": ""
-        "repo": "<github username>/<repository>",
-		"branch": "master"
-    }
-	```
+```json
+  {
+	  "id": "",
+    "name": "",
+    "author": "",
+    "description": "",
+    "repo": "<github username>/<repository>"
+  }
+```
 3. Fill out the information of your plugin. Below you can find the description of each field (taken from the [obsidian-releases](https://github.com/obsidianmd/obsidian-releases#community-plugins) repo):
 	-   `id`: A unique ID for your plugin. Make sure this is the same one you have in your `manifest.json`.
 	-   `name`: The name of your plugin. This will be used to search for your plugin.
 	-   `author`: The author's name.
 	-   `description`: A short description of what your plugin does.
 	-   `repo`: The GitHub repository identifier, in the form of `user-name/repo-name`, if your GitHub repo is located at `https://github.com/user-name/repo-name`.
-	-   `branch`: (optional) A branch if you prefer to use a specific branch of your repo. Defaults to `master`.
 4.  Make a pull request at [https://github.com/obsidianmd/obsidian-releases](https://github.com/obsidianmd/obsidian-releases) to add your plugin.
 5. Once you've opened the PR, you'll be prompted to use the pull request template. Complete everything in it and submit.
 	![[plugin-submission-PR-template.png]]


### PR DESCRIPTION
## Edited

Removed the defunct key `branch` from the instructions for adding your plugin to the directory. See [this PR](https://github.com/obsidianmd/obsidian-releases/pull/2280) naming the field as invalid. Remaining instructions revalidated!

## Checklist
- [ ] ~~before creating a new note, I searched the vault~~
- [ ] ~~new notes have the `.md` extension~~
- [ ] ~~(if applicable) attached images have descriptive file names~~
- [ ] ~~(if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses~~
