### PR TITLE
update obsidian.vimrc link by chrisgrieser to use permalink

### DIFF
--- a/04 - Guides, Workflows, & Courses/for Vim users.md
+++ b/04 - Guides, Workflows, & Courses/for Vim users.md
@@ -19,7 +19,7 @@ This site is for all information valuable to users familiar with vim, that want 
 
 ## Example vimrcs
 - [obsidian.vimrc and usage infos](https://bauer.codes/notes/Obsidian#Obsidian+vim+window+controls) by pmbauer
-- [obsidian.vimrc](https://github.com/chrisgrieser/.config/blob/main/obsidian/obsidian.vimrc) by [[chrisgrieser|pseudometa]]
+- [obsidian.vimrc](https://github.com/chrisgrieser/.config/blob/41a9e915ec0b299084cf58f4265fb2f3a39e4643/obsidian/obsidian-vimrc.vim) by [[chrisgrieser|pseudometa]]
 
 %% Hub footer: Please don't edit anything below this line %%
 


### PR DESCRIPTION
## Edited
<!-- Add a brief description here -->
update 04 - Guides, Workflows, & Courses/for Vim users.md - link to obsidian.vimrc link by chrisgrieser|pseudometa to use permalink address to last commit (as of November 2, 2023)

the [old address results in 404](https://github.com/chrisgrieser/.config/blob/main/obsidian/obsidian.vimrc), commit chrisgrieser/.config@41a9e915ec0b299084cf58f4265fb2f3a39e4643 is from November 1, 2023
## Added
<!-- Add a brief description here-->

## Checklist
- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
- [x] (if applicable) attached images have descriptive file names
- [x] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
