### PR TITLE
Removes duplicate project

### DIFF
--- a/04 - Guides, Workflows, & Courses/Guides/How to find examples of Jest-based plugin tests.md
+++ b/04 - Guides, Workflows, & Courses/Guides/How to find examples of Jest-based plugin tests.md
@@ -61,7 +61,6 @@ As of 2023-11-21.
 - ganesshkumar/[obsidian-table-editor](https://github.com/ganesshkumar/obsidian-table-editor)
 - Gorkycreator/[obsidian-quick-tagger](https://github.com/Gorkycreator/obsidian-quick-tagger)
 - greater-than/[Obsidian-Tracker-Plus](https://github.com/greater-than/Obsidian-Tracker-Plus)
-- greater-than/[Obsidian-Tracker-Plus](https://github.com/greater-than/Obsidian-Tracker-Plus)
 - gtg922r/[obsidian-numerals](https://github.com/gtg922r/obsidian-numerals)
 - hadynz/[obsidian-kindle-plugin](https://github.com/hadynz/obsidian-kindle-plugin)
 - ivan-lednev/[obsidian-day-planner](https://github.com/ivan-lednev/obsidian-day-planner)


### PR DESCRIPTION
## Edited
I removed a duplicated project on the [How to find examples of Jest-based plugin tests](https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/Guides/How+to+find+examples+of+Jest-based+plugin+tests#How+to+find+examples+of+Jest-based+plugin+tests) page. 

## Added
N/A

## Checklist
- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
- [x] (if applicable) attached images have descriptive file names
- [x] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
