### PR TITLE
Fix #791: enable sorting of uncategorized plugins

### DIFF
--- a/.github/scripts/plugins.py
+++ b/.github/scripts/plugins.py
@@ -19,9 +19,7 @@ class Plugin:
         # Make a copy to avoid modifying the original input data
         self.__data = data.copy()
 
-        # Sanitize the description in place
-        if 'description' in self.__data:
-            self.__data['description'] = self.__data['description'].replace('\n', ' ')
+        self.sanitize_description()
 
     def repo(self) -> str:
         return str(self.__data.get("repo"))
@@ -98,3 +96,9 @@ class Plugin:
             add_file_group(file_groups, "error", f"{releases_id}/{manifest_id}")
             ids_match = False
         return ids_match
+
+    def sanitize_description(self) -> None:
+        # Sanitize the description in place.
+        # See https://github.com/obsidian-community/obsidian-hub/issues/791
+        if 'description' in self.__data:
+            self.__data['description'] = self.__data['description'].replace('\n', ' ')

--- a/.github/scripts/plugins.py
+++ b/.github/scripts/plugins.py
@@ -80,6 +80,8 @@ class Plugin:
 
         self.__data.update(mobile=mobile, user=user, **manifest)
         update_author_name_for_manual_exceptions(self.__data)
+        
+        self.sanitize_description()
 
         return plugin_is_valid
 

--- a/.github/scripts/plugins.py
+++ b/.github/scripts/plugins.py
@@ -16,7 +16,12 @@ DESKTOP_ONLY = "[[Desktop-only plugins|No]]"
 class Plugin:
 
     def __init__(self, data: PluginStorage):
-        self.__data = data
+        # Make a copy to avoid modifying the original input data
+        self.__data = data.copy()
+
+        # Sanitize the description in place
+        if 'description' in self.__data:
+            self.__data['description'] = self.__data['description'].replace('\n', ' ')
 
     def repo(self) -> str:
         return str(self.__data.get("repo"))

--- a/.github/scripts/tests/approved_files/test_plugins.test_description_contains_newline.approved.md
+++ b/.github/scripts/tests/approved_files/test_plugins.test_description_contains_newline.approved.md
@@ -1,7 +1,7 @@
 {
     "author": "chenfeicqq",
     "authorUrl": "https://github.com/chenfeicqq",
-    "description": "Attachment folder name binding note name, automatically rename, automatically delete, show/hide.\n\u9644\u4ef6\u6587\u4ef6\u5939\u540d\u79f0\u7ed1\u5b9a\u7b14\u8bb0\u540d\u3001\u81ea\u52a8\u91cd\u547d\u540d\u3001\u81ea\u52a8\u5220\u9664\u3001\u663e\u793a/\u9690\u85cf\u3002",
+    "description": "Attachment folder name binding note name, automatically rename, automatically delete, show/hide. \u9644\u4ef6\u6587\u4ef6\u5939\u540d\u79f0\u7ed1\u5b9a\u7b14\u8bb0\u540d\u3001\u81ea\u52a8\u91cd\u547d\u540d\u3001\u81ea\u52a8\u5220\u9664\u3001\u663e\u793a/\u9690\u85cf\u3002",
     "id": "attachment-manager",
     "isDesktopOnly": true,
     "minAppVersion": "0.12.17",

--- a/.github/scripts/tests/approved_files/test_plugins.test_description_contains_newline.approved.md
+++ b/.github/scripts/tests/approved_files/test_plugins.test_description_contains_newline.approved.md
@@ -1,0 +1,13 @@
+{
+    "author": "chenfeicqq",
+    "authorUrl": "https://github.com/chenfeicqq",
+    "description": "Attachment folder name binding note name, automatically rename, automatically delete, show/hide.\n\u9644\u4ef6\u6587\u4ef6\u5939\u540d\u79f0\u7ed1\u5b9a\u7b14\u8bb0\u540d\u3001\u81ea\u52a8\u91cd\u547d\u540d\u3001\u81ea\u52a8\u5220\u9664\u3001\u663e\u793a/\u9690\u85cf\u3002",
+    "id": "attachment-manager",
+    "isDesktopOnly": true,
+    "minAppVersion": "0.12.17",
+    "mobile": "[[Desktop-only plugins|No]]",
+    "name": "Attachment Manager",
+    "repo": "chenfeicqq/obsidian-attachment-manager",
+    "user": "chenfeicqq",
+    "version": "1.2.2"
+}

--- a/.github/scripts/tests/approved_files/test_plugins.test_description_contains_newline.approved.txt
+++ b/.github/scripts/tests/approved_files/test_plugins.test_description_contains_newline.approved.txt
@@ -1,2 +1,0 @@
-Attachment folder name binding note name, automatically rename, automatically delete, show/hide.
-附件文件夹名称绑定笔记名、自动重命名、自动删除、显示/隐藏。

--- a/.github/scripts/tests/approved_files/test_plugins.test_description_contains_newline.approved.txt
+++ b/.github/scripts/tests/approved_files/test_plugins.test_description_contains_newline.approved.txt
@@ -1,0 +1,2 @@
+Attachment folder name binding note name, automatically rename, automatically delete, show/hide.
+附件文件夹名称绑定笔记名、自动重命名、自动删除、显示/隐藏。

--- a/.github/scripts/tests/test_plugins.py
+++ b/.github/scripts/tests/test_plugins.py
@@ -104,7 +104,9 @@ def test_description_contains_newline() -> None:
         "isDesktopOnly": true
     }
     '''
-    verify_plugin(manifest_as_json, plugin_as_json)
-    
+
     plugin = process_plugin(manifest_as_json, plugin_as_json)
     verify(plugin.data()['description'])
+
+    verify_plugin(manifest_as_json, plugin_as_json)
+   

--- a/.github/scripts/tests/test_plugins.py
+++ b/.github/scripts/tests/test_plugins.py
@@ -106,7 +106,7 @@ def test_description_contains_newline() -> None:
     '''
 
     plugin_from_obsidian_releases_and_manifest = process_plugin(manifest_as_json, plugin_as_json)
