### PR TITLE
Syncthing.md: correct .stignore proposal

### DIFF
--- a/02 - Community Expansions/02.05 All Community Expansions/Auxiliary Tools/Syncthing.md
+++ b/02 - Community Expansions/02.05 All Community Expansions/Auxiliary Tools/Syncthing.md
@@ -16,10 +16,11 @@ Available for: [[Windows Tools|Windows]], [[MacOS Tools|MacOS]], [[Linux Tools|L
 A peer-to-peer file synchronisation application, which can be used to keep your Obsidian vault synchronised across multiple devices almost instantaneously.
 
 ## Configuration for Obsidian
-You'll probably want the following files to be excluded from synchronisation in your `.stignore`. If you're not using the [[metadata-extractor|Metadata Extractor]] plugin, you'll only need to exclude `workspace`.
+You'll probably want the following files to be excluded from synchronisation in your `.stignore`. If you're not using the [[metadata-extractor|Metadata Extractor]] plugin, you'll only need to exclude `workspace.json` / `workspace-mobile.json`.
 ```
-// most important one. this keeps track of your open panes and files in the app
-.obsidian/workspace
+// most important ones. these keeps track of your open panes and files in the app
+.obsidian/workspace.json
+.obsidian/workspace-mobile.json
 // Metadata Extractor generates these automatically, so you shouldn't sync them
 .obsidian/plugins/metadata-extractor/allExceptMd.json
 .obsidian/plugins/metadata-extractor/metadata.json


### PR DESCRIPTION


## Edited
I corrected the `.stignore` proposal for vault synchronization over syncthing.
The currently relevant files are `.obsidian/workspace.json` and `.obsidian/workspace-mobile.json` for the android app, the previous `.stignore` proposal did instead specify to ignore an `.obsidian/workspace` folder, which does not match the json files.

<!-- Add a brief description here -->

## Added
<!-- Add a brief description here-->
