### PR TITLE
docs: updated for Religious Uses docs

### DIFF
--- a/04 - Guides, Workflows, & Courses/for Religious Uses.md
+++ b/04 - Guides, Workflows, & Courses/for Religious Uses.md
@@ -14,6 +14,7 @@ The [[🗂️ 01 - Community|Obsidian Community]] has created plenty of resource
 - The [[obsidian-bible-reference|Bible Reference Plugin]] will let you "fetch" a particular passage of the Bible from [ESV.org](https://www.esv.org/).
 - With [[obsidian-bible-linker|Bible Linker]], you can quickly copy bible verses and create links to them.
 - [[obsidian-daf-yomi|Daf Yomi]] helps you prepare for the [daily practice of learning the Oral Torah](https://en.wikipedia.org/wiki/Daf_Yomi) by downloading the day's PDF (one page of the [Talmud](https://en.wikipedia.org/wiki/Talmud)) and links to commentary and other resources.
+- The [[obsidian-quran-lookup|Quran Lookup Plugin]] replaces `chapter:verse` shorthand with verse text in arabic and translation.
 
 ## Media Resources
 - [[Chris Wilson]] has multiple YouTube videos about how he uses Obsidian to take notes on the Bible. Here is an introduction to his "Biblekasten": [How to set up Obsidian to take digital Bible notes](https://www.youtube.com/watch?v=kT4g59YCbd0)


### PR DESCRIPTION
## Edited
Listed [the Quran Lookup plugin](https://publish.obsidian.md/hub/02+-+Community+Expansions/02.05+All+Community+Expansions/Plugins/obsidian-quran-lookup) on [for Religious Uses](https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/for+Religious+Uses) page.

## Checklist

- [x] before creating a new note, I searched the vault
- [x] new notes have the .md extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses