### PR TITLE
Mark 'Improved VimCursor' plugin as Discontinued

### DIFF
--- a/02 - Community Expansions/02.01 Plugins by Category/Discontinued plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Discontinued plugins.md
@@ -15,9 +15,9 @@ These plugins were once published, but have have since been withdrawn, or are no
 
 %% Add a bullet here and link to the plugins you'd like to categorize - and sort them alphabetically! %%
 
-- [[improved-vimcursor|Improved VimCursor]]: An improved experience with the cursor in Obsidian
 - [[obsidian-advanced-appearance|Advanced Appearance]]: Change colors, fonts and other cosmetic settings.
 - [[obsidian-extra-md-commands|Extra Markdown Commands]] (use [[obsidian-smarter-md-hotkeys|Smarter Markdown Hotkeys]] instead.)
+- [[improved-vimcursor|Improved VimCursor]]: An improved experience with the cursor in Obsidian
 - [[linked-data-helper|Linked Data Helper]]: Parse Linked data for Linked Data Vocabularies.
 - [[linked-data-vocabularies|Linked Data Vocabularies]]: Add linked data to the YAML of your notes.
 - [[pdf-to-markdown-plugin|PDF to Markdown]]: Save a PDF's text (headings, paragraphs, lists, etc.) to a Markdown file.

--- a/02 - Community Expansions/02.01 Plugins by Category/Discontinued plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Discontinued plugins.md
@@ -15,6 +15,7 @@ These plugins were once published, but have have since been withdrawn, or are no
 
 %% Add a bullet here and link to the plugins you'd like to categorize - and sort them alphabetically! %%
 
+- [[improved-vimcursor|Improved VimCursor]]: An improved experience with the cursor in Obsidian
 - [[obsidian-advanced-appearance|Advanced Appearance]]: Change colors, fonts and other cosmetic settings.
 - [[obsidian-extra-md-commands|Extra Markdown Commands]] (use [[obsidian-smarter-md-hotkeys|Smarter Markdown Hotkeys]] instead.)
 - [[linked-data-helper|Linked Data Helper]]: Parse Linked data for Linked Data Vocabularies.

--- a/02 - Community Expansions/02.01 Plugins by Category/Vim-related Plugins.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Vim-related Plugins.md
@@ -14,7 +14,6 @@ Plugins related to [[Vim]] mode
 ## Plugins in this category
 
 - [[mrj-add-codemirror-matchbrackets|Add Codemirror's matchbrackets.js]]: This plugins adds matchbrackets.js which allows to use `di[` or `ya(` commands in Vim mode
-- [[improved-vimcursor|Improved VimCursor]]: An improved experience with the cursor in obsidian
 - [[obsidian-relative-line-numbers|Relative Line Numbers]]: Enables relative line numbers in editor mode
 - [[vim-im-select|Vim IM Select]]: Support auto select the apposite input method in different vim mode
 - [[obsidian-vim-im-switch-plugin|Vim Input Method Switch]]: Switch input method with fcitx-remote when Vim keymap is enabled.


### PR DESCRIPTION
## Edited
I removed a link to [improved-obsidian-vimcursor](https://github.com/hhhapz/improved-obsidian-vimcursor) as it was marked deprecated and obsolete in August, 2024.
<img width="846" alt="Screenshot 2025-02-28 at 1 00 03 PM" src="https://github.com/user-attachments/assets/fea6f103-ea39-474d-b075-baf33331d275" />


## Checklist
(None applicable)

- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
- [x] (if applicable) attached images have descriptive file names
- [x] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
