### PR TITLE
Remove illegal colon character from file name

### DIFF
--- a/01 - Community/People/norderan.md
+++ b/01 - Community/People/norderan.md
@@ -21,7 +21,7 @@ publish: true
 %% Begin Hub: Released contributions %%
 
 ### Themes
-- [[RedShift: OLED Blue Light Filter]]
+- [[RedShift - OLED Blue Light Filter]]
 %% End Hub: Released contributions %%
 
 %% Add links to any plugins, themes or other notes that the author has created but are not (yet) included in the `obsidian-releases` repo %%

--- a/02 - Community Expansions/02.05 All Community Expansions/Themes/RedShift - OLED Blue Light Filter.md
+++ b/02 - Community Expansions/02.05 All Community Expansions/Themes/RedShift - OLED Blue Light Filter.md
@@ -17,7 +17,7 @@ publish: true
 
 %% ----- Do not edit this section ----- %%
 
-# RedShift: OLED Blue Light Filter
+# RedShift - OLED Blue Light Filter
 
 Repository: [GitHub](https://github.com/norderan/RedShift-obsidian-theme)
 Designed by: [[norderan]]

--- a/02 - Community Expansions/02.05 All Community Expansions/Themes/🗂️ Themes.md
+++ b/02 - Community Expansions/02.05 All Community Expansions/Themes/🗂️ Themes.md
@@ -323,7 +323,7 @@ publish: true
 -  [[02 - Community Expansions/02.05 All Community Expansions/Themes/Red Graphite|Red Graphite]]
 -  [[02 - Community Expansions/02.05 All Community Expansions/Themes/Red Solitude|Red Solitude]]
 -  [[02 - Community Expansions/02.05 All Community Expansions/Themes/Red-Shadow|Red-Shadow]]
--  [[02 - Community Expansions/02.05 All Community Expansions/Themes/RedShift: OLED Blue Light Filter|RedShift: OLED Blue Light Filter]]
+-  [[RedShift - OLED Blue Light Filter|RedShift - OLED Blue Light Filter]]
 -  [[02 - Community Expansions/02.05 All Community Expansions/Themes/Refined Default|Refined Default]]
 -  [[02 - Community Expansions/02.05 All Community Expansions/Themes/Reshi|Reshi]]
 -  [[02 - Community Expansions/02.05 All Community Expansions/Themes/Retro Windows|Retro Windows]]


### PR DESCRIPTION

## Edited

Remove illegal colon character from file name, and update all links to the renamed file.

'RedShift: OLED Blue Light Filter' renamed to 'RedShift - OLED Blue Light Filter'.

Fixes #808
