### PR TITLE
Add Xiaohongshu content brief template

### DIFF
--- a/03 - Showcases & Templates/Templates/Projects/T - Xiaohongshu Content Brief.md
+++ b/03 - Showcases & Templates/Templates/Projects/T - Xiaohongshu Content Brief.md
@@ -1,0 +1,114 @@
+---
+aliases:
+- RedNote content brief
+- Xiaohongshu post brief
+tags:
+- seedling
+publish: true
+---
+
+# T - Xiaohongshu Content Brief
+
+This template helps creators turn saved references, rough notes, interviews, or reading highlights into a focused Xiaohongshu / RedNote post plan before drafting the final post.
+
+It is useful when a note needs to become a short-form content asset with a clear reader, one main promise, title candidates, a carousel plan, and a final review checklist.
+
+Source starter workflow: [XHS Obsidian Workflow Starter](https://github.com/Ronnie2025/xhs-obsidian-workflow-starter)
+
+```markdown
+---
+created: <% tp.file.creation_date("YYYY-MM-DD HH:mm") %>
+updated: <% tp.file.last_modified_date("YYYY-MM-DD HH:mm") %>
+tags:
+- content-brief
+- xiaohongshu
+- rednote
+- creator-workflow
+source:
+status: draft
+---
+
+# Xiaohongshu Content Brief
+
+## Source Material
+
+- Source link:
+- Source type:
+- One-sentence summary:
+- Useful details:
+  - ...
+  - ...
+  - ...
+
+## Reader
+
+- Who is this for?
+- What problem are they trying to solve?
+- What do they already know?
+- What should they do after reading?
+
+## Content Angle
+
+- Main claim:
+- Why this matters now:
+- What makes this concrete:
+- What should this post avoid?
+
+## Title Candidates
+
+1. ...
+2. ...
+3. ...
+4. ...
+5. ...
+
+## Draft Structure
+
+### Opening
+
+
+### Key Points
+
+1. ...
+2. ...
+3. ...
+
+### Example Or Proof
+
+
+### Closing
+
+
+## Carousel Plan
+
+| Page | Goal | Copy |
+| --- | --- | --- |
+| 1 | Hook |  |
+| 2 | Context |  |
+| 3 | Core point |  |
+| 4 | Example |  |
+| 5 | Checklist |  |
+| 6 | Save/share reason |  |
+
+## Publishing Package
+
+- Final title:
+- Cover text:
+- Caption:
+- Tags:
+- Comment prompt:
+
+## Review Checklist
+
+- [ ] The reader problem is specific.
+- [ ] The post has one main promise.
+- [ ] The example is concrete enough to copy or adapt.
+- [ ] The title does not overpromise.
+- [ ] The draft avoids unverifiable income or traffic claims.
+```
+
+%% Hub footer: Please don't edit anything below this line %%
+
+# This note in GitHub
+
+<span class="git-footer">[Edit In GitHub](https://github.dev/obsidian-community/obsidian-hub/blob/main/03%20-%20Showcases%20%26%20Templates/Templates/Projects/T%20-%20Xiaohongshu%20Content%20Brief.md "git-hub-edit-note") | [Copy this note](https://raw.githubusercontent.com/obsidian-community/obsidian-hub/main/03%20-%20Showcases%20%26%20Templates/Templates/Projects/T%20-%20Xiaohongshu%20Content%20Brief.md "git-hub-copy-note") | [Download this vault](https://github.com/obsidian-community/obsidian-hub/archive/refs/heads/main.zip "git-hub-download-vault") </span>


### PR DESCRIPTION
## Summary

- Add a project template note for planning Xiaohongshu / RedNote content in Obsidian.
- The template helps turn saved references or rough notes into a focused reader, angle, title, draft, carousel, and review checklist.
- Link to a free starter workflow repository for users who want the surrounding folder structure.

## Validation

- `git diff --check`
- `bash .github/scripts/run_markdownlint.sh` from `.github/scripts`
- `python .github/scripts/check_content.py` with Python 3.9 temp venv
- `python .github/scripts/case_conflicts.py` with Python 3.9 temp venv

Notes: content checks emitted existing warnings for `Blue Topaz.md` wiki aliases; the new template file did not add those warnings.