### PR TITLE
Add Tandem Comments to 'Plugins for collaboration'

### DIFF
--- a/02 - Community Expansions/02.01 Plugins by Category/Plugins for collaboration.md
+++ b/02 - Community Expansions/02.01 Plugins by Category/Plugins for collaboration.md
@@ -18,6 +18,7 @@ If you ever had to work on some kind of group project and wanted to collaborate 
 - [[obsidian-git|Obsidian Git]] can help you keep track of external changes to your notes by leveraging the [version control](https://www.wikiwand.com/en/Version_control) system [Git](https://book.git-scm.com/). Vaults could be shared through [GitHub](https://docs.github.com/en/get-started/quickstart).
 - [[02 - Community Expansions/02.05 All Community Expansions/Plugins/sekund|Sekund]] is social media for your notes. Engage others in peer-to-peer thinking and get feedback on drafts. Start discussions and gather in your group chat.
 - [@egradman's Etherpad Lite plugin](https://github.com/egradman/obsidian-etherpad-lite)(currently still in [[Plugins in Beta|beta]]) lets you upload any note to a self-hosted [Etherpad Lite](https://etherpad.org/) server and share the URL for live collaborative editing. This lightweight tool links your local document to its online version via a YAML key and continuously updates it as you type.
+- [[tandem-comments|Tandem Comments]] brings Google Docs-style commenting to your notes: quote-anchored comment threads are stored in a fenced block at the end of the file, so the prose itself stays untouched while reviewers comment, reply and resolve.
 - [[for Plugin Developers|Plugin developers]] might also be interested in [[netwik|Netwik]] which wanted to provide global access to notes by hosting them on a specified remote server. Be aware that this plugin is currently [[Discontinued plugins|unmaintained]].
 
 ## Related categories


### PR DESCRIPTION
Adds [Tandem Comments](https://github.com/leonpawelzik/obsidian-tandem-comments) (plugin id `tandem-comments`) to the *Plugins for collaboration* category page.

The plugin was admitted to the community plugin directory on 2026-06-10, so the auto-generated plugin note doesn't exist yet — the `[[tandem-comments]]` wikilink will resolve with the next scripted content update. Happy to adjust if you'd prefer I wait for that.

What it does: Google Docs-style commenting for notes — quote-anchored comment threads stored in a fenced block at the end of the file, so the prose itself stays untouched while reviewers comment, reply and resolve.