### PR TITLE
Add Personal Finance section to "for Specific Professions"

### DIFF
--- a/04 - Guides, Workflows, & Courses/for Specific Professions.md
+++ b/04 - Guides, Workflows, & Courses/for Specific Professions.md
@@ -18,6 +18,9 @@ publish: true
 ## Sales
 - [Dashboard for sales](https://forum.obsidian.md/t/dashboard-and-workflow-for-obsidian-at-work-sales/34794)
 
+## Personal Finance
+- [hledger + Obsidian + Claude Code: Personal Finance with Plain Text Accounting](https://www.mandalivia.com/obsidian/hledger-obsidian-personal-finance-with-claude-code/) — a setup guide for managing personal finances in Obsidian using hledger (plain text accounting) with Claude Code.
+
 %% Hub footer: Please don't edit anything below this line %%
 
 # This note in GitHub


### PR DESCRIPTION
Adds a new "Personal Finance" section to `for Specific Professions.md`, matched in shape to the existing "Sales" entry (external link with a one-line description).

Disclosing: I wrote the linked guide. Happy to drop or revise if it's not a fit — the article covers the workflow of using hledger (plain text accounting) inside an Obsidian vault, with Claude Code as an editing assistant, which seemed like it could help readers looking for personal-finance-oriented Obsidian workflows.