### PR TITLE
Create Drafting (Android).md

### DIFF
--- a/02 - Community Expansions/02.05 All Community Expansions/Auxiliary Tools/Drafting (Android).md
+++ b/02 - Community Expansions/02.05 All Community Expansions/Auxiliary Tools/Drafting (Android).md
@@ -1,0 +1,10 @@
+# Drafting
+Official website: https://play.google.com/store/apps/details?id=sen.drafting
+Documentation: -
+Cost: $4
+Available for: [[Android Apps|Android]]
+
+Drafting is a super fast and lightweight plain text editor for Android.
+
+It is a writing tool designed & developed to coexist with your favorite note-taking app, including Obsidian.
+

--- a/02 - Community Expansions/02.05 All Community Expansions/Auxiliary Tools/Drafting (Android).md
+++ b/02 - Community Expansions/02.05 All Community Expansions/Auxiliary Tools/Drafting (Android).md
@@ -1,4 +1,13 @@
+---
+aliases:
+  -
+tags:
+  - seedling
+publish: true
+---
+
 # Drafting
+
 Official website: https://play.google.com/store/apps/details?id=sen.drafting
 Documentation: -
 Cost: $4
@@ -7,4 +16,3 @@ Available for: [[Android Apps|Android]]
 Drafting is a super fast and lightweight plain text editor for Android.
 
 It is a writing tool designed & developed to coexist with your favorite note-taking app, including Obsidian.
-


### PR DESCRIPTION
Adding Drafting to Auxiliary Tools, a plain text editor for Android that coexists with Obsidian.

## Edited
<!-- Add a brief description here -->

## Added
<!-- Add a brief description here-->

## Checklist
- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
