### PR TITLE
add screen.garden to collaboration plugins

### DIFF
--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins for collaboration.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins for collaboration.md
@@ -17,6 +17,7 @@ If you ever had to work on some kind of group project and wanted to collaborate 
 
 - [[obsidian-git|Obsidian Git]] can help you keep track of external changes to your notes by leveraging the [version control](https://www.wikiwand.com/en/Version_control) system [Git](https://book.git-scm.com/). Vaults could be shared through [GitHub](https://docs.github.com/en/get-started/quickstart).
 - [[02 - Community Expansions/02.05 All Community Expansions/Plugins/sekund|Sekund]] is social media for your notes. Engage others in peer-to-peer thinking and get feedback on drafts. Start discussions and gather in your group chat.
+- [screen.garden](https://screen.garden) enables realtime multiplayer collaboration in addition to general-purpose sync, live cursors, and web access, among other features. Quickly work together on notes with your team or get read-only public or password-protected note links.
 - [@egradman's Etherpad Lite plugin](https://github.com/egradman/obsidian-etherpad-lite)(currently still in [[Plugins in Beta|beta]]) lets you upload any note to a self-hosted [Etherpad Lite](https://etherpad.org/) server and share the URL for live collaborative editing. This lightweight tool links your local document to its online version via a YAML key and continuously updates it as you type.
 - [[for Plugin Developers|Plugin developers]] might also be interested in [[netwik|Netwik]] which wanted to provide global access to notes by hosting them on a specified remote server. Be aware that this plugin is currently [[Discontinued plugins|unmaintained]].
 


### PR DESCRIPTION
## Edited

added screen.garden to `Plugins for collaboration.md`, after the published plugins and before the beta/discontinued ones.

## Checklist
- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
- [x] (if applicable) attached images have descriptive file names
- [x] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
