### PR TITLE
chore: replace legacy gabosgab handle references

### DIFF
--- a/01 - Community/People/ServerKarma.md
+++ b/01 - Community/People/ServerKarma.md
@@ -6,11 +6,11 @@ tags:
 publish: true
 ---
 
-# GB
+# ServerKarma
 
-- GitHub: [gabosgab](https://github.com/gabosgab/) ^github
+- GitHub: [ServerKarma](https://github.com/ServerKarma/) ^github
 <!-- - Discord: `@` ^discord-->
-- Website: <https://github.com/gabosgab/> ^website
+- Website: <https://github.com/ServerKarma/> ^website
 <!-- - [[Publish sites|Publish site]]: <https://> ^publish-->
 
 %% Feel free to add a bio below this comment %%
@@ -38,7 +38,7 @@ publish: true
 ## Sponsor this author
 -->
 
-<!-- - [[GitHub sponsors]]: [Sponsor @gabosgab on GitHub Sponsors](https://github.com/sponsors/gabosgab) ^github-sponsor-->
+<!-- - [[GitHub sponsors]]: [Sponsor @ServerKarma on GitHub Sponsors](https://github.com/sponsors/ServerKarma) ^github-sponsor-->
 <!-- - [[Buy me a coffee]]: <https://> ^buy-me-a-coffee-->
 <!-- - [[PayPal]]: <https://> ^paypal-->
 <!-- - [[Patreon]]: <https://> ^patreon-->
@@ -55,4 +55,4 @@ publish: true
 
 # This note in GitHub
 
-<span class="git-footer">[Edit In GitHub](https://github.dev/obsidian-community/obsidian-hub/blob/main/01%20-%20Community/People/gabosgab.md "git-hub-edit-note") | [Copy this note](https://raw.githubusercontent.com/obsidian-community/obsidian-hub/main/01%20-%20Community/People/gabosgab.md "git-hub-copy-note") | [Download this vault](https://github.com/obsidian-community/obsidian-hub/archive/refs/heads/main.zip "git-hub-download-vault") </span>
+<span class="git-footer">[Edit In GitHub](https://github.dev/obsidian-community/obsidian-hub/blob/main/01%20-%20Community/People/ServerKarma.md "git-hub-edit-note") | [Copy this note](https://raw.githubusercontent.com/obsidian-community/obsidian-hub/main/01%20-%20Community/People/ServerKarma.md "git-hub-copy-note") | [Download this vault](https://github.com/obsidian-community/obsidian-hub/archive/refs/heads/main.zip "git-hub-download-vault") </span>

--- a/01 - Community/People/🗂️ People.md
+++ b/01 - Community/People/🗂️ People.md
@@ -823,7 +823,7 @@ Overviews of all the work from notable People like Plugins Developers, Theme Des
 -  [[01 - Community/People/fzdwx|fzdwx]]
 -  [[01 - Community/People/G2Jose|G2Jose]]
 -  [[01 - Community/People/GabAlpha|GabAlpha]]
--  [[01 - Community/People/gabosgab|gabosgab]]
+-  [[01 - Community/People/ServerKarma|ServerKarma]]
 -  [[01 - Community/People/gaetanmuck|gaetanmuck]]
 -  [[01 - Community/People/Galacsh|Galacsh]]
 -  [[01 - Community/People/GanapathyRaman|GanapathyRaman]]

--- a/02 - Community Expansions/02.05 All Community Expansions/Plugins/private-ai.md
+++ b/02 - Community Expansions/02.05 All Community Expansions/Plugins/private-ai.md
@@ -9,10 +9,10 @@ publish: true
 
 %% ----- Badges ----- %%
 
-![GitHub all releases](https://img.shields.io/github/downloads/gabosgab/ObsidianPrivateAI/total?color=573E7A&logo=github&style=for-the-badge)   
-![GitHub manifest version](https://img.shields.io/github/manifest-json/v/gabosgab/ObsidianPrivateAI?color=573E7A&logo=github&style=for-the-badge)   
-![GitHub issues by-label](https://img.shields.io/github/issues/gabosgab/ObsidianPrivateAI/help%20wanted?color=573E7A&logo=github&style=for-the-badge)   
-![GitHub Repo stars](https://img.shields.io/github/stars/gabosgab/ObsidianPrivateAI?color=573E7A&logo=github&style=for-the-badge)
+![GitHub all releases](https://img.shields.io/github/downloads/ServerKarma/ObsidianPrivateAI/total?color=573E7A&logo=github&style=for-the-badge)   
+![GitHub manifest version](https://img.shields.io/github/manifest-json/v/ServerKarma/ObsidianPrivateAI?color=573E7A&logo=github&style=for-the-badge)   
+![GitHub issues by-label](https://img.shields.io/github/issues/ServerKarma/ObsidianPrivateAI/help%20wanted?color=573E7A&logo=github&style=for-the-badge)   
+![GitHub Repo stars](https://img.shields.io/github/stars/ServerKarma/ObsidianPrivateAI?color=573E7A&logo=github&style=for-the-badge)
 
 %% ----- Badges ----- %%
 
@@ -21,8 +21,8 @@ publish: true
 # Private AI
 
 Plugin ID: `private-ai`
-Links: [GitHub repository](https://github.com/gabosgab/ObsidianPrivateAI) or [<button id=HH>Open in Obsidian</button>](obsidian://show-plugin?id=private-ai)
-Developed by: [[gabosgab]]
+Links: [GitHub repository](https://github.com/ServerKarma/ObsidianPrivateAI) or [<button id=HH>Open in Obsidian</button>](obsidian://show-plugin?id=private-ai)
+Developed by: [[ServerKarma]]
 Mobile compatible: [[Desktop-only plugins|No]]
 
 Effortlessly chat with your notes using locally hosted AI.  Private by design, your notes never leave the device and use locally processing only.
@@ -30,7 +30,7 @@ Effortlessly chat with your notes using locally hosted AI.  Private by design, y
 %% ----- Do not edit anything above this line ----- %% 
 
 %% Does the repository or author have any sponsoring links? Uncomment the next line and add them to the author's note. If they don't, please delete the placeholder tag: #placeholder/author %%
-%% ![[gabosgab#Sponsor this author]] %%
+%% ![[ServerKarma#Sponsor this author]] %%
 
 %% Hub footer: Please don't edit anything below this line %%
 


### PR DESCRIPTION
This updates the legacy "gabosgab" author/profile references to the current GitHub handle "ServerKarma" for the Private AI plugin author page and related links.

Why: the old handle is no longer the active public GitHub identity and currently creates stale cross-linkage. This PR preserves attribution while removing outdated handle references from the published hub pages.