### PR TITLE
Add link to test-plugin suggestions

### DIFF
--- a/04 - Guides, Workflows, & Courses/Guides/How to test plugin code that uses Obsidian APIs.md
+++ b/04 - Guides, Workflows, & Courses/Guides/How to test plugin code that uses Obsidian APIs.md
@@ -26,11 +26,13 @@ This technique is demonstrated in the talk [[Plugin Testing for Developers]].
 
 There are some useful discussions and links in the Obsidian API issue [Error running tests #13](https://github.com/obsidianmd/obsidian-api/issues/13).
 
+- Test frameworks that have attempted to help with testing Obsidian plugins:
+    - [trashhalo/obsidian-plugin-e2e-test](https://github.com/trashhalo/obsidian-plugin-e2e-test): a sample repo with obsidian plugin e2e tests [suggested by](https://github.com/obsidianmd/obsidian-api/issues/13#issuecomment-880504457) `@lishid`
+    - [[obsimian-exporter]]: an Obsidian simulation framework for testing Obsidian plugins [suggested by](https://github.com/obsidianmd/obsidian-api/issues/13#issuecomment-880504457) `@lishid`
+    - [obsidian-community/jest-environment-obsidian](https://github.com/obsidian-community/jest-environment-obsidian) A Jest environment to facilitate unit testing for Obsidian plugins
+    - These are many months old, and may not be being maintained
+
 - In [this comment](https://github.com/obsidianmd/obsidian-api/issues/13#issuecomment-819035670) [[renehernandez]] describes abstracting the usage of the filesystem capabilities from obsidian through an internal interface and depending on that interface instead of FileSystemAdapter directly. That way they can introduce a fake object during test to verify the logic they wanted in the FileDoc object.
-- In [this comment](https://github.com/obsidianmd/obsidian-api/issues/13#issuecomment-880504457) `@lishid` lists some test frameworks that have attempted to help with testing Obsidian plugins:
-    - [trashhalo/obsidian-plugin-e2e-test](https://github.com/trashhalo/obsidian-plugin-e2e-test): a sample repo with obsidian plugin e2e tests
-    - [[obsimian-exporter#Obsimian Exporter]]: an Obsidian simulation framework for testing Obsidian plugins
-    - These are both many months old, and may not be being maintained
 - In [this comment](https://github.com/obsidianmd/obsidian-api/issues/13#issuecomment-1003880942) [[timhor]] reported that If anyone just needs to test editor-related functionality, he has had success substituting [CodeMirror](https://codemirror.net/doc/manual.html) as the editor on which his tests run (that's what Obsidian uses under the hood anyway). There are links showing how he did this.
 
 %% Hub footer: Please don't edit anything below this line %%


### PR DESCRIPTION
## Edited

## Added
Add 1 repo to list of test plugins that support API testing

## Checklist
- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
- [x] (if applicable) attached images have descriptive file names
- [x] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
