### PR TITLE
Add basic HTML description

### DIFF
--- a/05 - Concepts/HTML.md
+++ b/05 - Concepts/HTML.md
@@ -8,9 +8,7 @@ publish: true
 
 # HTML
 
-%% Add a description below this line. It doesn't need to be long: one or two sentences should be a good start. %%
-
-#placeholder/description 
+HyperText Markup Language (HTML) is a markup language commonly used on the web alongside CSS and JavaScript. In Obsidian and other software that makes use of Markdown, the markup is converted into basic HTML for display in browser-based applications. In addition, Obsidian can also render HTML directly inside of notes.
 
 %% Hub footer: Please don't edit anything below this line %%
 


### PR DESCRIPTION
## Edited
I added a basic description of HTML in its concept note since it was missing one. I've tried to give some info about how it is relevant to Obsidian.

## Added
No new notes; just adding a basic description to a concept.

## Checklist
- [ ] before creating a new note, I searched the vault
- [ ] new notes have the `.md` extension
- [ ] (if applicable) attached images have descriptive file names
- [ ] (if applicable) for new notes in the folder "04 - Guides, Workflows, & Courses", I added a link to them in one of the "for {group X}" overviews: https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/%F0%9F%97%82%EF%B8%8F+04+-+Guides%2C+Workflows%2C+%26+Courses
