### PR TITLE
Categorize plugins by JoLeaf

### DIFF
--- a/01 - Community/People/joleaf.md
+++ b/01 - Community/People/joleaf.md
@@ -21,6 +21,9 @@ publish: true
 %% Begin Hub: Released contributions %%
 ### Plugins
 - [[bpmn-plugin|BPMN Plugin]]
+- [[email-block-plugin|Email code block]]
+- [[dmn-plugin|DMN Plugin]]
+- [[dmn-eval|DMN Eval]]
 
 %% End Hub: Released contributions %%
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins for Diagrams.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins for Diagrams.md
@@ -15,12 +15,15 @@ Plugins to create diagrams other than [[Mermaid]] (which is [already natively su
 
 %% Add a bullet here and link to the plugins you'd like to categorize! %%
 
+- [[bpmn-plugin|BPMN Plugin]]: Render/Edit BPMNs 
 - [[drawio-obsidian|Diagrams]]: Draw.io diagrams for Obsidian. This plugin introduces diagrams that can be included within notes or as stand-alone files. Diagrams are created as SVG files (although .drawio extensions are also supported).
+- [[dmn-plugin|DMN Plugin]]:  Render DMN diagrams
 - [[obsidian-excalidraw-plugin|Excalidraw]]: An Obsidian plugin to edit and view Excalidraw drawings
 - [[obsidian-kroki|Kroki]]: Render Kroki Diagrams
 - [[obsidian-nomnoml-diagram|Nomnoml Diagram]]: Draw nomnoml diagrams in Obsidian notes
 - [[obsidian-graphviz|Obsidian Graphviz]]: Render Graphviz Diagrams
 - [[obsidian-plantuml|PlantUML]]: Render PlantUML Diagrams
+
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins to edit other file types.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins to edit other file types.md
@@ -13,7 +13,9 @@ Plugins enabling Obsidian to edit files other than markdown `.md`.
 
 ## Plugins in this category
 
+- [[bpmn-plugin|BPMN Plugin]]: Edit *.bpmn* files in Obsidian
 - [[csv-obsidian|CSV Editor]]: Edit CSV files in Obsidian
+- [[dmn-plugin|DMN Plugin]]: Edit *.dmn* files in Obsidian
 - [[obsidian-excalidraw-plugin|Excalidraw]]: An Obsidian plugin to edit and view Excalidraw drawings
 - [[obsidian-fountain|Fountain]]: Fountain Support for Obsidian
 - [[obsidian-org-mode|Org Mode]]: Add Org Mode support to Obsidian.

--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins with custom codeblock syntax.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins with custom codeblock syntax.md
@@ -15,8 +15,12 @@ Plugins that add specific renderers to Obsidian.
 
 - [[obsidian-5e-statblocks|5e Statblocks]]: Create 5e styled statblocks in Obsidian.md
 - [[obsidian-admonition|Admonition]]: Admonition block-styled content for Obsidian.md
+- [[bpmn-plugin|BPMN Plugin]]: Render BPMN diagrams
 - [[dataview|Dataview]]: Complex data views for the data-obsessed.
 - [[drawio-obsidian|Diagrams]]: Draw.io diagrams for Obsidian. This plugin introduces diagrams that can be included within notes or as stand-alone files. Diagrams are created as SVG files (although .drawio extensions are also supported).
+- [[dmn-eval|DMN Eval]]: Evaluate/Execute DMNs
+- [[dmn-plugin|DMN Plugin]]:  Render DMN diagrams
+- [[email-block-plugin|Email code block]]: Render an email block
 - [[initiative-tracker|Initiative Tracker]]: TTRPG Initiative Tracker for Obsidian.md
 - [[obsidian-kroki|Kroki]]: Render Kroki Diagrams
 - [[obsidian-markdown-furigana|Markdown Furigana]]: Simple Markdown to Furigana Rendering Plugin for Obsidian.
@@ -27,6 +31,7 @@ Plugins that add specific renderers to Obsidian.
 - [[scales-chords|Scales and Chords]]: Use this plugin to capture musical tab notation in your Obsidian vault.  Chords will become clickable links to modal images (provided by scales-chords.com)
 - [[obsidian-wavedrom|Wavedrom]]: This is very rough and quick integration of WaveDrom into obsidian
 - [[obsidian-query2table|query2table]]: Represent files returned by a query as a table of their YAML frontmatter
+
 
 ## Related categories
 

--- a/02 - Community Expansions/02.01 Plugins by Category/Uncategorized plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Uncategorized plugins.md
@@ -82,7 +82,6 @@ Plugins which have not yet been categorized by the community.
 - [[awesome-reader|Awesome Reader]]: Make Obsidian a proper Reader.
 - [[obsidian-bbcode|BBCode Convertor]]: Convert Markdown files to BBCode
 - [[bmo-chatbot|BMO Chatbot]]: Generate and brainstorm ideas while creating your notes using Large Language Models (LLMs) such as OpenAI's "gpt-3.5-turbo" and "gpt-4."
-- [[bpmn-plugin|BPMN Plugin]]: This plugin enables viewing/editing BPMN diagrams using bpmn-js.
 - [[babashka|Babashka]]: Evaluate Clojure(Script) codeblocks in Babashka.
 - [[background-image|Background Image]]: This allows you to specify a remote URL as the background image, and a few settings to tweak the experience.
 - [[badges|Badges]]: Add inline badges/callouts to notes.
@@ -187,8 +186,6 @@ Plugins which have not yet been categorized by the community.
 - [[cycle-in-sidebar|Cycle In Sidebar]]: This a plugin provides hotkeys to cycle through tabs in the left or right sidebars.
 - [[d2-obsidian|D2]]: The official D2 plugin for Obsidian. D2 is a modern diagram scripting language that turns text to diagrams.
 - [[dbfolder|DB Folder]]: Folder with the capability to store and retrieve data from a folder like database
-- [[dmn-eval|DMN Eval]]: This plugin enables evaluating/executing DMN
-- [[dmn-plugin|DMN Plugin]]: This plugin enables viewing DMNs using dmn-js.
 - [[obsidian-daily-note-outline|Daily Note Outline]]: Add a custom view which shows outline of multiple daily notes with headings, links, tags and list items
 - [[daily-notes-editor|Daily Notes Editor]]: A plugin for you to edit a bunch of daily notes in one page(inline), which works similar to Roam Research's default daily note view.
 - [[obsidian-daily-notes-viewer|Daily Notes Viewer]]: Help you to view some recent daily notes on one page.
@@ -228,7 +225,6 @@ Plugins which have not yet been categorized by the community.
 - [[cm-editor-syntax-highlight-obsidian|Editor Syntax Highlight]]: Show syntax highlighing in code blocks the editor
 - [[editor-width-slider|Editor Width Slider]]: Customize Obsidian's editor width with a slider for a tailored editing experience.
 - [[emacs-text-editor|Emacs text editor]]: Partial emulation of Emacs text editor for Obisidian
-- [[email-block-plugin|Email code block]]: This plugin renders an email code block.
 - [[embed-code-file|Embed Code File]]: This is a plugin for Obsidian that allows for embedding code files.
 - [[emo-uploader|Emo]]: Embed markdown online file/image links. This plugin is for uploading images to hosting or files to github in Obsidian.
 - [[emoji-tags-titler|EmoTagsTitler]]: Add the emojis contained in the tags to the beginning of the note title.


### PR DESCRIPTION
## Edited
Categorize plugins by JoLeaf
- Removed links inside the file:
  - 02 - Community Expansions/02.01 Plugins by Category/Uncategorized plugins.md

## Added
- Added links inside the  files
  - 01 - Community/People/joleaf.md 
  - 02 - Community Expansions/02.01 Plugins by Category/Plugins for Diagrams.md
  - 02 - Community Expansions/02.01 Plugins by Category/Plugins to edit other file types.md
  - 02 - Community Expansions/02.01 Plugins by Category/Plugins to edit other file types.md

## Checklist
- [-] ~~before creating a new note, I searched the vault~~ / **No new notes**
- [-] ~~new notes have the `.md` extension~~ / **No new notes**
- [-] ~~(if applicable) attached images have descriptive file names~~
- [-] ~~(if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses~~
