### PR TITLE
Added a warning at the end of the Project Cards note about incompatibility between the github view files and the guide

### DIFF
--- a/03 - Showcases & Templates/Templates/Plugin-specific templates/Dataview templates/Project Cards.md
+++ b/03 - Showcases & Templates/Templates/Plugin-specific templates/Dataview templates/Project Cards.md
@@ -330,7 +330,7 @@ return html;
 
 ---
 
-For more templates and examples, check out the original demo on [GitHub](https://github.com/kaelri/obsidian-dataview-test-vault).
+For more templates and examples, check out the original demo on [GitHub](https://github.com/kaelri/obsidian-dataview-test-vault). However, note that the Project Card view files hosted on GitHub are not fully compatible with this guide.
 
 %% Hub footer: Please don't edit anything below this line %%
 

--- a/03 - Showcases & Templates/Templates/Plugin-specific templates/Dataview templates/Project Cards.md
+++ b/03 - Showcases & Templates/Templates/Plugin-specific templates/Dataview templates/Project Cards.md
@@ -330,7 +330,7 @@ return html;
 
 ---
 
-For more templates and examples, check out the original demo on [GitHub](https://github.com/kaelri/obsidian-dataview-test-vault). However, note that the Project Card view files hosted on GitHub are not fully compatible with this guide.
+For more templates and examples, check out the original demo on [GitHub](https://github.com/kaelri/obsidian-dataview-test-vault). However, note that the Project Cards view files hosted on GitHub are not fully compatible with this guide.
 
 %% Hub footer: Please don't edit anything below this line %%
 


### PR DESCRIPTION
## Edited
- I added a warning at the end of the Project Cards note about incompatibility between the github view files and the guide.

## Checklist
- [ ] before creating a new note, I searched the vault
- [ ] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
