### PR TITLE
Add PDFAnnotations to Auxiliary Tools

### DIFF
--- a/02 - Community Expansions/02.05 All Community Expansions/Auxiliary Tools/PDFAnnotations.md
+++ b/02 - Community Expansions/02.05 All Community Expansions/Auxiliary Tools/PDFAnnotations.md
@@ -1,0 +1,9 @@
+PDFAnnotations Official website: https://pdfannotations.com/ Documentation: https://github.com/pdfannotations/pdfannotations Cost: free Available for: [[Webapp]]
+
+%% Add a description below this line. It doesn't need to be long: one or two sentences should be a good start. Mention [[🗂️ Auxiliary Tools]] or [[🗂️ 02.04 Auxiliary Tools by Category]] and any other relevant notes in this vault. %%
+
+**[PDFAnnotations](https://pdfannotations.com/)** is a free, privacy-first [[Webapp]] to extract PDF highlights, comments, and drawing annotations entirely locally in your browser. 
+
+It features an interactive **Template Designer** that formats your extracted highlights directly into native [[Obsidian]] callouts or [[Notion]] properties using dynamic variables. You can also toggle **Sentence Mode** to automatically expand highlighted words into complete sentences to preserve original context.
+
+This utility is useful in combination with [[🗂️ Auxiliary Tools]] and literature review workflows.


### PR DESCRIPTION
## Edited
None

## Added
Added a new auxiliary tool note: `PDFAnnotations.md`.
This is a free, privacy-first web utility for extracting PDF highlights, comments, and drawing annotations into custom Markdown format. It supports native Obsidian callouts and works completely offline.

## Checklist
- [x] before creating a new note, I searched the vault
- [x] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