-    verify(plugin_from_obsidian_releases_and_manifest.data()['description'])
+    assert plugin_from_obsidian_releases_and_manifest.data()['description'] == "Attachment folder name binding note name, automatically rename, automatically delete, show/hide.\n附件文件夹名称绑定笔记名、自动重命名、自动删除、显示/隐藏。"
 
     verify_plugin(manifest_as_json, plugin_as_json)
    

--- a/.github/scripts/tests/test_plugins.py
+++ b/.github/scripts/tests/test_plugins.py
@@ -3,6 +3,7 @@ import json
 import plugins
 
 from helpers_for_testing import verify_in_json_format_to_markdown
+from tests.helpers_for_testing import verify_in_json_format_to_markdown
 from utils import FileGroups
 
 
@@ -62,6 +63,35 @@ def test_author_missing_from_manifest() -> None:
         "isDesktopOnly": true,
         "js": "main.js",
         "version": "1.19.0"
+    }
+    '''
+    verify_plugin(manifest_as_json, plugin_as_json)
+
+
+def test_description_contains_newline() -> None:
+    # See https://github.com/obsidian-community/obsidian-hub/issues/791
+    # This plugin's manifest.json has a newline character in the description.
+    # This test verifies that this situation is handled correctly.
+    plugin_as_json = '''
+    {
+        "id": "attachment-manager",
+        "name": "Attachment Manager",
+        "author": "chenfeicqq",
+        "description": "Attachment Manager: Attachment folder name binding note name, automatically rename, automatically delete, show/hide.\\n附件管理器：附件文件夹名称绑定笔记名、自动重命名、自动删除、显示/隐藏。",
+        "repo": "chenfeicqq/obsidian-attachment-manager"
+    }
+    '''
+
+    manifest_as_json = '''
+    {
+        "id": "attachment-manager",
+        "name": "Attachment Manager",
+        "version": "1.2.2",
+        "minAppVersion": "0.12.17",
+        "description": "Attachment folder name binding note name, automatically rename, automatically delete, show/hide.\\n附件文件夹名称绑定笔记名、自动重命名、自动删除、显示/隐藏。",
+        "author": "chenfeicqq",
+        "authorUrl": "https://github.com/chenfeicqq",
+        "isDesktopOnly": true
     }
     '''
     verify_plugin(manifest_as_json, plugin_as_json)

--- a/.github/scripts/tests/test_plugins.py
+++ b/.github/scripts/tests/test_plugins.py
@@ -106,7 +106,7 @@ def test_description_contains_newline() -> None:
     '''
 
     plugin_from_obsidian_releases_and_manifest = process_plugin(manifest_as_json, plugin_as_json)
-    assert plugin_from_obsidian_releases_and_manifest.data()['description'] == "Attachment folder name binding note name, automatically rename, automatically delete, show/hide.\n附件文件夹名称绑定笔记名、自动重命名、自动删除、显示/隐藏。"
+    assert plugin_from_obsidian_releases_and_manifest.data()['description'] == "Attachment folder name binding note name, automatically rename, automatically delete, show/hide. 附件文件夹名称绑定笔记名、自动重命名、自动删除、显示/隐藏。"
 
     verify_plugin(manifest_as_json, plugin_as_json)
    

