### PR TITLE
add kemonine's digital art comp book vault page to repo

### DIFF
--- a/03 - Showcases & Templates/Vaults/Digital Art Composition Book.md
+++ b/03 - Showcases & Templates/Vaults/Digital Art Composition Book.md
@@ -1,0 +1,62 @@
+---
+aliases: 
+- 
+tags:
+- seedling
+publish: true
+---
+
+# Digital Art Composition Book
+
+%% Add a description below this comment. It doesn't need to be long: one or two sentences should be a good start. 
+
+Longer descriptions are also welcome! A few things you could cover are: 
+- Who is this useful for?
+- Where to start?
+- What each folder is for?
+- How to use tags?
+- Are any plugins needed? - Add links to them from 02.01
+	- Are they included in the kit/starter vault?
+- Any custom CSS? 
+	- Add links to 04 - Community themes or 05 - CSS Snippets or any other 10 - Resources
+- Any ancilliary tools?
+%%
+
+The `Digital Art Composition Book` vault is designed to facilitate keeping a digital composition book of art. Basically the digital equivalent to a paper art comp book that some artists are never without.
+
+Digital art tends to have more constraints than traditional art and this vault is designed to help wrangle your digital art into a form that's similar in feel to a more traditional, paper art comp book.
+
+## Who is this for?
+
+The `Digital Art Composition Book` is meant for anyone who practices a form of digital art and wants to create and manage a comp book in a digital form. Professionals, hobbyists, folk filling in coloring pages and others are all welcome.
+
+The vault is designed to be adaptable and work for any artist of any skill level working on any form of art.
+
+## Using the Vault
+
+The vault is setup as a series of folders for organizing different types of digital art and uses gallery notes to help with navigating the art stored within the vault. The main folders are 'types' of art and sub-directories are used to help organize art based on progress.
+
+The vault also contains a `Notes` section that includes some useful information and can be added to over time as well as an `Ideas - Inspiration` folder that can be used to track ideas and inspiration that you may want to use in the future.
+
+For additional detail: the vault contains a `__Using The Vault` note in the `Notes` folder that gives a full breakdown on how to use the vault and how it is organized. The main download URL below also contains a link to this file so you can view it on the web prior to downloading the vault.
+
+## Download 
+
+%% Add the link where people can download this vault or kit %%
+
+Link: https://github.com/mcrosson/digital-art-composition-book
+
+To download this vault, you first need to complete the following steps
+1. Click on the "Code" button on the right
+2. Click on "Download ZIP"
+3. Extract the zip file
+4. Open the extracted directory as an Obsidian vault
+
+A screen shot of the above steps is also shown at the link above.
+
+%% If there are any steps one needs to complete to download the starter vault or kit list them here in an ordered list (e.g. uncomment the next comment)
+%%
+%% To download this vault, you first need to complete the following steps
+1. Step 1
+2. Step 2
+%%


### PR DESCRIPTION
## Edited
Added an additional vault for the `Showcases & Templates` area of the hub

## Added
Information and a link to the `Digital Art Comp Book` template vault I've created

## Checklist
- [X] before creating a new note, I searched the vault
- [X] new notes have the `.md` extension
- [X] (if applicable) attached images have descriptive file names
- [X] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
