### PR TITLE
Add a link to InfraNodus graph view plugin

### DIFF
--- a/02 - Community Expansions/02.01 Plugins by Category/Graph plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Graph plugins.md
@@ -18,6 +18,7 @@ publish: true
 - [[adjacency-matrix-maker|Adjacency Matrix Maker]]: Create an interactive image of an adjacency matrix of your vault
 - [[breadcrumbs|Breadcrumbs]]: Visualise & navigate your vault's structure
 - [[graph-analysis|Graph Analysis]]: Analyse your Obsidian graph.
+- [[infranodus-graph-view|InfraNodus AI Graph View]]: Visualize the main topics and gaps in your ideas using advanced text network graph algorithm.
 - [[juggl|Juggl]]: Adds a completely interactive, stylable and expandable graph view to Obsidian.
 - [[obsidian-living-graph|Living Graph]]: A for-fun graph plugin
 - [[neo4j-graph-view|Neo4j Graph View]]: An Obsidian plugin for advanced graph visualization and querying using Neo4j.


### PR DESCRIPTION
## Edited
The Graph plugins page

## Added
A link to the InfraNodus graph view plugin

## Checklist
- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension (didn't add new notes!)
- [x] (if applicable) attached images have descriptive file names
- [x] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