--- a/.github/scripts/tests/test_plugins.py
+++ b/.github/scripts/tests/test_plugins.py
@@ -3,16 +3,22 @@ import json
 import plugins
 
 from helpers_for_testing import verify_in_json_format_to_markdown
+from plugins import Plugin
 from tests.helpers_for_testing import verify_in_json_format_to_markdown
 from utils import FileGroups
 
 
 def verify_plugin(manifest_as_json: str, plugin_as_json: str) -> None:
+    plugin = process_plugin(manifest_as_json, plugin_as_json)
+    verify_in_json_format_to_markdown(plugin.data())
+
+
+def process_plugin(manifest_as_json: str, plugin_as_json: str) -> Plugin:
     plugin = plugins.Plugin(json.loads(plugin_as_json))
     manifest = json.loads(manifest_as_json)
     file_groups: FileGroups = dict()
     result = plugin.collect_data_for_plugin_and_manifest(manifest, file_groups)
-    verify_in_json_format_to_markdown(plugin.data())
+    return plugin
 
 
 def test_author_augmented_for_ryanjamurphy() -> None:

--- a/.github/scripts/tests/test_plugins.py
+++ b/.github/scripts/tests/test_plugins.py
@@ -1,7 +1,5 @@
 import json
 
-from approvaltests import verify
-
 import plugins
 
 from helpers_for_testing import verify_in_json_format_to_markdown

--- a/.github/scripts/tests/test_plugins.py
+++ b/.github/scripts/tests/test_plugins.py
@@ -90,7 +90,7 @@ def test_description_contains_newline() -> None:
     }
     '''
     plugin_from_obsidian_releases = plugins.Plugin(json.loads(plugin_as_json))
-    assert plugin_from_obsidian_releases.data()['description'] == "Attachment Manager: Attachment folder name binding note name, automatically rename, automatically delete, show/hide.\n附件管理器：附件文件夹名称绑定笔记名、自动重命名、自动删除、显示/隐藏。"
+    assert plugin_from_obsidian_releases.data()['description'] == "Attachment Manager: Attachment folder name binding note name, automatically rename, automatically delete, show/hide. 附件管理器：附件文件夹名称绑定笔记名、自动重命名、自动删除、显示/隐藏。"
 
     manifest_as_json = '''
     {

--- a/.github/scripts/tests/test_plugins.py
+++ b/.github/scripts/tests/test_plugins.py
@@ -89,6 +89,8 @@ def test_description_contains_newline() -> None:
         "repo": "chenfeicqq/obsidian-attachment-manager"
     }
     '''
+    plugin_from_obsidian_releases = plugins.Plugin(json.loads(plugin_as_json))
+    assert plugin_from_obsidian_releases.data()['description'] == "Attachment Manager: Attachment folder name binding note name, automatically rename, automatically delete, show/hide.\n附件管理器：附件文件夹名称绑定笔记名、自动重命名、自动删除、显示/隐藏。"
 
     manifest_as_json = '''
     {

--- a/.github/scripts/tests/test_plugins.py
+++ b/.github/scripts/tests/test_plugins.py
@@ -105,8 +105,8 @@ def test_description_contains_newline() -> None:
     }
     '''
 
-    plugin = process_plugin(manifest_as_json, plugin_as_json)
-    verify(plugin.data()['description'])
+    plugin_from_obsidian_releases_and_manifest = process_plugin(manifest_as_json, plugin_as_json)
+    verify(plugin_from_obsidian_releases_and_manifest.data()['description'])
 
     verify_plugin(manifest_as_json, plugin_as_json)
    

--- a/.github/scripts/tests/test_plugins.py
+++ b/.github/scripts/tests/test_plugins.py
@@ -1,5 +1,7 @@
 import json
 
+from approvaltests import verify
+
 import plugins
 
 from helpers_for_testing import verify_in_json_format_to_markdown
@@ -101,3 +103,6 @@ def test_description_contains_newline() -> None:
     }
     '''
     verify_plugin(manifest_as_json, plugin_as_json)
+    
+    plugin = process_plugin(manifest_as_json, plugin_as_json)
+    verify(plugin.data()['description'])


### PR DESCRIPTION
This is a full fix of #791 - and plugin descriptions that contain a `\n` - either in the community plugin list of in plugin manifests, are fixed by replacing `\n` with a `space` character.

The following now correctly sorts all uncategorised plugins by name:

```bash
python update_releases.py --plugins
```

I expect that tonight's GitHub Action run will correctly fully-sort the `Uncategorized plugins` note.
