### PR TITLE
Add Tag Page plugin for tag-specific pages

### DIFF
--- a/02 - Community Expansions/02.01 Plugins by Category/Tag management plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Tag management plugins.md
@@ -20,6 +20,7 @@ Plugins to manage tags.
 - [[tag-page-preview|Tag Page Preview]]: Clicking a tag opens a dialog listing pages that use that tag
 - [[tag-wrangler|Tag Wrangler]]: Rename, merge, toggle, and search tags from the tag pane
 - [[obsidian-tagfolder|TagFolder]]: Show tags as folder
+- [[tag-page-md|Tag Page]]: Dynamically generate and update tag-specific pages, offering a consolidated view of each tag's references across your vault.
 
 ## Related categories
 


### PR DESCRIPTION
## Edited
<!-- Add a brief description here -->
N/A

## Added
<!-- Add a brief description here-->
A link to the 'Tag Page" plugin on the "Tag management plugins" page

## Checklist
- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
- [x] (if applicable) attached images have descriptive file names
- [x] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
